### PR TITLE
Template de type pour les domaines de composition

### DIFF
--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -300,7 +300,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "description": "Nom du type."
+                  "description": "Nom du type.\n\nSera considéré comme un type générique de la classe si utilisé dans une composition. Dans ce cas, il est aussi possible d'utiliser cette valeur comme un template de type en utilisant '{class}' pour référencer la classe composée."
                 },
                 "annotations": {
                   "type": "array",
@@ -330,7 +330,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "description": "Nom du type."
+                  "description": "Nom du type.\n\nSera considéré comme un type générique de la classe si utilisé dans une composition. Dans ce cas, il est aussi possible d'utiliser cette valeur comme un template de type en utilisant '{class}' pour référencer la classe composée. Si l'import est défini, ce sera la partie à gauche du '<' qui sera importée."
                 },
                 "import": {
                   "type": "string",
@@ -346,7 +346,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "description": "Nom du type."
+                  "description": "Nom du type.\n\nSera considéré comme un type générique de la classe si utilisé dans une composition. Dans ce cas, il est aussi possible d'utiliser cette valeur comme un template de type en utilisant '{class}' pour référencer la classe composée."
                 },
                 "imports": {
                   "type": "array",

--- a/TopModel.Generator/CSharp/CSharpUtils.cs
+++ b/TopModel.Generator/CSharp/CSharpUtils.cs
@@ -40,7 +40,8 @@ public static class CSharpUtils
                 "object" => cp.Composition.Name,
                 "list" => $"{(useIEnumerable ? "IEnumerable" : "ICollection")}<{cp.Composition.Name}>",
                 "async-list" => $"IAsyncEnumerable<{cp.Composition.Name}>",
-                string _ => $"{cp.DomainKind!.CSharp!.Type}<{cp.Composition.Name}>"
+                string _ when cp.DomainKind!.CSharp!.Type.Contains("{class}") => cp.DomainKind.CSharp.Type.Replace("{class}", cp.Composition.Name),
+                string _ => $"{cp.DomainKind.CSharp.Type}<{cp.Composition.Name}>"
             },
             AssociationProperty { Association: var assoc } when config.CanClassUseEnums(assoc) => $"{assoc}.{assoc.PrimaryKey!.Name}s?",
             AliasProperty { Property: AssociationProperty { Association: var assoc } } when config.CanClassUseEnums(assoc) => $"{assoc}.{assoc.PrimaryKey!.Name}s?",

--- a/TopModel.Generator/Javascript/JavascriptUtils.cs
+++ b/TopModel.Generator/Javascript/JavascriptUtils.cs
@@ -1,0 +1,53 @@
+﻿using TopModel.Core;
+
+namespace TopModel.Generator.Javascript;
+
+public static class JavascriptUtils
+{
+    public static string GetPropertyTypeName(this IProperty prop)
+    {
+        return prop switch
+        {
+            CompositionProperty cp => cp.Kind switch
+            {
+                "object" => cp.Composition.Name,
+                "list" or "async-list" => $"{cp.Composition.Name}[]",
+                string _ when cp.DomainKind!.TS!.Type.Contains("{class}") => cp.DomainKind.TS.Type.Replace("{class}", cp.Composition.Name),
+                string _ => $"{cp.DomainKind.TS.Type}<{cp.Composition.Name}>"
+            },
+            IFieldProperty fp => fp.TS.Type,
+            _ => string.Empty
+        };
+    }
+
+    public static IEnumerable<(string Import, string Path)> GetPropertyImports(IEnumerable<IProperty> properties)
+    {
+        return properties.OfType<IFieldProperty>()
+            .Where(p => p.Domain.TS?.Import != null)
+            .Select(p => (p.Domain.TS!.Type, p.Domain.TS.Import!))
+        .Concat(properties.OfType<CompositionProperty>()
+            .Where(p => p.DomainKind != null)
+            .Select(p => (p.DomainKind!.TS!.Type.Split('<').First(), p.DomainKind.TS.Import!)))
+        .Distinct();
+    }
+
+    public static IEnumerable<(string Code, string Module)> GetReferencesToImport(IEnumerable<IProperty> properties)
+    {
+        return properties
+            .Select(p => p is AliasProperty alp ? alp.Property : p)
+            .OfType<IFieldProperty>()
+            .Select(prop => (prop, classe: prop is AssociationProperty ap ? ap.Association : prop.Class))
+            .Where(pc => pc.prop.TS.Type != pc.prop.Domain.TS!.Type && pc.prop.Domain.TS.Type == "string" && pc.classe.Reference)
+            .Select(pc => (pc.prop.TS.Type, pc.classe.Namespace.Module))
+            .Distinct();
+    }
+
+    public static IList<(string Import, string Path)> GroupAndSortImports(IEnumerable<(string Import, string Path)> imports)
+    {
+        return imports
+             .GroupBy(i => i.Path)
+             .Select(i => (Import: string.Join(", ", i.Select(l => l.Import)), Path: i.Key))
+             .OrderBy(i => i.Path.StartsWith(".") ? i.Path : $"...{i.Path}")
+             .ToList();
+    }
+}

--- a/TopModel.Generator/Jpa/JpaUtils.cs
+++ b/TopModel.Generator/Jpa/JpaUtils.cs
@@ -3,7 +3,7 @@ using TopModel.Utils;
 
 namespace TopModel.Generator.Jpa;
 
-public static class GetJavaTypeJpaExtensions
+public static class JpaUtils
 {
     public static string GetJavaType(this IProperty prop)
     {
@@ -53,18 +53,14 @@ public static class GetJavaTypeJpaExtensions
 
     public static string GetJavaType(this CompositionProperty cp)
     {
-        if (cp.Kind == "object")
+        return cp.Kind switch
         {
-            return cp.Composition.Name;
-        }
-        else if (cp.Kind == "list")
-        {
-            return $"Set<{cp.Composition.Name}>";
-        }
-        else
-        {
-            return $"{cp.DomainKind!.Java!.Type}<{cp.Composition.Name}>";
-        }
+            "object" => cp.Composition.Name,
+            "list" => $"Set<{cp.Composition.Name}>",
+            "async-list" => $"IAsyncEnumerable<{cp.Composition.Name}>",
+            string _ when cp.DomainKind!.Java!.Type.Contains("{class}") => cp.DomainKind.Java.Type.Replace("{class}", cp.Composition.Name),
+            string _ => $"{cp.DomainKind.Java.Type}<{cp.Composition.Name}>"
+        };
     }
 
     public static bool IsEnum(this RegularProperty rp)


### PR DESCRIPTION
Cette PR permet de spécifier un template de type C#/Java/TS sur un domaine utilisé pour de la composition (dans "kind").
On identifie que le type est un template s'il contient `{class}` : dans ce cas, on remplacera ce token par le nom de la classe composée pour déterminer le nom du type final. Si le type n'est pas un template, le fonctionnement actuel reste inchangé (=> pour une composition, le nom du type final sera toujours `{type}<{class}>`). Il n'y a donc aucun breaking change avec cette nouvelle fonctionnalité.

J'en ai profité pour consolider un peu la gestion des types et des imports entre la génération de modèle et de client d'API côté JS.