### PR TITLE
Pluriels et types d'associations

### DIFF
--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -32,6 +32,9 @@ public class ClassLoader
                 case "name":
                     classe.Name = new LocatedString(value);
                     break;
+                case "pluralName":
+                    classe.PluralName = value.Value;
+                    break;
                 case "sqlName":
                     classe.SqlName = value.Value;
                     break;

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -1,4 +1,5 @@
 ﻿using TopModel.Core.FileModel;
+using TopModel.Utils;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -7,10 +8,12 @@ namespace TopModel.Core.Loaders;
 public class ClassLoader
 {
     private readonly FileChecker _fileChecker;
+    private readonly ModelConfig _modelConfig;
 
-    public ClassLoader(FileChecker fileChecker)
+    public ClassLoader(FileChecker fileChecker, ModelConfig modelConfig)
     {
         _fileChecker = fileChecker;
+        _modelConfig = modelConfig;
     }
 
     internal Class LoadClass(Parser parser, string filePath)
@@ -65,6 +68,7 @@ public class ClassLoader
         }
 
         classe.Label ??= classe.Name;
+        classe.SqlName ??= ModelUtils.ConvertCsharp2Bdd(_modelConfig.PluralizeTableNames ? classe.PluralName : classe.Name);
 
         parser.Consume<Scalar>();
         parser.Consume<SequenceStart>();

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -1,4 +1,5 @@
-﻿using TopModel.Core.FileModel;
+﻿using System.Text;
+using TopModel.Core.FileModel;
 
 namespace TopModel.Core;
 
@@ -26,7 +27,41 @@ public class AssociationProperty : IFieldProperty
 
     public string? DefaultValue { get; set; }
 
-    public string Name => (Association?.Extends == null && !AsAlias ? Association?.Name : string.Empty) + Association?.Properties.Single(p => p.PrimaryKey).Name + (Role?.Replace(" ", string.Empty) ?? string.Empty);
+    public string Name
+    {
+        get
+        {
+            if (Association == null)
+            {
+                return string.Empty;
+            }
+
+            var name = new StringBuilder();
+            if (Association.Extends == null && !AsAlias)
+            {
+                if (Type == AssociationType.OneToMany || Type == AssociationType.ManyToMany)
+                {
+                    name.Append(Association.PluralName);
+                }
+                else
+                {
+                    name.Append(Association.Name);
+                }
+            }
+
+            if (Type == AssociationType.ManyToOne || Type == AssociationType.OneToOne)
+            {
+                name.Append(Association?.Properties.Single(p => p.PrimaryKey).Name);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Role))
+            {
+                name.Append(Role?.Replace(" ", string.Empty));
+            }
+
+            return name.ToString();
+        }
+    }
 
     public Domain Domain => Association.Properties.OfType<IFieldProperty>().Single(p => p.PrimaryKey).Domain;
 

--- a/TopModel.Core/Model/AssociationType.cs
+++ b/TopModel.Core/Model/AssociationType.cs
@@ -3,9 +3,9 @@
 public enum AssociationType
 {
     /// <summary>
-    /// One to many.
+    /// Many to one.
     /// </summary>
-    OneToMany,
+    ManyToOne,
 
     /// <summary>
     /// One to one.
@@ -13,9 +13,9 @@ public enum AssociationType
     OneToOne,
 
     /// <summary>
-    /// Many to one.
+    /// One to many.
     /// </summary>
-    ManyToOne,
+    OneToMany,
 
     /// <summary>
     /// Many to many.

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -1,18 +1,17 @@
 ﻿using TopModel.Core.FileModel;
-using TopModel.Utils;
 
 namespace TopModel.Core;
 
 public class Class
 {
-    private string? _sqlName;
-
     private string? _pluralName;
 
     public LocatedString? Trigram { get; set; }
 
 #nullable disable
     public LocatedString Name { get; set; }
+
+    public string SqlName { get; set; }
 
     public string Comment { get; set; }
 
@@ -42,12 +41,6 @@ public class Class
     public IList<ReferenceValue>? ReferenceValues { get; set; }
 
     public IList<IList<IFieldProperty>>? UniqueKeys { get; set; }
-
-    public string SqlName
-    {
-        get => _sqlName ?? ModelUtils.ConvertCsharp2Bdd(Name);
-        set => _sqlName = value;
-    }
 
     public string PluralName
     {

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -7,6 +7,8 @@ public class Class
 {
     private string? _sqlName;
 
+    private string? _pluralName;
+
     public LocatedString? Trigram { get; set; }
 
 #nullable disable
@@ -45,6 +47,12 @@ public class Class
     {
         get => _sqlName ?? ModelUtils.ConvertCsharp2Bdd(Name);
         set => _sqlName = value;
+    }
+
+    public string PluralName
+    {
+        get => _pluralName ?? (Name.EndsWith("s") ? Name : $"{Name}s");
+        set => _pluralName = value;
     }
 
     public bool IsPersistent => Properties.Any(p => p is not AliasProperty && p.PrimaryKey) || Properties.All(p => p is AssociationProperty);

--- a/TopModel.Core/ModelConfig.cs
+++ b/TopModel.Core/ModelConfig.cs
@@ -11,6 +11,8 @@ public class ModelConfig
 
     public bool AllowCompositePrimaryKey { get; set; }
 
+    public bool PluralizeTableNames { get; set; }
+
     public string GetFileName(string filePath)
     {
         return Path.GetRelativePath(Path.Combine(Directory.GetCurrentDirectory(), ModelRoot), filePath)

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -27,6 +27,10 @@
       "type": "boolean",
       "description": "Autorise les clés primaires composites (incompatible avec une génération de C#)."
     },
+    "pluralizeTableNames": {
+      "type": "boolean",
+      "description": "Utilise le nom au pluriel des classes pour générer leur noms de table SQL."
+    },
     "proceduralSql": {
       "type": "array",
       "description": "Liste de configs pour la génération de SQL 'procédurale' (sans SSDT)",

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -64,7 +64,7 @@
             },
             "type": {
               "type": "string",
-              "description": "Type de l'association. La plupart des générateurs ignorent ce paramètre et considèrent qu'une associtation est toujours une FK simple. Par défaut: 'oneToMany'",
+              "description": "Type de l'association. La plupart des générateurs ignorent ce paramètre et considèrent qu'une associtation est toujours une FK simple. Par défaut: 'manyToOne'",
               "enum": [ "oneToOne", "oneToMany", "manyToOne", "manyToMany" ]
             },
             "required": {

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -64,7 +64,7 @@
             },
             "type": {
               "type": "string",
-              "description": "Type de l'association. La plupart des générateurs ignorent ce paramètre et considèrent qu'une associtation est toujours une FK simple. Par défaut: 'manyToOne'",
+              "description": "Type de l'association. Par défaut: 'manyToOne'",
               "enum": [ "oneToOne", "oneToMany", "manyToOne", "manyToMany" ]
             },
             "required": {

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -394,7 +394,11 @@
             },
             "name": {
               "type": "string",
-              "description": "Nom C#/TS de la classe. Sera converti en SQL en SNAKE_CASE."
+              "description": "Nom de la classe. Sera converti en SQL en SNAKE_CASE."
+            },
+            "pluralName": {
+              "type": "string",
+              "description": "Nom de la classe au pluriel. Sera généré à partir du nom avec un 's' si non renseigné."
             },
             "sqlName": {
               "type": "string",

--- a/TopModel.Generator/CSharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpClassGenerator.cs
@@ -450,6 +450,11 @@ public class CSharpClassGenerator
 
         var type = _config.GetPropertyTypeName(property, useIEnumerable: false);
 
+        if (property is AssociationProperty a && a.Type != AssociationType.ManyToOne && a.Type != AssociationType.OneToOne)
+        {
+            throw new ModelException(a, $"Le type d'association {a.Type} n'est pas supporté par le générateur C#");
+        }
+
         if (property is IFieldProperty fp)
         {
             var domain = (fp as AliasProperty)?.ListDomain ?? fp.Domain;

--- a/TopModel.Generator/CSharp/CSharpUtils.cs
+++ b/TopModel.Generator/CSharp/CSharpUtils.cs
@@ -92,16 +92,6 @@ public static class CSharpUtils
     }
 
     /// <summary>
-    /// Mets au pluriel le nom.
-    /// </summary>
-    /// <param name="className">Le nom de la classe.</param>
-    /// <returns>Au pluriel.</returns>
-    public static string Pluralize(string className)
-    {
-        return className.EndsWith("s") ? className : className + "s";
-    }
-
-    /// <summary>
     /// Initialisation des types.
     /// </summary>
     private static void InitializeRegType()

--- a/TopModel.Generator/CSharp/DbContextGenerator.cs
+++ b/TopModel.Generator/CSharp/DbContextGenerator.cs
@@ -2,9 +2,6 @@
 using TopModel.Core;
 
 namespace TopModel.Generator.CSharp;
-
-using static CSharpUtils;
-
 public class DbContextGenerator
 {
     private readonly CSharpConfig _config;
@@ -96,7 +93,7 @@ public class DbContextGenerator
         {
             w.WriteLine();
             w.WriteSummary(2, "Accès à l'entité " + classe.Name);
-            w.WriteLine(2, "public DbSet<" + classe.Name + "> " + Pluralize(classe.Name) + " { get; set; }");
+            w.WriteLine(2, "public DbSet<" + classe.Name + "> " + classe.PluralName + " { get; set; }");
         }
 
         if (_config.UseEFMigrations)

--- a/TopModel.Generator/CSharp/ReferenceAccessorGenerator.cs
+++ b/TopModel.Generator/CSharp/ReferenceAccessorGenerator.cs
@@ -2,9 +2,6 @@
 using TopModel.Core;
 
 namespace TopModel.Generator.CSharp;
-
-using static CSharpUtils;
-
 public class ReferenceAccessorGenerator
 {
     private readonly CSharpConfig _config;
@@ -23,7 +20,7 @@ public class ReferenceAccessorGenerator
     public void Generate(IEnumerable<Class> classes)
     {
         var classList = classes
-            .OrderBy(x => Pluralize(x.Name), StringComparer.Ordinal)
+            .OrderBy(x => x.PluralName, StringComparer.Ordinal)
             .ToList();
 
         if (!classList.Any() || _config.Kinetix == KinetixVersion.None)
@@ -155,7 +152,7 @@ public class ReferenceAccessorGenerator
 
         foreach (var classe in classList.Where(c => c.IsPersistent || c.ReferenceValues != null))
         {
-            var serviceName = "Load" + (_config.DbContextPath == null ? $"{classe.Name}List" : Pluralize(classe.Name));
+            var serviceName = "Load" + (_config.DbContextPath == null ? $"{classe.Name}List" : classe.PluralName);
             w.WriteLine(2, "/// <inheritdoc cref=\"" + interfaceName + "." + serviceName + "\" />");
             w.WriteLine(2, "public ICollection<" + classe.Name + "> " + serviceName + "()\r\n{");
             w.WriteLine(3, LoadReferenceAccessorBody(classe));
@@ -254,7 +251,7 @@ public class ReferenceAccessorGenerator
                 w.WriteLine(2, "[OperationContract]");
             }
 
-            w.WriteLine(2, "ICollection<" + classe.Name + "> Load" + (_config.DbContextPath == null ? $"{classe.Name}List" : Pluralize(classe.Name)) + "();");
+            w.WriteLine(2, "ICollection<" + classe.Name + "> Load" + (_config.DbContextPath == null ? $"{classe.Name}List" : classe.PluralName) + "();");
 
             if (count != classList.Count())
             {
@@ -294,7 +291,7 @@ public class ReferenceAccessorGenerator
                 queryParameter = $".OrderBy(row => row.{defaultProperty.Name})";
             }
 
-            return $"return _dbContext.{Pluralize(classe.Name)}{queryParameter}.ToList();";
+            return $"return _dbContext.{classe.PluralName}{queryParameter}.ToList();";
         }
         else
         {

--- a/docs/model/classes.md
+++ b/docs/model/classes.md
@@ -7,6 +7,8 @@ Une classe se définit de la façon suivante :
 ```yaml
 class:
   name: # Nom de la classe
+  pluralName: # Nom de la classe au pluriel, si différent de "name" avec un "s"
+  sqlName: # Nom de la table SQL associée, si différent de "name" ou "pluralName" (selon configuration) en SNAKE_CASE
   label: # Libellé de la classe
   comment: # Description de la calasse
   # Autres propriétés comme "trigram" (si persistant), "defaultProperty", "reference" pour les listes de références...

--- a/docs/model/properties.md
+++ b/docs/model/properties.md
@@ -24,7 +24,13 @@ comment: Montant initial du prêt.
 
 Une association est une propriété spéciale qui permet de **référencer la clé primaire d'une autre classe**. L'usage principal est de pouvoir définir des clés étrangères dans un modèle persisté. Elle est identifiée par la présence de la propriété `association` en premier.
 
-Une association peut être obligatoire (ou non) et définir un rôle optionnel. Le nom de la propriété sera déterminé automatiquement comme étant `{ClasseCible}{CléPrimaire}{Rôle}`. Une association peut aussi définir une multiplicité ("one to one", "one to many"...), mais cette information n'est en général pas utilisée par les divers générateurs, qui supposent qu'il s'agit toujours d'une "one to many".
+Une association peut être obligatoire (ou non) et définir un rôle optionnel.
+
+Une association peut également définir sa multiplicité : `manyToOne` (par défaut), `oneToOne`, `oneToMany` et `manyToMany`.
+
+Une `manyToOne` correspond à une clé étrangère simple vers la classe référencée, tandis que `oneToOne` y ajoute une contrainte d'unicité. Dans ces deux cas, le nom de la propriété sera déterminé automatiquement comme étant `{ClasseCible.Name}{ClasseCible.PrimaryKey}{Rôle}`.
+
+Les `oneToMany` et `manyToMany` ne sont (pour l'instant) acceptées que par le générateur JPA, qui implémentera ces associations comme des collections de la classe cible. Dans ces deux cas, le nom de la propriété sera déterminé automatiquement comme étant `{ClasseCible.PluralName}{Rôle}`.
 
 La classe référencée par l'association doit être connue du fichier de modèle courant, soit parce qu'elle est définie dedans, soit parce que son fichier est référencé dans la section `uses`.
 


### PR DESCRIPTION
Issue liée : #22

## Pluriels

Toute classe définit désormais un `PluralName`, qui est son nom au pluriel. Il est défini par défaut comme le nom de la classe avec un "s" à la fin (sauf s'il y en a déjà un). Puisqu'on ne veut pas chercher à déterminer des pluriels automatiquement (et en plusieurs langues...), on permet de saisir manuellement sur la classe.

Jusqu'à présent, le pluriel (non paramétrable) n'était utilisé que dans le générateur C# pour déterminer les noms de DbSet et les noms des accesseurs de listes de référence.

Désormais, ils seront également utilisés : 
- pour déterminer le `SqlName` d'une classe, si la nouvelle option `pluralizeTableNames` est renseignée dans la config (il s'agit d'une configuration commune à tous les générateurs). Cela permet d'avoir une classe `Utilisateur` mappée sur une table persistée `UTILISATEURS` par exemple, sans avoir à renseigner le `SqlName` (ni le `PluralName` d'ailleurs dans ce cas) sur la classe
- pour déterminer le nom d'une propriété d'association typée `oneToMany` ou `manyToMany`. Les autres types d'associations utilisent toujours `{class.Name}{class.primaryKey}{Role}`, tandis que celles-ci sont désormais définies comme `{class.PluralName}{class.Role}` (sans le nom de la PK du coup, vu qu'elles sont générées comme des collections).

## Types d'associations

Les types d'associations sont désormais utilisés dans les générateurs SQL et C#. Enfin, ils vont jeter une erreur si on utilise `oneToMany` ou `manyToMany`, qui ne sont volontairement pas gérés. En revanche, la `oneToOne` va désormais générer une clé d'unicité sur la FK pour les 3 générateurs.

De plus, le type par défaut est désormais `manyToOne`, ce qui correspond bien à ce que faisaient ces générateurs par défaut.

## La suite

Je laisse @gideruette s'occuper de la prise en compte de la nouvelle règle de nommage dans le générateur JPA et de faire les ajustements nécessaires dans la génération JS pour les `oneToMany`/`manyToMany` (qui étaient la demande initiale de #22)