### PR TITLE
Intégration des alias de classes dans les listes des références d'un fichier/d'une classe

### DIFF
--- a/TopModel.Core/FileModel/Alias.cs
+++ b/TopModel.Core/FileModel/Alias.cs
@@ -6,7 +6,7 @@ internal class Alias
 {
     public Reference File { get; set; }
 
-    public List<Reference> Classes { get; set; } = new();
+    public List<ClassReference> Classes { get; set; } = new();
 
     public List<Reference> Endpoints { get; set; } = new();
 

--- a/TopModel.Core/FileModel/Alias.cs
+++ b/TopModel.Core/FileModel/Alias.cs
@@ -4,11 +4,11 @@ namespace TopModel.Core.FileModel;
 
 internal class Alias
 {
-    public string File { get; set; }
+    public Reference File { get; set; }
 
-    public string[] Classes { get; set; } = Array.Empty<string>();
+    public List<Reference> Classes { get; set; } = new();
 
-    public string[] Endpoints { get; set; } = Array.Empty<string>();
+    public List<Reference> Endpoints { get; set; } = new();
 
     public ModelFile ModelFile { get; set; }
 

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -26,6 +26,7 @@ public class ModelFile
         .Concat(Properties.OfType<AssociationProperty>().Select(p => (p.Reference as Reference, p.Association as object)))
         .Concat(Properties.OfType<CompositionProperty>().SelectMany(p => new (Reference, object)[] { (p.Reference, p.Composition), (p.DomainKindReference, p.DomainKind) }))
         .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[] { (p.ClassReference, p.OriginalProperty?.Class), (p.PropertyReference, p.OriginalProperty), (p.ListDomainReference, p.ListDomain) }))
+        .Concat(Aliases.SelectMany(a => a.Classes).Select(c => (c as Reference, ResolvedAliases.OfType<Class>().FirstOrDefault(ra => ra.Name == c.ReferenceName) as object)))
         .Where(t => t.Item1 != null && t.Item2 != null)
         .DistinctBy(t => t.Item1)
         .ToDictionary(t => t.Item1, t => t.Item2);

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -5,9 +5,9 @@ public class ModelFile
 {
     public string Module { get; set; }
 
-    public IList<string> Tags { get; set; } = new List<string>();
+    public List<string> Tags { get; set; } = new();
 
-    public IList<Reference> Uses { get; set; } = new List<Reference>();
+    public List<Reference> Uses { get; set; } = new();
 
     public string Name { get; set; }
 
@@ -31,7 +31,7 @@ public class ModelFile
         .ToDictionary(t => t.Item1, t => t.Item2);
 
     public IList<Reference> UselessImports => Uses
-        .Where(use => !Aliases.Select(alias => alias.File)
+        .Where(use => !Aliases.Select(alias => alias.File.ReferenceName)
         .Concat(References.Values.Select(r => r.GetFile().Name))
         .Contains(use.ReferenceName)).ToList();
 

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -116,7 +116,7 @@ public class ModelFileLoader
 
                             while (parser.Current is not SequenceEnd)
                             {
-                                alias.Classes.Add(new Reference(parser.Consume<Scalar>()));
+                                alias.Classes.Add(new ClassReference(parser.Consume<Scalar>()));
                             }
 
                             parser.Consume<SequenceEnd>();

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -98,7 +98,44 @@ public class ModelFileLoader
             }
             else if (scalar.Value == "alias")
             {
-                var alias = _fileChecker.Deserialize<Alias>(parser);
+                var alias = new Alias();
+
+                parser.Consume<MappingStart>();
+                while (parser.Current is not MappingEnd)
+                {
+                    var prop = parser.Consume<Scalar>().Value;
+                    parser.TryConsume<Scalar>(out var value);
+
+                    switch (prop)
+                    {
+                        case "file":
+                            alias.File = new Reference(value);
+                            break;
+                        case "classes":
+                            parser.Consume<SequenceStart>();
+
+                            while (parser.Current is not SequenceEnd)
+                            {
+                                alias.Classes.Add(new Reference(parser.Consume<Scalar>()));
+                            }
+
+                            parser.Consume<SequenceEnd>();
+                            break;
+                        case "uses":
+                            parser.Consume<SequenceStart>();
+
+                            while (parser.Current is not SequenceEnd)
+                            {
+                                alias.Endpoints.Add(new Reference(parser.Consume<Scalar>()));
+                            }
+
+                            parser.Consume<SequenceEnd>();
+                            break;
+                    }
+                }
+
+                parser.Consume<MappingEnd>();
+
                 alias.ModelFile = file;
                 alias.Location = new Reference(scalar);
                 file.Aliases.Add(alias);

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -54,10 +54,12 @@ public static class ModelExtensions
                     _ => null! // Impossible
                 }, File: p.GetFile());
             })
-            .Concat(modelStore.Classes.Where(c => c.Extends == classe).Select(c =>
-            {
-                return (Reference: c.ExtendsReference!, File: c.GetFile());
-            }))
+            .Concat(modelStore.Classes.Where(c => c.Extends == classe)
+                .Select(c => (Reference: c.ExtendsReference!, File: c.GetFile())))
+            .Concat(modelStore.Files.SelectMany(f =>
+                f.Aliases.SelectMany(a => a.Classes
+                    .Where(c => f.ResolvedAliases.OfType<Class>().Any(ra => ra.Name == c.ReferenceName && ra == classe))
+                    .Select(c => (Reference: c, File: f)))))
             .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
     }
 

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -448,19 +448,19 @@ public class ModelStore
 
         foreach (var alias in modelFile.Aliases)
         {
-            var referencedFile = dependencies.SingleOrDefault(dep => dep.Name == alias.File);
+            var referencedFile = dependencies.SingleOrDefault(dep => dep.Name == alias.File.ReferenceName);
             if (referencedFile == null)
             {
-                yield return new ModelError(alias, $"Le fichier '{alias.File}' est introuvable dans les dépendances du fichier.") { ModelErrorType = ModelErrorType.TMD1003 };
+                yield return new ModelError(alias, $"Le fichier '{alias.File.ReferenceName}' est introuvable dans les dépendances du fichier.", alias.File) { ModelErrorType = ModelErrorType.TMD1003 };
                 continue;
             }
 
-            foreach (var className in alias.Classes)
+            foreach (var aliasClass in alias.Classes)
             {
-                var referencedClass = referencedFile.Classes.SingleOrDefault(classe => classe.Name == className);
+                var referencedClass = referencedFile.Classes.SingleOrDefault(classe => classe.Name == aliasClass.ReferenceName);
                 if (referencedClass == null)
                 {
-                    yield return new ModelError(alias, $"La classe '{className}' est introuvable dans le fichier '{alias.File}'.") { ModelErrorType = ModelErrorType.TMD1002 };
+                    yield return new ModelError(alias, $"La classe '{aliasClass.ReferenceName}' est introuvable dans le fichier '{alias.File.ReferenceName}'.", aliasClass) { ModelErrorType = ModelErrorType.TMD1002 };
                     continue;
                 }
 
@@ -478,12 +478,12 @@ public class ModelStore
                 modelFile.ResolvedAliases.Add(referencedClass);
             }
 
-            foreach (var endpointName in alias.Endpoints)
+            foreach (var aliasEndpoint in alias.Endpoints)
             {
-                var referencedEndpoint = referencedFile.Endpoints.SingleOrDefault(endpoint => endpoint.Name == endpointName);
+                var referencedEndpoint = referencedFile.Endpoints.SingleOrDefault(endpoint => endpoint.Name == aliasEndpoint.ReferenceName);
                 if (referencedEndpoint == null)
                 {
-                    yield return new ModelError(alias, $"L'endpoint '{endpointName}' est introuvable dans le fichier '{alias.File}'.") { ModelErrorType = ModelErrorType.TMD1006 };
+                    yield return new ModelError(alias, $"L'endpoint '{aliasEndpoint.ReferenceName}' est introuvable dans le fichier '{alias.File.ReferenceName}'.", aliasEndpoint) { ModelErrorType = ModelErrorType.TMD1006 };
                     continue;
                 }
 


### PR DESCRIPTION
Pour les alias de classes/endpoints, on récupère désormais les références des fichiers, classes et endpoints référencés. Les références de classes sont identifiées en tant que telles et ont été ajoutées dans les références d'un fichier, ainsi que dans le listing des références d'une classe.

Cela permet donc de : 
- Mettre les erreurs de fichier/classe/endpoint incorrects sur la bonne ligne
- Avoir la coloration sémantique et la navigation sur les classes
- Inclure les références de classes dans la liste des références d'une classe (CodeLens, rename)

Pour être exhaustif avec ce qu'on sait déjà faire, il aurait fallu intégrer la complétion sur les noms de fichiers/classes/endpoints, et gérer le symbole de la référence de fichier, mais l'intérêt est assez faible vu la faible utilisation de la fonctionnalité...