### PR TITLE
JPA : Implémenter générateur Spring Api client #134

### DIFF
--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -285,13 +285,9 @@
               "description": "Catégorie de fichier que le générateur doit lire."
             }
           },
-          "apiServerOutputDirectory": {
+          "apiOutputDirectory": {
             "type": "string",
             "description": "Dossier de sortie pour les Controllers."
-          },
-          "apiClientOutputDirectory": {
-            "type": "string",
-            "description": "Dossier de sortie pour les clients d'api."
           },
           "modelOutputDirectory": {
             "type": "string",
@@ -315,13 +311,14 @@
             "type": "string",
             "description": "Précise l'interface des fields enum générés."
           },
-          "apiServerPackageName": {
+          "apiPackageName": {
             "type": "string",
             "description": "Précise le nom du package dans lequel générer les controllers."
           },
-          "apiClientPackageName": {
+          "apiGeneration": {
             "type": "string",
-            "description": "Précise le nom du package dans lequel générer les clients d'api."
+            "description": "Mode de génération de l'API ('Client' ou 'Server')",
+            "enum": ["Client", "Server"]
           }
         }
       }

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -285,9 +285,13 @@
               "description": "Catégorie de fichier que le générateur doit lire."
             }
           },
-          "apiOutputDirectory": {
+          "apiServerOutputDirectory": {
             "type": "string",
             "description": "Dossier de sortie pour les Controllers."
+          },
+          "apiClientOutputDirectory": {
+            "type": "string",
+            "description": "Dossier de sortie pour les clients d'api."
           },
           "modelOutputDirectory": {
             "type": "string",
@@ -311,9 +315,13 @@
             "type": "string",
             "description": "Précise l'interface des fields enum générés."
           },
-          "apiPackageName": {
+          "apiServerPackageName": {
             "type": "string",
             "description": "Précise le nom du package dans lequel générer les controllers."
+          },
+          "apiClientPackageName": {
+            "type": "string",
+            "description": "Précise le nom du package dans lequel générer les clients d'api."
           }
         }
       }

--- a/TopModel.Generator/Config/ApiGeneration.cs
+++ b/TopModel.Generator/Config/ApiGeneration.cs
@@ -1,4 +1,4 @@
-﻿namespace TopModel.Generator.CSharp;
+﻿namespace TopModel.Generator;
 
 /// <summary>
 /// Version de Kinetix.

--- a/TopModel.Generator/Jpa/JpaConfig.cs
+++ b/TopModel.Generator/Jpa/JpaConfig.cs
@@ -32,22 +32,18 @@ public class JpaConfig : GeneratorConfigBase
     /// <summary>
     /// Précise le nom du package dans lequel générer les controllers.
     /// </summary>
-    public string ApiServerPackageName { get; set; }
-
-    /// <summary>
-    /// Précise le nom du package dans lequel générer les clients d'api.
-    /// </summary>
-    public string ApiClientPackageName { get; set; }
+    public string ApiPackageName { get; set; }
 
 #nullable enable
 
     /// <summary>
     /// Dossier de sortie pour les controllers.
     /// </summary>
-    public string? ApiServerOutputDirectory { get; set; }
+    public string? ApiOutputDirectory { get; set; }
+
 
     /// <summary>
-    /// Dossier de sortie pour les clients d'api.
+    /// Mode de génération de l'API ("client" ou "server").
     /// </summary>
-    public string? ApiClientOutputDirectory { get; set; }
+    public ApiGeneration ApiGeneration { get; set; }
 }

--- a/TopModel.Generator/Jpa/JpaConfig.cs
+++ b/TopModel.Generator/Jpa/JpaConfig.cs
@@ -32,12 +32,22 @@ public class JpaConfig : GeneratorConfigBase
     /// <summary>
     /// Précise le nom du package dans lequel générer les controllers.
     /// </summary>
-    public string ApiPackageName { get; set; }
+    public string ApiServerPackageName { get; set; }
+
+    /// <summary>
+    /// Précise le nom du package dans lequel générer les clients d'api.
+    /// </summary>
+    public string ApiClientPackageName { get; set; }
 
 #nullable enable
 
     /// <summary>
-    /// Dossier de sortie pour les Controllers.
+    /// Dossier de sortie pour les controllers.
     /// </summary>
-    public string? ApiOutputDirectory { get; set; }
+    public string? ApiServerOutputDirectory { get; set; }
+
+    /// <summary>
+    /// Dossier de sortie pour les clients d'api.
+    /// </summary>
+    public string? ApiClientOutputDirectory { get; set; }
 }

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -1,0 +1,299 @@
+﻿using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Core.FileModel;
+using TopModel.Utils;
+
+namespace TopModel.Generator.Jpa;
+
+/// <summary>
+/// Générateur des objets de traduction javascripts.
+/// </summary>
+public class SpringClientApiGenerator : GeneratorBase
+{
+    private readonly JpaConfig _config;
+    private readonly ILogger<SpringClientApiGenerator> _logger;
+
+    private readonly IDictionary<string, ModelFile> _files = new Dictionary<string, ModelFile>();
+
+    public SpringClientApiGenerator(ILogger<SpringClientApiGenerator> logger, JpaConfig config)
+        : base(logger, config)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    public override string Name => "SpringClientApiGenerator";
+
+    public override IEnumerable<string> GeneratedFiles => _files.Select(f => GetFilePath(f.Value));
+
+    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    {
+        foreach (var file in files)
+        {
+            _files[file.Name] = file;
+            GenerateClient(file);
+        }
+    }
+
+    private string GetDestinationFolder(ModelFile file)
+    {
+        return Path.Combine(_config.ApiClientOutputDirectory!, Path.Combine(_config.ApiClientOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiClientPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
+    }
+
+    private string GetClassName(ModelFile file)
+    {
+        if (file.Options?.Endpoints?.FileName != null)
+        {
+            return $"Abstract{file.Options.Endpoints.FileName.ToFirstUpper()}Client";
+        }
+
+        var filePath = file.Name.Split("/").Last();
+        return $"Abstract{string.Join('_', filePath.Split("_").Skip(filePath.Contains('_') ? 1 : 0)).ToFirstUpper()}Controller";
+    }
+
+    private string GetFileName(ModelFile file)
+    {
+        var filePath = file.Name.Split("/").Last();
+        return $"{GetClassName(file)}.java";
+    }
+
+    private string GetFilePath(ModelFile file)
+    {
+        return $"{GetDestinationFolder(file)}\\{GetFileName(file)}";
+    }
+
+    private void GenerateClient(ModelFile file)
+    {
+        if (!file.Endpoints.Any() || _config.ApiClientOutputDirectory == null)
+        {
+            return;
+        }
+
+        foreach (var endpoint in file.Endpoints)
+        {
+            CheckEndpoint(endpoint);
+        }
+
+        var destFolder = GetDestinationFolder(file);
+        Directory.CreateDirectory(destFolder);
+
+        using var fw = new JavaWriter($"{GetFilePath(file)}", _logger, null);
+
+        fw.WriteLine($"package {_config.ApiClientPackageName}.{file.Module.ToLower()};");
+
+        WriteImports(file, fw);
+        fw.WriteLine();
+
+        fw.WriteLine("@Generated(\"TopModel : https://github.com/klee-contrib/topmodel\")");
+        fw.WriteLine($"public abstract class {GetClassName(file)} {{");
+
+        fw.WriteLine();
+
+        fw.WriteLine(1, $"protected RestTemplate restTemplate;");
+        fw.WriteLine(1, $"protected String host;");
+
+        fw.WriteLine();
+        fw.WriteDocStart(1, "Constructeur par paramètres");
+        fw.WriteLine(1, " * @param restTemplate");
+        fw.WriteLine(1, " * @param host");
+        fw.WriteDocEnd(1);
+        fw.WriteLine(1, $"{GetClassName(file)}(RestTemplate restTemplate, String host) {{");
+        fw.WriteLine(2, $"this.restTemplate = restTemplate;");
+        fw.WriteLine(2, $"this.host = host;");
+        fw.WriteLine(1, $"}}");
+
+        GetClassName(file);
+
+        foreach (var endpoint in file.Endpoints)
+        {
+            WriteEndPoint(fw, endpoint);
+        }
+
+        fw.WriteLine("}");
+    }
+
+    private void WriteEndPoint(JavaWriter fw, Endpoint endpoint)
+    {
+        fw.WriteLine();
+        WriteUriBuilderMethod(fw, endpoint);
+        fw.WriteLine();
+        WriteEndpointCallMethod(fw, endpoint);
+    }
+    private List<string> GetMethodParams(Endpoint endpoint, bool withType = true, bool withBody = true)
+    {
+        var methodParams = new List<string>();
+        foreach (var param in endpoint.GetRouteParams())
+        {
+            if (withType)
+            {
+                methodParams.Add($"{param.GetJavaType()} {param.GetParamName()}");
+            }
+            else
+            {
+                methodParams.Add(param.GetParamName());
+            }
+        }
+
+        foreach (var param in endpoint.GetQueryParams())
+        {
+            if (withType)
+            {
+                methodParams.Add($"{param.GetJavaType()} {param.GetParamName()}");
+            }
+            else
+            {
+                methodParams.Add(param.GetParamName());
+            }
+        }
+
+        var bodyParam = endpoint.GetBodyParam();
+        if (bodyParam != null && withBody)
+        {
+            if (withType)
+            {
+                methodParams.Add($"{bodyParam.GetJavaType()} {bodyParam.GetParamName()}");
+            }
+            else
+            {
+                methodParams.Add(bodyParam.GetParamName());
+            }
+        }
+
+        return methodParams;
+    }
+
+    private void WriteUriBuilderMethod(JavaWriter fw, Endpoint endpoint)
+    {
+        fw.WriteDocStart(1, $"UriComponentsBuilder pour la méthode {endpoint.Name}");
+
+        foreach (var param in endpoint.GetRouteParams().Concat(endpoint.GetQueryParams()))
+        {
+            fw.WriteLine(1, $" * @param {param.GetParamName()} {param.Comment}");
+        }
+
+        if (endpoint.Returns != null)
+        {
+            fw.WriteLine(1, $" * @return uriBuilder avec les query params remplis");
+        }
+
+        fw.WriteLine(1, " */");
+        var returnType = "UriComponentsBuilder";
+        var methodParams = GetMethodParams(endpoint, true, false);
+
+        fw.WriteLine(1, $"protected {returnType} {endpoint.Name.ToFirstLower()}UriComponentsBuilder ({string.Join(", ", methodParams)}) {{");
+        var fullRoute = endpoint.FullRoute;
+        foreach (IProperty p in endpoint.GetRouteParams())
+        {
+            fullRoute = fullRoute.Replace(@$"{{{p.GetParamName()}}}", "%s");
+        }
+        if (endpoint.GetRouteParams().Any())
+        {
+            fullRoute = $@"""{fullRoute}"".formatted({string.Join(", ", endpoint.GetRouteParams().Select(p => p.GetParamName()))});";
+        }
+        else
+        {
+            fullRoute = $@"""{fullRoute}""";
+        }
+
+        fw.WriteLine(2, @$"String uri = host + {fullRoute};");
+        if (!endpoint.GetQueryParams().Any())
+        {
+            fw.WriteLine(2, @$"return UriComponentsBuilder.fromUri(URI.create(uri));");
+            fw.WriteLine(1, "}");
+            return;
+        }
+        fw.WriteLine(2, @$"UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));");
+        foreach (IProperty p in endpoint.GetQueryParams())
+        {
+            var indentLevel = 2;
+            var isRequired = p is IFieldProperty fp && fp.Required;
+            if (!isRequired)
+            {
+                fw.WriteLine(2, @$"if ({p.GetParamName()} != null) {{");
+                indentLevel++;
+            }
+
+            fw.WriteLine(indentLevel, @$"uriBuilder.queryParam(""{p.GetParamName()}"", {p.GetParamName()});");
+            if (!isRequired)
+            {
+                fw.WriteLine(2, @$"}}");
+                fw.WriteLine();
+            }
+        }
+
+        fw.WriteLine(2, $"return uriBuilder;");
+        fw.WriteLine(1, "}");
+    }
+    private void WriteEndpointCallMethod(JavaWriter fw, Endpoint endpoint)
+    {
+        fw.WriteDocStart(1, endpoint.Description);
+
+        foreach (var param in endpoint.Params)
+        {
+            fw.WriteLine(1, $" * @param {param.GetParamName()} {param.Comment}");
+        }
+
+        if (endpoint.Returns != null)
+        {
+            fw.WriteLine(1, $" * @return {endpoint.Returns.Comment}");
+        }
+
+        fw.WriteLine(1, " */");
+        var returnType = "ResponseEntity";
+
+        if (endpoint.Returns != null)
+        {
+            returnType = $"ResponseEntity<{endpoint.Returns.GetJavaType().Split('<').First()}>";
+        }
+
+        var methodParams = GetMethodParams(endpoint, true, false);
+        fw.WriteLine(1, $"public {returnType} {endpoint.Name.ToFirstLower()}({string.Join(", ", GetMethodParams(endpoint).Concat(new List<string>(){"MultiValueMap<String, String> headers"}))}) {{");
+        fw.WriteLine(2, $"UriComponentsBuilder uri = this.{endpoint.Name.ToFirstLower()}UriComponentsBuilder({string.Join(", ", GetMethodParams(endpoint, false, false))});");
+        var body = $"new HttpEntity<>({(endpoint.GetBodyParam()?.GetParamName() != null ? $"{endpoint.GetBodyParam()?.GetParamName()}, " : string.Empty)}headers)";
+        if (endpoint.Returns != null)
+        {
+            fw.WriteLine(2, $"return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.{endpoint.Method}, {body}, {endpoint.Returns.GetJavaType().Split('<').First()}.class);");
+        }
+        else
+        {
+            fw.WriteLine(2, $"return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.{endpoint.Method}, {body}, (Class<?>) null);");
+        }
+        fw.WriteLine(1, "}");
+    }
+    private void WriteImports(ModelFile file, JavaWriter fw)
+    {
+        var imports = new List<string>();
+        imports.AddRange(GetTypeImports(file));
+        imports.Add("javax.annotation.Generated");
+        imports.Add("org.springframework.web.util.UriComponentsBuilder");
+        imports.Add("org.springframework.web.client.RestTemplate");
+        imports.Add("java.net.URI");
+        imports.Add("org.springframework.http.HttpMethod");
+        imports.Add("org.springframework.http.HttpEntity");
+        imports.Add("org.springframework.util.MultiValueMap");
+        imports.Add("org.springframework.http.ResponseEntity");
+        fw.WriteImports(imports.Distinct().ToArray());
+    }
+
+    private IEnumerable<string> GetTypeImports(ModelFile file)
+    {
+        var properties = file.Endpoints.SelectMany(endpoint => endpoint.Params).Concat(file.Endpoints.Where(endpoint => endpoint.Returns is not null).Select(endpoint => endpoint.Returns));
+        return properties.SelectMany(property => property!.GetImports(_config));
+    }
+
+    private void CheckEndpoint(Endpoint endpoint)
+    {
+        foreach (var q in endpoint.GetQueryParams().Concat(endpoint.GetRouteParams()))
+        {
+            if (q is AssociationProperty ap)
+            {
+                throw new ModelException(endpoint, $"Le endpoint {endpoint.Route} ne peut pas contenir d'association");
+            }
+        }
+
+        if (endpoint.Returns != null && endpoint.Returns is AssociationProperty)
+        {
+            throw new ModelException(endpoint, $"Le retour du endpoint {endpoint.Route} ne peut pas être une association");
+        }
+    }
+}

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -48,7 +48,7 @@ public class SpringClientApiGenerator : GeneratorBase
         }
 
         var filePath = file.Name.Split("/").Last();
-        return $"Abstract{string.Join('_', filePath.Split("_").Skip(filePath.Contains('_') ? 1 : 0)).ToFirstUpper()}Client";
+        return $"Abstract{string.Join('_', filePath.Split("_").Skip(filePath.Contains('_') ? 1 : 0)).ToFirstUpper().Replace("-", string.Empty)}Client";
     }
 
     private string GetFileName(ModelFile file)

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -37,7 +37,7 @@ public class SpringClientApiGenerator : GeneratorBase
 
     private string GetDestinationFolder(ModelFile file)
     {
-        return Path.Combine(_config.ApiClientOutputDirectory!, Path.Combine(_config.ApiClientOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiClientPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
+        return Path.Combine(_config.ApiOutputDirectory!, Path.Combine(_config.ApiOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
     }
 
     private string GetClassName(ModelFile file)
@@ -64,7 +64,7 @@ public class SpringClientApiGenerator : GeneratorBase
 
     private void GenerateClient(ModelFile file)
     {
-        if (!file.Endpoints.Any() || _config.ApiClientOutputDirectory == null)
+        if (!file.Endpoints.Any() || _config.ApiOutputDirectory == null)
         {
             return;
         }
@@ -79,7 +79,7 @@ public class SpringClientApiGenerator : GeneratorBase
 
         using var fw = new JavaWriter($"{GetFilePath(file)}", _logger, null);
 
-        fw.WriteLine($"package {_config.ApiClientPackageName}.{file.Module.ToLower()};");
+        fw.WriteLine($"package {_config.ApiPackageName}.{file.Module.ToLower()};");
 
         WriteImports(file, fw);
         fw.WriteLine();

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -181,7 +181,7 @@ public class SpringClientApiGenerator : GeneratorBase
         var returnType = "UriComponentsBuilder";
         var methodParams = GetMethodParams(endpoint, true, false);
 
-        fw.WriteLine(1, $"protected {returnType} {endpoint.Name.ToFirstLower()}UriComponentsBuilder ({string.Join(", ", methodParams)}) {{");
+        fw.WriteLine(1, $"protected {returnType} {endpoint.Name.ToFirstLower()}UriComponentsBuilder({string.Join(", ", methodParams)}) {{");
         var fullRoute = endpoint.FullRoute;
         foreach (IProperty p in endpoint.GetRouteParams())
         {
@@ -257,7 +257,7 @@ public class SpringClientApiGenerator : GeneratorBase
         }
 
         var methodParams = GetMethodParams(endpoint, true, false);
-        fw.WriteLine(1, $"public {returnType} {endpoint.Name.ToFirstLower()}({string.Join(", ", GetMethodParams(endpoint).Concat(new List<string>() { "HttpHeaders headers" }))}) {{");
+        fw.WriteLine(1, $"public {returnType} {endpoint.Name.ToFirstLower()}({string.Join(", ", GetMethodParams(endpoint).Concat(new List<string>() { "HttpHeaders headers" }))}){{");
         fw.WriteLine(2, $"UriComponentsBuilder uri = this.{endpoint.Name.ToFirstLower()}UriComponentsBuilder({string.Join(", ", GetMethodParams(endpoint, false, false))});");
         var body = $"new HttpEntity<>({(endpoint.GetBodyParam()?.GetParamName() != null ? $"{endpoint.GetBodyParam()?.GetParamName()}, " : string.Empty)}headers)";
         if (endpoint.Returns != null)

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
@@ -37,7 +37,7 @@ public class SpringServerApiGenerator : GeneratorBase
 
     private string GetDestinationFolder(ModelFile file)
     {
-        return Path.Combine(_config.ApiServerOutputDirectory!, Path.Combine(_config.ApiServerOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiServerPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
+        return Path.Combine(_config.ApiOutputDirectory!, Path.Combine(_config.ApiOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
     }
 
     private string GetClassName(ModelFile file)
@@ -64,7 +64,7 @@ public class SpringServerApiGenerator : GeneratorBase
 
     private void GenerateController(ModelFile file)
     {
-        if (!file.Endpoints.Any() || _config.ApiServerOutputDirectory == null)
+        if (!file.Endpoints.Any() || _config.ApiOutputDirectory == null)
         {
             return;
         }
@@ -79,7 +79,7 @@ public class SpringServerApiGenerator : GeneratorBase
 
         using var fw = new JavaWriter($"{GetFilePath(file)}", _logger, null);
 
-        fw.WriteLine($"package {_config.ApiServerPackageName}.{file.Module.ToLower()};");
+        fw.WriteLine($"package {_config.ApiPackageName}.{file.Module.ToLower()};");
 
         WriteImports(file, fw);
         fw.WriteLine();

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
@@ -8,21 +8,21 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class SpringApiGenerator : GeneratorBase
+public class SpringServerApiGenerator : GeneratorBase
 {
     private readonly JpaConfig _config;
-    private readonly ILogger<SpringApiGenerator> _logger;
+    private readonly ILogger<SpringServerApiGenerator> _logger;
 
     private readonly IDictionary<string, ModelFile> _files = new Dictionary<string, ModelFile>();
 
-    public SpringApiGenerator(ILogger<SpringApiGenerator> logger, JpaConfig config)
+    public SpringServerApiGenerator(ILogger<SpringServerApiGenerator> logger, JpaConfig config)
         : base(logger, config)
     {
         _config = config;
         _logger = logger;
     }
 
-    public override string Name => "SpringApiGenerator";
+    public override string Name => "SpringServerApiGenerator";
 
     public override IEnumerable<string> GeneratedFiles => _files.Select(f => GetFilePath(f.Value));
 
@@ -37,7 +37,7 @@ public class SpringApiGenerator : GeneratorBase
 
     private string GetDestinationFolder(ModelFile file)
     {
-        return Path.Combine(_config.ApiOutputDirectory!, Path.Combine(_config.ApiPackageName.ToLower().Split(".")), "controller", Path.Combine(file.Module.ToLower().Split(".")));
+        return Path.Combine(_config.ApiServerOutputDirectory!, Path.Combine(_config.ApiServerOutputDirectory!.ToLower().Split(".")), Path.Combine(_config.ApiServerPackageName.Split('.')), Path.Combine(file.Module.ToLower().Split(".")));
     }
 
     private string GetClassName(ModelFile file)
@@ -64,7 +64,7 @@ public class SpringApiGenerator : GeneratorBase
 
     private void GenerateController(ModelFile file)
     {
-        if (!file.Endpoints.Any() || _config.ApiOutputDirectory == null)
+        if (!file.Endpoints.Any() || _config.ApiServerOutputDirectory == null)
         {
             return;
         }
@@ -79,7 +79,7 @@ public class SpringApiGenerator : GeneratorBase
 
         using var fw = new JavaWriter($"{GetFilePath(file)}", _logger, null);
 
-        fw.WriteLine($"package {_config.ApiPackageName}.controller.{file.Module.ToLower()};");
+        fw.WriteLine($"package {_config.ApiServerPackageName}.{file.Module.ToLower()};");
 
         WriteImports(file, fw);
         fw.WriteLine();

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -143,8 +143,7 @@ if (config.Jpa != null)
     foreach (var jpaConfig in config.Jpa)
     {
         CombinePath(dn, jpaConfig, c => c.ModelOutputDirectory);
-        CombinePath(dn, jpaConfig, c => c.ApiServerOutputDirectory);
-        CombinePath(dn, jpaConfig, c => c.ApiClientOutputDirectory);
+        CombinePath(dn, jpaConfig, c => c.ApiOutputDirectory);
 
         services
             .AddSingleton<IModelWatcher>(p =>
@@ -157,18 +156,20 @@ if (config.Jpa != null)
             .AddSingleton<IModelWatcher>(p =>
                 new JpaDaoGenerator(p.GetRequiredService<ILogger<JpaDaoGenerator>>(), jpaConfig));
 
-        if (jpaConfig.ApiServerOutputDirectory != null)
+        if (jpaConfig.ApiOutputDirectory != null)
         {
-            services
-                .AddSingleton<IModelWatcher>(p =>
-                    new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), jpaConfig));
-        }
-
-        if (jpaConfig.ApiClientOutputDirectory != null)
-        {
-            services
-                .AddSingleton<IModelWatcher>(p =>
-                    new SpringClientApiGenerator(p.GetRequiredService<ILogger<SpringClientApiGenerator>>(), jpaConfig));
+            if (jpaConfig.ApiGeneration == ApiGeneration.Server)
+            {
+                services
+                    .AddSingleton<IModelWatcher>(p =>
+                        new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), jpaConfig));
+            }
+            else if (jpaConfig.ApiGeneration == ApiGeneration.Client)
+            {
+                services
+                    .AddSingleton<IModelWatcher>(p =>
+                        new SpringClientApiGenerator(p.GetRequiredService<ILogger<SpringClientApiGenerator>>(), jpaConfig));
+            }
         }
     }
 }

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -143,7 +143,8 @@ if (config.Jpa != null)
     foreach (var jpaConfig in config.Jpa)
     {
         CombinePath(dn, jpaConfig, c => c.ModelOutputDirectory);
-        CombinePath(dn, jpaConfig, c => c.ApiOutputDirectory);
+        CombinePath(dn, jpaConfig, c => c.ApiServerOutputDirectory);
+        CombinePath(dn, jpaConfig, c => c.ApiClientOutputDirectory);
 
         services
             .AddSingleton<IModelWatcher>(p =>
@@ -156,11 +157,18 @@ if (config.Jpa != null)
             .AddSingleton<IModelWatcher>(p =>
                 new JpaDaoGenerator(p.GetRequiredService<ILogger<JpaDaoGenerator>>(), jpaConfig));
 
-        if (jpaConfig.ApiOutputDirectory != null)
+        if (jpaConfig.ApiServerOutputDirectory != null)
         {
             services
                 .AddSingleton<IModelWatcher>(p =>
-                    new SpringApiGenerator(p.GetRequiredService<ILogger<SpringApiGenerator>>(), jpaConfig));
+                    new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), jpaConfig));
+        }
+
+        if (jpaConfig.ApiClientOutputDirectory != null)
+        {
+            services
+                .AddSingleton<IModelWatcher>(p =>
+                    new SpringClientApiGenerator(p.GetRequiredService<ILogger<SpringClientApiGenerator>>(), jpaConfig));
         }
     }
 }

--- a/docs/exemple/Securite/Utilisateur/04_Utilisateur.tmd
+++ b/docs/exemple/Securite/Utilisateur/04_Utilisateur.tmd
@@ -2,6 +2,7 @@
 module: Securite.Utilisateur
 tags:
   - dto
+  - api-client
 uses:
   - Securite/Utilisateur/02_Entities
   - Securite/Utilisateur/03_Dtos

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
@@ -1,0 +1,157 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.exemple.name.api.securite.utilisateur;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Generated;
+import javax.validation.constraints.Email;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import topmodel.exemple.name.dao.dtos.utilisateur.UtilisateurDto;
+import topmodel.exemple.name.dao.entities.utilisateur.TypeUtilisateur;
+
+@Generated("TopModel : https://github.com/klee-contrib/topmodel")
+public abstract class AbstractUtilisateurApiClient {
+
+	protected RestTemplate restTemplate;
+	protected String host;
+
+	/**
+	 * Constructeur par paramètres.
+	 * @param restTemplate
+	 * @param host
+	 */
+	AbstractUtilisateurApiClient(RestTemplate restTemplate, String host) {
+		this.restTemplate = restTemplate;
+		this.host = host;
+	}
+
+	/**
+	 * UriComponentsBuilder pour la méthode GetUtilisateur.
+	 * @param utiId Id technique
+	 * @return uriBuilder avec les query params remplis
+	 */
+	protected UriComponentsBuilder getUtilisateurUriComponentsBuilder (long utiId) {
+		String uri = host + "utilisateur/%s".formatted(utiId);;
+		return UriComponentsBuilder.fromUri(URI.create(uri));
+	}
+
+	/**
+	 * Charge le détail d'un utilisateur.
+	 * @param utiId Id technique
+	 * @return Le détail de l'utilisateur
+	 */
+	public ResponseEntity<UtilisateurDto> getUtilisateur(long utiId, MultiValueMap<String, String> headers) {
+		UriComponentsBuilder uri = this.getUtilisateurUriComponentsBuilder(utiId);
+		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.GET, new HttpEntity<>(headers), UtilisateurDto.class);
+	}
+
+	/**
+	 * UriComponentsBuilder pour la méthode GetUtilisateurList.
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
+	 * @return uriBuilder avec les query params remplis
+	 */
+	protected UriComponentsBuilder getUtilisateurListUriComponentsBuilder (TypeUtilisateur.Values typeUtilisateurCode) {
+		String uri = host + "utilisateur/list";
+		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));
+		if (typeUtilisateurCode != null) {
+			uriBuilder.queryParam("typeUtilisateurCode", typeUtilisateurCode);
+		}
+
+		return uriBuilder;
+	}
+
+	/**
+	 * Charge une liste d'utilisateurs par leur type.
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
+	 * @return Liste des utilisateurs
+	 */
+	public ResponseEntity<List> getUtilisateurList(TypeUtilisateur.Values typeUtilisateurCode, MultiValueMap<String, String> headers) {
+		UriComponentsBuilder uri = this.getUtilisateurListUriComponentsBuilder(typeUtilisateurCode);
+		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.GET, new HttpEntity<>(headers), List.class);
+	}
+
+	/**
+	 * UriComponentsBuilder pour la méthode SaveUtilisateur.
+	 * @return uriBuilder avec les query params remplis
+	 */
+	protected UriComponentsBuilder saveUtilisateurUriComponentsBuilder () {
+		String uri = host + "utilisateur/save";
+		return UriComponentsBuilder.fromUri(URI.create(uri));
+	}
+
+	/**
+	 * Sauvegarde un utilisateur.
+	 * @param utilisateur Utilisateur à sauvegarder
+	 * @return Utilisateur sauvegardé
+	 */
+	public ResponseEntity<UtilisateurDto> saveUtilisateur(UtilisateurDto utilisateur, MultiValueMap<String, String> headers) {
+		UriComponentsBuilder uri = this.saveUtilisateurUriComponentsBuilder();
+		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(utilisateur, headers), UtilisateurDto.class);
+	}
+
+	/**
+	 * UriComponentsBuilder pour la méthode SaveAllUtilisateur.
+	 * @return uriBuilder avec les query params remplis
+	 */
+	protected UriComponentsBuilder saveAllUtilisateurUriComponentsBuilder () {
+		String uri = host + "utilisateur/saveAll";
+		return UriComponentsBuilder.fromUri(URI.create(uri));
+	}
+
+	/**
+	 * Sauvegarde une liste d'utilisateurs.
+	 * @param utilisateur Utilisateur à sauvegarder
+	 * @return Utilisateur sauvegardé
+	 */
+	public ResponseEntity<List> saveAllUtilisateur(List<UtilisateurDto> utilisateur, MultiValueMap<String, String> headers) {
+		UriComponentsBuilder uri = this.saveAllUtilisateurUriComponentsBuilder();
+		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(utilisateur, headers), List.class);
+	}
+
+	/**
+	 * UriComponentsBuilder pour la méthode Search.
+	 * @param utiUtilisateurId Id technique
+	 * @param utilisateuremail Email de l'utilisateur
+	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
+	 * @return uriBuilder avec les query params remplis
+	 */
+	protected UriComponentsBuilder searchUriComponentsBuilder (long utiUtilisateurId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode) {
+		String uri = host + "utilisateur/search";
+		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));
+		uriBuilder.queryParam("utiUtilisateurId", utiUtilisateurId);
+		if (utilisateuremail != null) {
+			uriBuilder.queryParam("utilisateuremail", utilisateuremail);
+		}
+
+		if (utilisateurTypeUtilisateurCode != null) {
+			uriBuilder.queryParam("utilisateurTypeUtilisateurCode", utilisateurTypeUtilisateurCode);
+		}
+
+		return uriBuilder;
+	}
+
+	/**
+	 * Recherche des utilisateurs.
+	 * @param utiUtilisateurId Id technique
+	 * @param utilisateuremail Email de l'utilisateur
+	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
+	 * @return Utilisateurs matchant les critères
+	 */
+	public ResponseEntity<Page> search(long utiUtilisateurId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, MultiValueMap<String, String> headers) {
+		UriComponentsBuilder uri = this.searchUriComponentsBuilder(utiUtilisateurId, utilisateuremail, utilisateurTypeUtilisateurCode);
+		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(headers), Page.class);
+	}
+}

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
@@ -13,9 +13,9 @@ import javax.validation.constraints.Email;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -33,7 +33,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param restTemplate
 	 * @param host
 	 */
-	AbstractUtilisateurApiClient(RestTemplate restTemplate, String host) {
+	protected AbstractUtilisateurApiClient(RestTemplate restTemplate, String host) {
 		this.restTemplate = restTemplate;
 		this.host = host;
 	}
@@ -53,7 +53,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param utiId Id technique
 	 * @return Le détail de l'utilisateur
 	 */
-	public ResponseEntity<UtilisateurDto> getUtilisateur(long utiId, MultiValueMap<String, String> headers) {
+	public ResponseEntity<UtilisateurDto> getUtilisateur(long utiId, HttpHeaders headers) {
 		UriComponentsBuilder uri = this.getUtilisateurUriComponentsBuilder(utiId);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.GET, new HttpEntity<>(headers), UtilisateurDto.class);
 	}
@@ -78,7 +78,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return Liste des utilisateurs
 	 */
-	public ResponseEntity<List> getUtilisateurList(TypeUtilisateur.Values typeUtilisateurCode, MultiValueMap<String, String> headers) {
+	public ResponseEntity<List> getUtilisateurList(TypeUtilisateur.Values typeUtilisateurCode, HttpHeaders headers) {
 		UriComponentsBuilder uri = this.getUtilisateurListUriComponentsBuilder(typeUtilisateurCode);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.GET, new HttpEntity<>(headers), List.class);
 	}
@@ -97,7 +97,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param utilisateur Utilisateur à sauvegarder
 	 * @return Utilisateur sauvegardé
 	 */
-	public ResponseEntity<UtilisateurDto> saveUtilisateur(UtilisateurDto utilisateur, MultiValueMap<String, String> headers) {
+	public ResponseEntity<UtilisateurDto> saveUtilisateur(UtilisateurDto utilisateur, HttpHeaders headers) {
 		UriComponentsBuilder uri = this.saveUtilisateurUriComponentsBuilder();
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(utilisateur, headers), UtilisateurDto.class);
 	}
@@ -116,7 +116,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param utilisateur Utilisateur à sauvegarder
 	 * @return Utilisateur sauvegardé
 	 */
-	public ResponseEntity<List> saveAllUtilisateur(List<UtilisateurDto> utilisateur, MultiValueMap<String, String> headers) {
+	public ResponseEntity<List> saveAllUtilisateur(List<UtilisateurDto> utilisateur, HttpHeaders headers) {
 		UriComponentsBuilder uri = this.saveAllUtilisateurUriComponentsBuilder();
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(utilisateur, headers), List.class);
 	}
@@ -150,7 +150,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return Utilisateurs matchant les critères
 	 */
-	public ResponseEntity<Page> search(long utiUtilisateurId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, MultiValueMap<String, String> headers) {
+	public ResponseEntity<Page> search(long utiUtilisateurId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, HttpHeaders headers) {
 		UriComponentsBuilder uri = this.searchUriComponentsBuilder(utiUtilisateurId, utilisateuremail, utilisateurTypeUtilisateurCode);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(headers), Page.class);
 	}

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/IUtilisateurApiController.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/IUtilisateurApiController.java
@@ -2,7 +2,7 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-package topmodel.exemple.name.api.controller.securite.utilisateur;
+package topmodel.exemple.name.api.securite.utilisateur;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/docs/exemple/topmodel.exemple.config
+++ b/docs/exemple/topmodel.exemple.config
@@ -7,9 +7,9 @@ jpa:
       - entity
     modelOutputDirectory: ./jpa/src/main/javagen
     daoPackageName: topmodel.exemple.name.dao
-    apiServerOutputDirectory: ./jpa/src/main/javagen
-    apiServerPackageName: topmodel.exemple.name.api
-    apiClientPackageName: topmodel.exemple.name.api
+    apiOutputDirectory: ./jpa/src/main/javagen
+    apiPackageName: topmodel.exemple.name.api
+    apiGeneration: server
     fieldsEnum: true
     fieldsEnumInterface: topmodel.exemple.utils.IFieldEnum<>
     enumShortcutMode: false
@@ -17,8 +17,9 @@ jpa:
       - api-client
     modelOutputDirectory: ./jpa/src/main/javagen
     daoPackageName: topmodel.exemple.name.dao
-    apiClientOutputDirectory: ./jpa/src/main/javagen
-    apiClientPackageName: topmodel.exemple.name.api
+    apiOutputDirectory: ./jpa/src/main/javagen
+    apiPackageName: topmodel.exemple.name.api
+    apiGeneration: client
 javascript:
   - tags:
       - dto

--- a/docs/exemple/topmodel.exemple.config
+++ b/docs/exemple/topmodel.exemple.config
@@ -7,11 +7,18 @@ jpa:
       - entity
     modelOutputDirectory: ./jpa/src/main/javagen
     daoPackageName: topmodel.exemple.name.dao
-    apiOutputDirectory: ./jpa/src/main/javagen
-    apiPackageName: topmodel.exemple.name.api
+    apiServerOutputDirectory: ./jpa/src/main/javagen
+    apiServerPackageName: topmodel.exemple.name.api
+    apiClientPackageName: topmodel.exemple.name.api
     fieldsEnum: true
     fieldsEnumInterface: topmodel.exemple.utils.IFieldEnum<>
     enumShortcutMode: false
+  - tags:
+      - api-client
+    modelOutputDirectory: ./jpa/src/main/javagen
+    daoPackageName: topmodel.exemple.name.dao
+    apiClientOutputDirectory: ./jpa/src/main/javagen
+    apiClientPackageName: topmodel.exemple.name.api
 javascript:
   - tags:
       - dto

--- a/docs/exemple/topmodel.lock
+++ b/docs/exemple/topmodel.lock
@@ -4,14 +4,15 @@
 
 version: 1.10.0
 generatedFiles:
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\securite\IDtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\securite\IEntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\securite\IReferencesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\securite\utilisateur\IUtilisateurApiController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\utilisateur\IDecoratorsController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\utilisateur\IDtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\utilisateur\IEntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\controller\utilisateur\IReferencesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IDtosController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IEntitiesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IReferencesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\AbstractUtilisateurApiClient.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\IUtilisateurApiController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IDecoratorsController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IDtosController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IEntitiesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IReferencesController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\dao\daos\securite\ProfilDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\dao\daos\securite\ProfilDtoDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\dao\daos\securite\TypeProfilDAO.java

--- a/docs/generator/jpa.md
+++ b/docs/generator/jpa.md
@@ -197,8 +197,55 @@ public interface IUtilisateurDto {
 }
 ```
 
-## Api
+## Api Server
 
 Le générateur créé des `interface` contenant, pour chaque endPoint paramétré, la méthode abstraite `Nom du endpoint`, à implémenter dans votre controller.
 
 Pour créer votre API, il suffit donc de créer un nouveau controller qui implémente la classe générée. L'annotation `@RestController` reste nécessaire.
+
+## Api Client
+
+Le générateur créé des classes abstraites contenant, toutes les méthodes permettant d'accéder aux endpoints paramétrés.
+
+Pour créer votre client d'API, il suffit de créer une classe qui hérite de cette classe abstraite. Pour fonctionner, elle devra appeler le constructeur de la classe abrstaite, en renseignant :
+
+- Le host de l'API
+- Une instance de `RestTemplate`
+
+Exemple :
+
+```java
+@Service
+public class UtilisateurApiClient extends AbstractUtilisateurApiCLient {
+
+  private static final HOST = "http://localhost:8080/my-app/api/";
+
+  @Autowired
+  public UtilisateurApiClient(RestTemplate restTemplate) {
+    super(restTemplate, HOST);
+  }
+}
+```
+
+Pour appeler l'API utilisateur, injecter le service UtilisateurApiClient. Puis appeler la méthode de votre choix en entrant les différents paramètres, en y ajoutant l'objet HttpHeaders désiré.
+
+```java
+@Service
+public class UtilisateurService {
+
+  private static final HOST = "http://localhost:8080/my-app/api/";
+
+  private final UtilisateurApiClient utilisateurApiClient;
+
+  @Autowired
+  public UtilisateurService(UtilisateurApiClient utilisateurApiClient) {
+    this.utilisateurApiClient = utilisateurApiClient;
+  }
+
+  public UtilisateurDto getUtilisateur(Long id){
+    var headers = new HttpHeaders();
+    headers.add("token-sécurisé", "MON_TOKEN_SECURISE");
+    return utilisateurApiClient.getUtilisateur(id, headers);
+  }
+}
+```


### PR DESCRIPTION
- Création du générateur SpringClientApiGenerator
- Renommage du SpringApiGenerator en SpringServerApiGenerator
- Ajout des configurations  apiClientOutputDirectory et apiClientPackageName
- Renommage équivalent pour SpringServerApiGenerator
- Suppression de l'ajout du répertoire `controller` dans les package des controllers créés

Fix #134 