### PR TITLE
Auto-complétion des propriétés d'alias

### DIFF
--- a/TopModel.Core/FileModel/AliasReference.cs
+++ b/TopModel.Core/FileModel/AliasReference.cs
@@ -2,7 +2,7 @@
 
 namespace TopModel.Core.FileModel;
 
-internal class AliasReference : ClassReference
+public class AliasReference : ClassReference
 {
     public List<Reference> IncludeReferences { get; } = new();
 

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -24,8 +24,21 @@ public class ModelFile
     public IDictionary<Reference, object> References => Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object))
         .Concat(Properties.OfType<RegularProperty>().Select(p => (p.DomainReference as Reference, p.Domain as object)))
         .Concat(Properties.OfType<AssociationProperty>().Select(p => (p.Reference as Reference, p.Association as object)))
-        .Concat(Properties.OfType<CompositionProperty>().SelectMany(p => new (Reference, object)[] { (p.Reference, p.Composition), (p.DomainKindReference, p.DomainKind) }))
-        .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[] { (p.ClassReference, p.OriginalProperty?.Class), (p.PropertyReference, p.OriginalProperty), (p.ListDomainReference, p.ListDomain) }))
+        .Concat(Properties.OfType<CompositionProperty>().SelectMany(p => new (Reference, object)[]
+        {
+            (p.Reference, p.Composition),
+            (p.DomainKindReference, p.DomainKind)
+        }))
+        .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[]
+        {
+            (p.ClassReference, p.OriginalProperty?.Class),
+            (p.PropertyReference, p.OriginalProperty),
+            (p.ListDomainReference, p.ListDomain)
+        }))
+        .Concat(Properties.OfType<AliasProperty>()
+            .SelectMany(p => (p?.ClassReference as AliasReference)?.ExcludeReferences?
+                .Select(er => (er, p?.OriginalProperty?.Class?.Properties?.FirstOrDefault(p => p?.Name == er?.ReferenceName) as object))
+            ?? new List<(Reference, object)>()))
         .Concat(Aliases.SelectMany(a => a.Classes).Select(c => (c as Reference, ResolvedAliases.OfType<Class>().FirstOrDefault(ra => ra.Name == c.ReferenceName) as object)))
         .Where(t => t.Item1 != null && t.Item2 != null)
         .DistinctBy(t => t.Item1)

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -70,6 +70,10 @@ public class AliasProperty : IFieldProperty
 
     public ClassReference? ClassReference { get; set; }
 
+    public AliasReference? Reference { get; set; }
+
+    public Reference? PropertyReference { get; set; }
+
     internal string? Prefix { get; set; }
 
     internal string? Suffix { get; set; }
@@ -78,10 +82,6 @@ public class AliasProperty : IFieldProperty
     internal Reference Location { get; set; }
 
 #nullable enable
-    internal AliasReference? Reference { get; set; }
-
-    internal Reference? PropertyReference { get; set; }
-
     internal DomainReference? ListDomainReference { get; set; }
 
     internal AliasProperty? OriginalAliasProperty { get; private set; }

--- a/TopModel.Core/ModelErrorType.cs
+++ b/TopModel.Core/ModelErrorType.cs
@@ -23,6 +23,11 @@ public enum ModelErrorType
     TMD0003,
 
     /// <summary>
+    /// La propriété '{propertyReference.Name}' est déjà référencée dans la définition de l'alias.
+    /// </summary>
+    TMD0004,
+
+    /// <summary>
     /// La classe '{0}' doit avoir une (et une seule) clé primaire pour être référencée dans une association.
     /// </summary>
     TMD1001,

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -85,6 +85,16 @@ public class ModelStore
         return fsWatcher;
     }
 
+    public Dictionary<string, Class> GetReferencedClasses(ModelFile modelFile)
+    {
+        var dependencies = GetDependencies(modelFile).ToList();
+        return dependencies
+            .SelectMany(m => m.Classes)
+            .Concat(modelFile.Classes.Where(c => !modelFile.ResolvedAliases.Contains(c)))
+            .Distinct()
+            .ToDictionary(c => c.Name.Value, c => c);
+    }
+
     public void OnModelFileChange(string filePath, string? content = null)
     {
         _logger.LogInformation(string.Empty);

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -409,6 +409,18 @@ public class ModelStore
                 }
             }
 
+            foreach (var include in alp.Reference.IncludeReferences.Where((e, i) => alp.Reference.IncludeReferences.Where((p, j) => p.ReferenceName == e.ReferenceName && j < i).Any()))
+            {
+                yield return new ModelError(modelFile, $"La propriété '{include.ReferenceName}' est déjà référencée dans la définition de l'alias.", include) { IsError = true, ModelErrorType = ModelErrorType.TMD0004 };
+                shouldBreak = true;
+            }
+
+            foreach (var exclude in alp.Reference.ExcludeReferences.Where((e, i) => alp.Reference.ExcludeReferences.Where((p, j) => p.ReferenceName == e.ReferenceName && j < i).Any()))
+            {
+                yield return new ModelError(modelFile, $"La propriété '{exclude.ReferenceName}' est déjà référencée dans la définition de l'alias.", exclude) { IsError = true, ModelErrorType = ModelErrorType.TMD0004 };
+                shouldBreak = true;
+            }
+
             if (shouldBreak)
             {
                 continue;

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -107,7 +107,7 @@ class CodeActionHandler : CodeActionHandlerBase
         var fs = request.TextDocument.Uri.GetFileSystemPath();
         var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var domainName = line[diagnostic.Range.Start.Character..diagnostic.Range.End.Character];
+        var domainName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
 
         return _modelStore.Files.Where(f => f.Domains.Any()).Select(f =>
         {
@@ -150,7 +150,7 @@ domain:
         var fs = request.TextDocument.Uri.GetFileSystemPath();
         var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var className = line[diagnostic.Range.Start.Character..diagnostic.Range.End.Character];
+        var className = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
         var availableClasses = _modelStore.Classes;
         var useIndex = modelFile!.Uses.Any()
             ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
@@ -191,7 +191,7 @@ domain:
     {
         var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var className = line[diagnostic.Range.Start.Character..diagnostic.Range.End.Character];
+        var className = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
         return new List<CommandOrCodeAction>{
             new CodeAction
             {

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -21,6 +21,11 @@ public static class OmnisharpExtensions
 
     public static bool ShouldMatch(this string word, string otherword)
     {
+        if (string.IsNullOrWhiteSpace(otherword))
+        {
+            return true;
+        }
+
         var currentIndex = 0;
 
         foreach (var character in otherword.ToLower())


### PR DESCRIPTION
Fix #8

L'autocomplétion des propriétés d'alias est désormais fonctionnelle, dans tous les cas.
J'ai aussi corrigé un "bug" où VSCode pouvait ne pas prendre en compte le début de la saisie lorsqu'il insérait la complétion (dans tous les cas).

J'en ai profité pour ajouter une nouvelle erreur si une propriété est référencée plusieurs fois dans une même définition d'alias (TMD0004), en particulier parce que la complétion ne regarde pas si la propriété est déjà listée (peut être une autre fois...).

De plus, les propriétés exclues dans les alias sont correctement identifiées comme des références vers des propriétés (ce n'était pas le cas automatiquement puisque la propriété n'est justement pas dans la classe cible).

J'ai aussi corrigé un bug sur le code action provider que j'ai vu si tu fais des trucs un peu bizarre.