### PR TITLE
Mappings sur les compositions

### DIFF
--- a/TopModel.Core/FileModel/FileOptions.cs
+++ b/TopModel.Core/FileModel/FileOptions.cs
@@ -1,4 +1,4 @@
-#nullable disable
+﻿#nullable disable
 
 namespace TopModel.Core.FileModel;
 

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -53,7 +53,7 @@ public class ModelFile
         .Concat(Classes.SelectMany(c => c.UniqueKeyReferences.SelectMany(uk => uk).Select(propRef => (propRef, (object)c.Properties.FirstOrDefault(p => p.Name == propRef.ReferenceName)))))
         .Concat(Classes.SelectMany(c => c.ReferenceValueReferences.SelectMany(rv => rv.Value).Select(prop => (prop.Key, (object)c.Properties.FirstOrDefault(p => p.Name == prop.Key.ReferenceName)))))
         .Concat(Classes.SelectMany(c => c.FromMappers.SelectMany(m => m.Params).Concat(c.ToMappers)).Select(p => (p.ClassReference as Reference, (object)p.Class)))
-        .Concat(Classes.SelectMany(c => c.FromMappers.SelectMany(m => m.Params).Concat(c.ToMappers).SelectMany(m => m.MappingReferences.SelectMany(mr => new[] { (mr.Key, (object)c.Properties.FirstOrDefault(k => k.Name == mr.Key.ReferenceName)), (mr.Value, (object)m.Mappings.Values.FirstOrDefault(k => k.Name == mr.Value.ReferenceName)) }))))
+        .Concat(Classes.SelectMany(c => c.FromMappers.SelectMany(m => m.Params).Concat(c.ToMappers).SelectMany(m => m.MappingReferences.SelectMany(mr => new[] { (mr.Key, (object)c.Properties.FirstOrDefault(k => k.Name == mr.Key.ReferenceName)), (mr.Value, mr.Value.ReferenceName == "this" || mr.Value.ReferenceName == "false" ? new object() : m.Mappings.Values.FirstOrDefault(k => k.Name == mr.Value.ReferenceName)) }))))
         .Concat(Aliases.SelectMany(a => a.Classes).Select(c => (c as Reference, ResolvedAliases.OfType<Class>().FirstOrDefault(ra => ra.Name == c.ReferenceName) as object)))
         .Where(t => t.Item1 != null && t.Item2 != null)
         .DistinctBy(t => t.Item1)

--- a/TopModel.Core/Model/ClassMappings.cs
+++ b/TopModel.Core/Model/ClassMappings.cs
@@ -14,7 +14,7 @@ public class ClassMappings
 #nullable enable
     public string? Comment { get; set; }
 
-    public Dictionary<IFieldProperty, IFieldProperty> Mappings { get; } = new();
+    public Dictionary<IProperty, IFieldProperty> Mappings { get; } = new();
 
     public Dictionary<Reference, Reference> MappingReferences { get; } = new();
 

--- a/TopModel.Core/Model/ClassMappings.cs
+++ b/TopModel.Core/Model/ClassMappings.cs
@@ -14,7 +14,7 @@ public class ClassMappings
 #nullable enable
     public string? Comment { get; set; }
 
-    public Dictionary<IProperty, IFieldProperty> Mappings { get; } = new();
+    public Dictionary<IProperty, IFieldProperty?> Mappings { get; } = new();
 
     public Dictionary<Reference, Reference> MappingReferences { get; } = new();
 

--- a/TopModel.Core/ModelErrorType.cs
+++ b/TopModel.Core/ModelErrorType.cs
@@ -108,6 +108,21 @@ public enum ModelErrorType
     TMD1016,
 
     /// <summary>
+    /// La propriété '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car ce n'est pas une association.
+    /// </summary>
+    TMD1017,
+
+    /// <summary>
+    /// L'association '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car les types de composition et d'association ne correspondent pas.
+    /// </summary>
+    TMD1018,
+
+    /// <summary>
+    /// La propriété '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car elle n'a pas le même domaine que la clé primaire de la classe '{cp.Composition.Name}' composée.
+    /// </summary>
+    TMD1019,
+
+    /// <summary>
     /// L'import {} n'est pas utilisé.
     /// </summary>
     TMD9001,

--- a/TopModel.Core/ModelErrorType.cs
+++ b/TopModel.Core/ModelErrorType.cs
@@ -123,6 +123,11 @@ public enum ModelErrorType
     TMD1019,
 
     /// <summary>
+    /// La classe '{mappedClass.Name}' ne peut pas être mappée sur la propriété '{currentProperty.Name}' car ce n'est pas une composition de cette classe.
+    /// </summary>
+    TMD1020,
+
+    /// <summary>
     /// L'import {} n'est pas utilisé.
     /// </summary>
     TMD9001,

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -874,6 +874,20 @@ public class ModelStore
                         continue;
                     }
 
+                    if (currentProperty != null && mapping.Value.ReferenceName == "this")
+                    {
+                        if (currentProperty is CompositionProperty cp && cp.Composition == mappedClass)
+                        {
+                            mappings.Mappings.Add(currentProperty, null);
+                        }
+                        else
+                        {
+                            yield return new ModelError(classe, $"La classe '{mappedClass.Name}' ne peut pas être mappée sur la propriété '{currentProperty.Name}' car ce n'est pas une composition de cette classe.", mapping.Value) { ModelErrorType = ModelErrorType.TMD1020 };
+                        }
+
+                        continue;
+                    }
+
                     var mappedProperty = mappedClass.Properties.OfType<IFieldProperty>().FirstOrDefault(p => p.Name == mapping.Value.ReferenceName);
                     if (mappedProperty == null)
                     {
@@ -1013,7 +1027,7 @@ public class ModelStore
 
                 foreach (var mapping in mapper.Mappings.Where((e, i) => mapper.Mappings.Where((p, j) => p.Value == e.Value && j < i).Any()))
                 {
-                    yield return new ModelError(classe, $"Plusieurs propriétés de la classe peuvent être mappées sur '{mapper.Class}.{mapping.Value.Name}' : {string.Join(", ", mapper.Mappings.Where(p => p.Value == mapping.Value).Select(p => $"'{p.Key.Name}'"))}.", mapper.GetLocation()) { ModelErrorType = ModelErrorType.TMD1016 };
+                    yield return new ModelError(classe, $"Plusieurs propriétés de la classe peuvent être mappées sur '{mapper.Class}.{mapping.Value?.Name}' : {string.Join(", ", mapper.Mappings.Where(p => p.Value == mapping.Value).Select(p => $"'{p.Key.Name}'"))}.", mapper.GetLocation()) { ModelErrorType = ModelErrorType.TMD1016 };
                 }
             }
         }

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -863,7 +863,7 @@ public class ModelStore
 
                 foreach (var mapping in mappings.MappingReferences)
                 {
-                    var currentProperty = classe.Properties.OfType<IFieldProperty>().FirstOrDefault(p => p.Name == mapping.Key.ReferenceName);
+                    var currentProperty = classe.Properties.FirstOrDefault(p => p.Name == mapping.Key.ReferenceName);
                     if (currentProperty == null)
                     {
                         yield return new ModelError(classe, $"La propriété '{{0}}' est introuvable sur la classe '{classe}'.", mapping.Key) { ModelErrorType = ModelErrorType.TMD1004 };
@@ -884,9 +884,40 @@ public class ModelStore
                     {
                         mappings.Mappings.Add(currentProperty, mappedProperty);
 
-                        if (currentProperty.Domain != mappedProperty.Domain)
+                        if (currentProperty is IFieldProperty fp && fp.Domain != mappedProperty.Domain)
                         {
-                            yield return new ModelError(classe, $"La propriété '{mappedProperty.Name}' ne peut pas être mappée à '{currentProperty.Name}' car elle n'a pas le même domaine ('{mappedProperty.Domain.Name}' au lieu de '{currentProperty.Domain.Name}').", mapping.Value) { ModelErrorType = ModelErrorType.TMD1014 };
+                            yield return new ModelError(classe, $"La propriété '{mappedProperty.Name}' ne peut pas être mappée à '{currentProperty.Name}' car elle n'a pas le même domaine ('{mappedProperty.Domain.Name}' au lieu de '{fp.Domain.Name}').", mapping.Value) { ModelErrorType = ModelErrorType.TMD1014 };
+                        }
+                        else if (currentProperty is CompositionProperty cp)
+                        {
+                            var mappedAp = mappedProperty switch
+                            {
+                                AssociationProperty ap => ap,
+                                AliasProperty { Property: AssociationProperty ap } => ap,
+                                _ => null
+                            };
+
+                            if (mappedAp == null)
+                            {
+                                yield return new ModelError(classe, $"La propriété '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car ce n'est pas une association.", mapping.Value) { ModelErrorType = ModelErrorType.TMD1017 };
+                            }
+                            else
+                            {
+                                if (!(
+                                    cp.Kind == "object" && (mappedAp.Type == AssociationType.ManyToOne || mappedAp.Type == AssociationType.OneToOne)
+                                    || cp.Kind == "list" && (mappedAp.Type == AssociationType.ManyToMany || mappedAp.Type == AssociationType.OneToMany)))
+                                {
+                                    yield return new ModelError(classe, $"L'association '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car les types de composition et d'association ne correspondent pas.", mapping.Value) { ModelErrorType = ModelErrorType.TMD1018 };
+                                }
+
+                                var compositionPKs = cp.Composition.Properties.OfType<IFieldProperty>().Where(p => p.PrimaryKey);
+                                var compositionPK = compositionPKs.Count() == 1 ? compositionPKs.Single() : null;
+
+                                if (compositionPK?.Domain != mappedAp.Domain)
+                                {
+                                    yield return new ModelError(classe, $"La propriété '{mappedProperty.Name}' ne peut pas être mappée à la composition '{currentProperty.Name}' car elle n'a pas le même domaine que la clé primaire de la classe '{cp.Composition.Name}' composée ('{mappedProperty.Domain.Name}' au lieu de '{compositionPK?.Domain.Name ?? string.Empty}').", mapping.Value) { ModelErrorType = ModelErrorType.TMD1019 };
+                                }
+                            }
                         }
                     }
                 }

--- a/TopModel.Generator/CSharp/CSharpWriter.cs
+++ b/TopModel.Generator/CSharp/CSharpWriter.cs
@@ -32,7 +32,19 @@ public class CSharpWriter : IDisposable
     /// <param name="text">Texte.</param>
     public void Write(string text)
     {
-        _writer.Write(text);
+        Write(0, text);
+    }
+
+    /// <summary>
+    /// Ecrit la chaine avec le niveau indenté.
+    /// </summary>
+    /// <param name="indentationLevel">Niveau d'indentation.</param>
+    /// <param name="value">Valeur à écrire dans le flux.</param>
+    public void Write(int indentationLevel, string value)
+    {
+        var indentValue = GetIdentValue(indentationLevel);
+        value = value.Replace("\r\n", "\r\n" + indentValue);
+        _writer.Write(indentValue + value);
     }
 
     /// <summary>
@@ -125,17 +137,7 @@ public class CSharpWriter : IDisposable
     /// <param name="value">Valeur à écrire dans le flux.</param>
     public void WriteLine(int indentationLevel, string value)
     {
-        if (_useLatestCSharp && indentationLevel > 0)
-        {
-            indentationLevel--;
-        }
-
-        var indentValue = string.Empty;
-        for (var i = 0; i < indentationLevel; ++i)
-        {
-            indentValue += IndentValue;
-        }
-
+        var indentValue = GetIdentValue(indentationLevel);
         value = value.Replace("\r\n", "\r\n" + indentValue);
         _writer.WriteLine(indentValue + value);
     }
@@ -318,5 +320,26 @@ public class CSharpWriter : IDisposable
 
         sb.Append("\r\n/// </summary>");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Calcule l'identation nécessaire.
+    /// </summary>
+    /// <param name="indentationLevel">Niveau d'indention.</param>
+    /// <returns>Identation.</returns>
+    private string GetIdentValue(int indentationLevel)
+    {
+        if (_useLatestCSharp && indentationLevel > 0)
+        {
+            indentationLevel--;
+        }
+
+        var indentValue = string.Empty;
+        for (var i = 0; i < indentationLevel; ++i)
+        {
+            indentValue += IndentValue;
+        }
+
+        return indentValue;
     }
 }

--- a/TopModel.Generator/CSharp/MapperGenerator.cs
+++ b/TopModel.Generator/CSharp/MapperGenerator.cs
@@ -96,16 +96,23 @@ public class MapperGenerator
                     {
                         w.Write(4, $"{mapping.Key.Name} = ");
 
-                        if (mapping.Key is CompositionProperty cp)
+                        if (mapping.Value == null)
                         {
-                            w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                            w.Write(param.Name);
                         }
-
-                        w.Write($"{mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}.{mapping.Value.Name}");
-
-                        if (mapping.Key is CompositionProperty)
+                        else
                         {
-                            w.Write("}");
+                            if (mapping.Key is CompositionProperty cp)
+                            {
+                                w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                            }
+
+                            w.Write($"{mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}.{mapping.Value.Name}");
+
+                            if (mapping.Key is CompositionProperty)
+                            {
+                                w.Write("}");
+                            }
                         }
 
                         if (mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1)
@@ -125,16 +132,23 @@ public class MapperGenerator
                 {
                     w.Write(4, $"{mapping.Key.Name} = ");
 
-                    if (mapping.Key is CompositionProperty cp)
+                    if (mapping.Value == null)
                     {
-                        w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                        w.Write(param.Name);
                     }
-
-                    w.Write($"{param.Name}.{mapping.Value.Name}");
-
-                    if (mapping.Key is CompositionProperty)
+                    else
                     {
-                        w.Write(" }");
+                        if (mapping.Key is CompositionProperty cp)
+                        {
+                            w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                        }
+
+                        w.Write($"{param.Name}.{mapping.Value.Name}");
+
+                        if (mapping.Key is CompositionProperty)
+                        {
+                            w.Write(" }");
+                        }
                     }
 
                     if (mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1)
@@ -184,13 +198,13 @@ public class MapperGenerator
             {
                 foreach (var mapping in mapper.ParentMapper.Mappings)
                 {
-                    w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{GetSourceMapping(mapping.Key)};");
+                    w.WriteLine(3, $"dest.{mapping.Value?.Name} = source.{GetSourceMapping(mapping.Key)};");
                 }
             }
 
             foreach (var mapping in mapper.Mappings)
             {
-                w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{GetSourceMapping(mapping.Key)};");
+                w.WriteLine(3, $"dest.{mapping.Value?.Name} = source.{GetSourceMapping(mapping.Key)};");
             }
 
             w.WriteLine(3, "return dest;");

--- a/TopModel.Generator/CSharp/MapperGenerator.cs
+++ b/TopModel.Generator/CSharp/MapperGenerator.cs
@@ -94,7 +94,26 @@ public class MapperGenerator
                     var mappings = param.Mappings.ToList();
                     foreach (var mapping in mappings)
                     {
-                        w.WriteLine(4, $"{mapping.Key.Name} = {mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}.{mapping.Value.Name}{(mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1 ? "," : string.Empty)}");
+                        w.Write(4, $"{mapping.Key.Name} = ");
+
+                        if (mapping.Key is CompositionProperty cp)
+                        {
+                            w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                        }
+
+                        w.Write($"{mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}.{mapping.Value.Name}");
+
+                        if (mapping.Key is CompositionProperty)
+                        {
+                            w.Write("}");
+                        }
+
+                        if (mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1)
+                        {
+                            w.Write(",");
+                        }
+
+                        w.WriteLine();
                     }
                 }
             }
@@ -104,7 +123,26 @@ public class MapperGenerator
                 var mappings = param.Mappings.ToList();
                 foreach (var mapping in mappings)
                 {
-                    w.WriteLine(4, $"{mapping.Key.Name} = {param.Name}.{mapping.Value.Name}{(mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1 ? "," : string.Empty)}");
+                    w.Write(4, $"{mapping.Key.Name} = ");
+
+                    if (mapping.Key is CompositionProperty cp)
+                    {
+                        w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                    }
+
+                    w.Write($"{param.Name}.{mapping.Value.Name}");
+
+                    if (mapping.Key is CompositionProperty)
+                    {
+                        w.Write(" }");
+                    }
+
+                    if (mapper.Params.IndexOf(param) < mapper.Params.Count - 1 || mappings.IndexOf(mapping) < mappings.Count - 1)
+                    {
+                        w.Write(",");
+                    }
+
+                    w.WriteLine();
                 }
             }
 
@@ -130,17 +168,29 @@ public class MapperGenerator
             w.WriteLine(2, "{");
             w.WriteLine(3, $"dest ??= new {mapper.Class}();");
 
+            static string GetSourceMapping(IProperty property)
+            {
+                if (property is CompositionProperty cp)
+                {
+                    return $"{cp.Name}?.{cp.Composition.PrimaryKey?.Name}";
+                }
+                else
+                {
+                    return property.Name;
+                }
+            }
+
             if (mapper.ParentMapper != null)
             {
                 foreach (var mapping in mapper.ParentMapper.Mappings)
                 {
-                    w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{mapping.Key.Name};");
+                    w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{GetSourceMapping(mapping.Key)};");
                 }
             }
 
             foreach (var mapping in mapper.Mappings)
             {
-                w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{mapping.Key.Name};");
+                w.WriteLine(3, $"dest.{mapping.Value.Name} = source.{GetSourceMapping(mapping.Key)};");
             }
 
             w.WriteLine(3, "return dest;");

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
@@ -212,7 +212,11 @@ public class JpaModelConstructorGenerator
                                 }
                                 else if (mapping.Key is CompositionProperty cp)
                                 {
-                                    if (cp.Composition.FromMappers.Any(f => f.Params.Count == 1 && f.Params.First().Class == mapping.Value.Class))
+                                    if (mapping.Value == null)
+                                    {
+                                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {param.Name};");
+                                    }
+                                    else if (cp.Composition.FromMappers.Any(f => f.Params.Count == 1 && f.Params.First().Class == mapping.Value.Class))
                                     {
                                         var cpMapper = cp.Composition.FromMappers.Find(f => f.Params.Count == 1 && f.Params.First().Class == mapping.Value.Class);
                                         fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = new {mapping.Key.Class.Name.ToFirstUpper()}({param.Name.ToFirstLower()}.get{ap.GetJavaName().ToFirstUpper()}());");
@@ -252,7 +256,7 @@ public class JpaModelConstructorGenerator
                     }
                     else
                     {
-                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {param.Name.ToFirstLower()}.get{mapping.Value.Name.ToFirstUpper()}();");
+                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {param.Name.ToFirstLower()}.get{mapping.Value!.Name.ToFirstUpper()}();");
                     }
                 }
 

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
@@ -465,6 +465,21 @@ public class JpaModelGenerator : GeneratorBase
                     {
                         fw.WriteLine(2, $"dest.set{mapping.Value.GetJavaName().ToFirstUpper()}(this.get{mapping.Key.GetJavaName().ToFirstUpper()}());");
                     }
+                    else if (mapping.Key is CompositionProperty cp)
+                    {
+                        if (mapping.Key.Class.ToMappers.Any(t => t.Class == mapping.Value.Class))
+                        {
+                            var cpMapper = mapping.Key.Class.ToMappers.Find(t => t.Class == mapping.Value.Class)!;
+                            fw.WriteLine(2, $@"if (this.get{cp.GetJavaName().ToFirstUpper()}() != null) {{");
+                            fw.WriteLine(3, $@"dest.set{mapping.Value.GetJavaName().ToFirstUpper()}(this.get{cp.GetJavaName().ToFirstUpper()}().{cpMapper.Name.ToFirstLower()}(dest.get{mapping.Value.GetJavaName().ToFirstUpper()}());");
+                            fw.WriteLine(2, $@"}}");
+                            fw.WriteLine();
+                        }
+                        else
+                        {
+                            throw new ModelException(classe, $"La propriété {mapping.Key.Name} ne peut pas être mappée avec la propriété {mapping.Value.Name} car il n'existe pas de mapper {mapping.Key.Class.Name} -> {mapping.Value.Class.Name}");
+                        }
+                    }
                 }
                 else
                 {

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
@@ -483,7 +483,7 @@ public class JpaModelGenerator : GeneratorBase
                 }
                 else
                 {
-                    fw.WriteLine(2, $"dest.set{mapping.Value.GetJavaName().ToFirstUpper()}(this.get{mapping.Key.GetJavaName().ToFirstUpper()}());");
+                    fw.WriteLine(2, $"dest.set{mapping.Value!.GetJavaName().ToFirstUpper()}(this.get{mapping.Key.GetJavaName().ToFirstUpper()}());");
                 }
             }
 

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -263,6 +263,7 @@ class CompletionHandler : CompletionHandlerBase
                     if (classe != null)
                     {
                         string? searchText = null;
+                        var includeCompositions = false;
 
                         if (currentLine.Contains("defaultProperty:") || currentLine.Contains("flagProperty:") || currentLine.Contains("orderProperty:"))
                         {
@@ -352,11 +353,18 @@ class CompletionHandler : CompletionHandlerBase
                                     }
                                 }
                             }
+                            else if (isMappings)
+                            {
+                                includeCompositions = true;
+                            }
                         }
 
                         if (searchText != null)
                         {
-                            return Task.FromResult(new CompletionList(classe.Properties.OfType<IFieldProperty>()
+                            return Task.FromResult(new CompletionList(
+                                (includeCompositions
+                                    ? classe.Properties
+                                    : classe.Properties.Where(p => p is IFieldProperty))
                                 .Where(f => f.Name.ShouldMatch(searchText))
                                 .Select(f => new CompletionItem
                                 {

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -27,7 +27,12 @@ class DefinitionHandler : DefinitionHandlerBase
             if (matchedReference != null)
             {
                 var objet = file.References[matchedReference];
-                var selectionRange = objet.GetLocation().ToRange()!;
+                var selectionRange = objet.GetLocation().ToRange();
+                if (selectionRange == null)
+                {
+                    return Task.FromResult<LocationOrLocationLinks>(new());
+                }
+
                 return Task.FromResult<LocationOrLocationLinks>(new(new LocationLink
                 {
                     OriginSelectionRange = matchedReference.ToRange(),

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -60,6 +60,7 @@ class SemanticTokensHandler : SemanticTokensHandlerBase
                     {
                         ClassReference or DecoratorReference => SemanticTokenType.Class,
                         DomainReference => SemanticTokenType.EnumMember,
+                        Reference r when r.ReferenceName == "this" || r.ReferenceName == "false" => SemanticTokenType.Keyword,
                         _ => SemanticTokenType.Function
                     },
                     SemanticTokenModifier.Definition);

--- a/docs/exemple/Securite/Utilisateur/02_Entities.tmd
+++ b/docs/exemple/Securite/Utilisateur/02_Entities.tmd
@@ -36,7 +36,6 @@ class:
       comment: Type d'utilisateur en Many to one
       type: manyToOne
     - association: Utilisateur
-      comment: Utilisateur jumeau
-      role: Jumeau
+      comment: Utilisateur parent
+      role: Parent
       type: oneToOne
-

--- a/docs/exemple/Securite/Utilisateur/03_Dtos.tmd
+++ b/docs/exemple/Securite/Utilisateur/03_Dtos.tmd
@@ -5,6 +5,7 @@ uses:
   - decorators
 tags:
   - dto
+
 ---
 class:
   name: UtilisateurDto
@@ -18,7 +19,7 @@ class:
         exclude:
           - dateCreation
           - dateModification
-      prefix: true
+          - UtilisateurIdParent
     - composition: UtilisateurDto
       name: UtilisateurParent
       comment: UtilisateurParent
@@ -27,5 +28,9 @@ class:
     from:
       - params:
           - class: Utilisateur
+            mappings:
+              UtilisateurParent: UtilisateurIdParent
     to:
       - class: Utilisateur
+        mappings:
+          UtilisateurParent: UtilisateurIdParent

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/AbstractUtilisateurApiClient.java
@@ -123,36 +123,31 @@ public abstract class AbstractUtilisateurApiClient {
 
 	/**
 	 * UriComponentsBuilder pour la méthode Search.
-	 * @param utiUtilisateurId Id technique
-	 * @param utilisateurAge Age en années de l'utilisateur
-	 * @param utilisateurProfilId Profil de l'utilisateur
-	 * @param utilisateuremail Email de l'utilisateur
-	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
-	 * @param utilisateurUtilisateurIdJumeau Utilisateur jumeau
+	 * @param utiId Id technique
+	 * @param age Age en années de l'utilisateur
+	 * @param profilId Profil de l'utilisateur
+	 * @param email Email de l'utilisateur
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return uriBuilder avec les query params remplis
 	 */
-	protected UriComponentsBuilder searchUriComponentsBuilder(long utiUtilisateurId, Long utilisateurAge, long utilisateurProfilId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, long utilisateurUtilisateurIdJumeau) {
+	protected UriComponentsBuilder searchUriComponentsBuilder(long utiId, Long age, long profilId, String email, TypeUtilisateur.Values typeUtilisateurCode) {
 		String uri = host + "utilisateur/search";
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));
-		uriBuilder.queryParam("utiUtilisateurId", utiUtilisateurId);
-		if (utilisateurAge != null) {
-			uriBuilder.queryParam("utilisateurAge", utilisateurAge);
+		uriBuilder.queryParam("utiId", utiId);
+		if (age != null) {
+			uriBuilder.queryParam("age", age);
 		}
 
-		if (utilisateurProfilId != null) {
-			uriBuilder.queryParam("utilisateurProfilId", utilisateurProfilId);
+		if (profilId != null) {
+			uriBuilder.queryParam("profilId", profilId);
 		}
 
-		if (utilisateuremail != null) {
-			uriBuilder.queryParam("utilisateuremail", utilisateuremail);
+		if (email != null) {
+			uriBuilder.queryParam("email", email);
 		}
 
-		if (utilisateurTypeUtilisateurCode != null) {
-			uriBuilder.queryParam("utilisateurTypeUtilisateurCode", utilisateurTypeUtilisateurCode);
-		}
-
-		if (utilisateurUtilisateurIdJumeau != null) {
-			uriBuilder.queryParam("utilisateurUtilisateurIdJumeau", utilisateurUtilisateurIdJumeau);
+		if (typeUtilisateurCode != null) {
+			uriBuilder.queryParam("typeUtilisateurCode", typeUtilisateurCode);
 		}
 
 		return uriBuilder;
@@ -160,16 +155,15 @@ public abstract class AbstractUtilisateurApiClient {
 
 	/**
 	 * Recherche des utilisateurs.
-	 * @param utiUtilisateurId Id technique
-	 * @param utilisateurAge Age en années de l'utilisateur
-	 * @param utilisateurProfilId Profil de l'utilisateur
-	 * @param utilisateuremail Email de l'utilisateur
-	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
-	 * @param utilisateurUtilisateurIdJumeau Utilisateur jumeau
+	 * @param utiId Id technique
+	 * @param age Age en années de l'utilisateur
+	 * @param profilId Profil de l'utilisateur
+	 * @param email Email de l'utilisateur
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return Utilisateurs matchant les critères
 	 */
-	public ResponseEntity<Page> search(long utiUtilisateurId, Long utilisateurAge, long utilisateurProfilId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, long utilisateurUtilisateurIdJumeau, HttpHeaders headers){
-		UriComponentsBuilder uri = this.searchUriComponentsBuilder(utiUtilisateurId, utilisateurAge, utilisateurProfilId, utilisateuremail, utilisateurTypeUtilisateurCode, utilisateurUtilisateurIdJumeau);
+	public ResponseEntity<Page> search(long utiId, Long age, long profilId, String email, TypeUtilisateur.Values typeUtilisateurCode, HttpHeaders headers){
+		UriComponentsBuilder uri = this.searchUriComponentsBuilder(utiId, age, profilId, email, typeUtilisateurCode);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(headers), Page.class);
 	}
 }

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/IUtilisateurApiController.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/IUtilisateurApiController.java
@@ -61,14 +61,13 @@ public interface IUtilisateurApiController {
 
 	/**
 	 * Recherche des utilisateurs.
-	 * @param utiUtilisateurId Id technique
-	 * @param utilisateurAge Age en années de l'utilisateur
-	 * @param utilisateurProfilId Profil de l'utilisateur
-	 * @param utilisateuremail Email de l'utilisateur
-	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
-	 * @param utilisateurUtilisateurIdJumeau Utilisateur jumeau
+	 * @param utiId Id technique
+	 * @param age Age en années de l'utilisateur
+	 * @param profilId Profil de l'utilisateur
+	 * @param email Email de l'utilisateur
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return Utilisateurs matchant les critères
 	 */
 	@PostMapping(path = "/search")
-	Page<UtilisateurDto> search(@RequestParam(value = "utiUtilisateurId", required = true) long utiUtilisateurId, @RequestParam(value = "utilisateurAge", required = false) Long utilisateurAge, @RequestParam(value = "utilisateurProfilId", required = false) long utilisateurProfilId, @RequestParam(value = "utilisateuremail", required = false) String utilisateuremail, @RequestParam(value = "utilisateurTypeUtilisateurCode", required = false) TypeUtilisateur.Values utilisateurTypeUtilisateurCode, @RequestParam(value = "utilisateurUtilisateurIdJumeau", required = false) long utilisateurUtilisateurIdJumeau);
+	Page<UtilisateurDto> search(@RequestParam(value = "utiId", required = true) long utiId, @RequestParam(value = "age", required = false) Long age, @RequestParam(value = "profilId", required = false) long profilId, @RequestParam(value = "email", required = false) String email, @RequestParam(value = "typeUtilisateurCode", required = false) TypeUtilisateur.Values typeUtilisateurCode);
 }

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/UtilisateurDto.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/UtilisateurDto.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 
 import javax.annotation.Generated;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
 
 import topmodel.exemple.name.dtos.utilisateur.interfaces.IUtilisateurDto;
 import topmodel.exemple.name.entities.utilisateur.TypeUtilisateur;
@@ -26,39 +25,32 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	 * Id technique.
 	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getId() Utilisateur#getId()} 
 	 */
-	@NotNull
-	private long utilisateurId;
+	private long id;
 
 	/**
 	 * Age en années de l'utilisateur.
 	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getAge() Utilisateur#getAge()} 
 	 */
-	private Long utilisateurAge;
+	private Long age;
 
 	/**
 	 * Profil de l'utilisateur.
 	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getProfilId() Utilisateur#getProfilId()} 
 	 */
-	private long utilisateurProfilId;
+	private long profilId;
 
 	/**
 	 * Email de l'utilisateur.
 	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getEmail() Utilisateur#getEmail()} 
 	 */
 	@Email
-	private String utilisateuremail;
+	private String email;
 
 	/**
 	 * Type d'utilisateur en Many to one.
 	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getTypeUtilisateurCode() Utilisateur#getTypeUtilisateurCode()} 
 	 */
-	private TypeUtilisateur.Values utilisateurTypeUtilisateurCode;
-
-	/**
-	 * Utilisateur jumeau.
-	 * Alias of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#getUtilisateurIdJumeau() Utilisateur#getUtilisateurIdJumeau()} 
-	 */
-	private long utilisateurUtilisateurIdJumeau;
+	private TypeUtilisateur.Values typeUtilisateurCode;
 
 	/**
 	 * UtilisateurParent.
@@ -80,32 +72,29 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 			return;
 		}
 
-		this.utilisateurId = utilisateurDto.getUtilisateurId();
-		this.utilisateurAge = utilisateurDto.getUtilisateurAge();
-		this.utilisateurProfilId = utilisateurDto.getUtilisateurProfilId();
-		this.utilisateuremail = utilisateurDto.getUtilisateuremail();
-		this.utilisateurTypeUtilisateurCode = utilisateurDto.getUtilisateurTypeUtilisateurCode();
-		this.utilisateurUtilisateurIdJumeau = utilisateurDto.getUtilisateurUtilisateurIdJumeau();
+		this.id = utilisateurDto.getId();
+		this.age = utilisateurDto.getAge();
+		this.profilId = utilisateurDto.getProfilId();
+		this.email = utilisateurDto.getEmail();
+		this.typeUtilisateurCode = utilisateurDto.getTypeUtilisateurCode();
 		this.utilisateurParent = utilisateurDto.getUtilisateurParent();
 	}
 
 	/**
 	 * All arg constructor.
-	 * @param utilisateurId Id technique
-	 * @param utilisateurAge Age en années de l'utilisateur
-	 * @param utilisateurProfilId Profil de l'utilisateur
-	 * @param utilisateuremail Email de l'utilisateur
-	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
-	 * @param utilisateurUtilisateurIdJumeau Utilisateur jumeau
+	 * @param id Id technique
+	 * @param age Age en années de l'utilisateur
+	 * @param profilId Profil de l'utilisateur
+	 * @param email Email de l'utilisateur
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @param utilisateurParent UtilisateurParent
 	 */
-	public UtilisateurDto(long utilisateurId, Long utilisateurAge, long utilisateurProfilId, String utilisateuremail, TypeUtilisateur.Values utilisateurTypeUtilisateurCode, long utilisateurUtilisateurIdJumeau, UtilisateurDto utilisateurParent) {
-		this.utilisateurId = utilisateurId;
-		this.utilisateurAge = utilisateurAge;
-		this.utilisateurProfilId = utilisateurProfilId;
-		this.utilisateuremail = utilisateuremail;
-		this.utilisateurTypeUtilisateurCode = utilisateurTypeUtilisateurCode;
-		this.utilisateurUtilisateurIdJumeau = utilisateurUtilisateurIdJumeau;
+	public UtilisateurDto(long id, Long age, long profilId, String email, TypeUtilisateur.Values typeUtilisateurCode, UtilisateurDto utilisateurParent) {
+		this.id = id;
+		this.age = age;
+		this.profilId = profilId;
+		this.email = email;
+		this.typeUtilisateurCode = typeUtilisateurCode;
 		this.utilisateurParent = utilisateurParent;
 	}
 
@@ -125,22 +114,18 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	 */
 	protected void from(Utilisateur utilisateur) {
 		if(utilisateur != null) {
-			this.utilisateurId = utilisateur.getId();
-			this.utilisateurAge = utilisateur.getAge();
+			this.utilisateurParent = new UtilisateurDto(utilisateur.getUtilisateurParent());
+			this.id = utilisateur.getId();
+			this.age = utilisateur.getAge();
 
 			if(utilisateur.getProfil() != null) {
-				this.utilisateurProfilId = utilisateur.getProfil().getId();
+				this.profilId = utilisateur.getProfil().getId();
 			}
 
-			this.utilisateuremail = utilisateur.getEmail();
+			this.email = utilisateur.getEmail();
 
 			if(utilisateur.getTypeUtilisateur() != null) {
-				this.utilisateurTypeUtilisateurCode = utilisateur.getTypeUtilisateur().getCode();
-			}
-
-
-			if(utilisateur.getUtilisateurJumeau() != null) {
-				this.utilisateurUtilisateurIdJumeau = utilisateur.getUtilisateurJumeau().getId();
+				this.typeUtilisateurCode = utilisateur.getTypeUtilisateur().getCode();
 			}
 
 		}
@@ -148,63 +133,53 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	}
 
 	/**
-	 * Getter for utilisateurId.
+	 * Getter for id.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurId utilisateurId}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#id id}.
 	 */
 	@Override
-	public long getUtilisateurId() {
-		return this.utilisateurId;
+	public long getId() {
+		return this.id;
 	}
 
 	/**
-	 * Getter for utilisateurAge.
+	 * Getter for age.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurAge utilisateurAge}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#age age}.
 	 */
 	@Override
-	public Long getUtilisateurAge() {
-		return this.utilisateurAge;
+	public Long getAge() {
+		return this.age;
 	}
 
 	/**
-	 * Getter for utilisateurProfilId.
+	 * Getter for profilId.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurProfilId utilisateurProfilId}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#profilId profilId}.
 	 */
 	@Override
-	public long getUtilisateurProfilId() {
-		return this.utilisateurProfilId;
+	public long getProfilId() {
+		return this.profilId;
 	}
 
 	/**
-	 * Getter for utilisateuremail.
+	 * Getter for email.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateuremail utilisateuremail}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#email email}.
 	 */
 	@Override
-	public String getUtilisateuremail() {
-		return this.utilisateuremail;
+	public String getEmail() {
+		return this.email;
 	}
 
 	/**
-	 * Getter for utilisateurTypeUtilisateurCode.
+	 * Getter for typeUtilisateurCode.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurTypeUtilisateurCode utilisateurTypeUtilisateurCode}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#typeUtilisateurCode typeUtilisateurCode}.
 	 */
 	@Override
-	public TypeUtilisateur.Values getUtilisateurTypeUtilisateurCode() {
-		return this.utilisateurTypeUtilisateurCode;
-	}
-
-	/**
-	 * Getter for utilisateurUtilisateurIdJumeau.
-	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurUtilisateurIdJumeau utilisateurUtilisateurIdJumeau}.
-	 */
-	@Override
-	public long getUtilisateurUtilisateurIdJumeau() {
-		return this.utilisateurUtilisateurIdJumeau;
+	public TypeUtilisateur.Values getTypeUtilisateurCode() {
+		return this.typeUtilisateurCode;
 	}
 
 	/**
@@ -218,51 +193,43 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurId utilisateurId}.
-	 * @param utilisateurId value to set
+	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#id id}.
+	 * @param id value to set
 	 */
-	public void setUtilisateurId(long utilisateurId) {
-		this.utilisateurId = utilisateurId;
+	public void setId(long id) {
+		this.id = id;
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurAge utilisateurAge}.
-	 * @param utilisateurAge value to set
+	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#age age}.
+	 * @param age value to set
 	 */
-	public void setUtilisateurAge(Long utilisateurAge) {
-		this.utilisateurAge = utilisateurAge;
+	public void setAge(Long age) {
+		this.age = age;
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurProfilId utilisateurProfilId}.
-	 * @param utilisateurProfilId value to set
+	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#profilId profilId}.
+	 * @param profilId value to set
 	 */
-	public void setUtilisateurProfilId(long utilisateurProfilId) {
-		this.utilisateurProfilId = utilisateurProfilId;
+	public void setProfilId(long profilId) {
+		this.profilId = profilId;
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateuremail utilisateuremail}.
-	 * @param utilisateuremail value to set
+	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#email email}.
+	 * @param email value to set
 	 */
-	public void setUtilisateuremail(String utilisateuremail) {
-		this.utilisateuremail = utilisateuremail;
+	public void setEmail(String email) {
+		this.email = email;
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurTypeUtilisateurCode utilisateurTypeUtilisateurCode}.
-	 * @param utilisateurTypeUtilisateurCode value to set
+	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#typeUtilisateurCode typeUtilisateurCode}.
+	 * @param typeUtilisateurCode value to set
 	 */
-	public void setUtilisateurTypeUtilisateurCode(TypeUtilisateur.Values utilisateurTypeUtilisateurCode) {
-		this.utilisateurTypeUtilisateurCode = utilisateurTypeUtilisateurCode;
-	}
-
-	/**
-	 * Set the value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurUtilisateurIdJumeau utilisateurUtilisateurIdJumeau}.
-	 * @param utilisateurUtilisateurIdJumeau value to set
-	 */
-	public void setUtilisateurUtilisateurIdJumeau(long utilisateurUtilisateurIdJumeau) {
-		this.utilisateurUtilisateurIdJumeau = utilisateurUtilisateurIdJumeau;
+	public void setTypeUtilisateurCode(TypeUtilisateur.Values typeUtilisateurCode) {
+		this.typeUtilisateurCode = typeUtilisateurCode;
 	}
 
 	/**
@@ -283,9 +250,13 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	public Utilisateur toUtilisateur(Utilisateur dest) {
 		dest = dest == null ? new Utilisateur() : dest;
 
-		dest.setId(this.getUtilisateurId());
-		dest.setAge(this.getUtilisateurAge());
-		dest.setEmail(this.getUtilisateuremail());
+		if (this.getUtilisateurParent() != null) {
+			dest.setUtilisateurParent(this.getUtilisateurParent().toUtilisateur(dest.getUtilisateurParent());
+		}
+
+		dest.setId(this.getId());
+		dest.setAge(this.getAge());
+		dest.setEmail(this.getEmail());
 
 		return dest;
 	}

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/interfaces/IUtilisateurDto.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/interfaces/IUtilisateurDto.java
@@ -14,46 +14,39 @@ import topmodel.exemple.name.entities.utilisateur.TypeUtilisateur;
 public interface IUtilisateurDto {
 
 	/**
-	 * Getter for utilisateurId.
+	 * Getter for id.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurId utilisateurId}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#id id}.
 	 */
-	long getUtilisateurId();
+	long getId();
 
 	/**
-	 * Getter for utilisateurAge.
+	 * Getter for age.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurAge utilisateurAge}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#age age}.
 	 */
-	Long getUtilisateurAge();
+	Long getAge();
 
 	/**
-	 * Getter for utilisateurProfilId.
+	 * Getter for profilId.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurProfilId utilisateurProfilId}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#profilId profilId}.
 	 */
-	long getUtilisateurProfilId();
+	long getProfilId();
 
 	/**
-	 * Getter for utilisateuremail.
+	 * Getter for email.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateuremail utilisateuremail}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#email email}.
 	 */
-	String getUtilisateuremail();
+	String getEmail();
 
 	/**
-	 * Getter for utilisateurTypeUtilisateurCode.
+	 * Getter for typeUtilisateurCode.
 	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurTypeUtilisateurCode utilisateurTypeUtilisateurCode}.
+	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#typeUtilisateurCode typeUtilisateurCode}.
 	 */
-	TypeUtilisateur.Values getUtilisateurTypeUtilisateurCode();
-
-	/**
-	 * Getter for utilisateurUtilisateurIdJumeau.
-	 *
-	 * @return value of {@link topmodel.exemple.name.dtos.utilisateur.UtilisateurDto#utilisateurUtilisateurIdJumeau utilisateurUtilisateurIdJumeau}.
-	 */
-	long getUtilisateurUtilisateurIdJumeau();
+	TypeUtilisateur.Values getTypeUtilisateurCode();
 
 	/**
 	 * Getter for utilisateurParent.

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/entities/utilisateur/Utilisateur.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/entities/utilisateur/Utilisateur.java
@@ -92,11 +92,11 @@ public class Utilisateur {
 	private TypeUtilisateur typeUtilisateur;
 
 	/**
-	 * Utilisateur jumeau.
+	 * Utilisateur parent.
 	 */
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, optional = true)
-	@JoinColumn(name = "UTI_ID_JUMEAU", referencedColumnName = "UTI_ID", unique = true)
-	private Utilisateur utilisateurJumeau;
+	@JoinColumn(name = "UTI_ID_PARENT", referencedColumnName = "UTI_ID", unique = true)
+	private Utilisateur utilisateurParent;
 
 	/**
 	 * No arg constructor.
@@ -120,7 +120,7 @@ public class Utilisateur {
 		this.profil = utilisateur.getProfil();
 		this.email = utilisateur.getEmail();
 		this.typeUtilisateur = utilisateur.getTypeUtilisateur();
-		this.utilisateurJumeau = utilisateur.getUtilisateurJumeau();
+		this.utilisateurParent = utilisateur.getUtilisateurParent();
 	}
 
 	/**
@@ -132,9 +132,9 @@ public class Utilisateur {
 	 * @param profil Profil de l'utilisateur
 	 * @param email Email de l'utilisateur
 	 * @param typeUtilisateur Type d'utilisateur en Many to one
-	 * @param utilisateurJumeau Utilisateur jumeau
+	 * @param utilisateurParent Utilisateur parent
 	 */
-	public Utilisateur(DateTime dateCreation, DateTime dateModification, long id, Long age, Profil profil, String email, TypeUtilisateur typeUtilisateur, Utilisateur utilisateurJumeau) {
+	public Utilisateur(DateTime dateCreation, DateTime dateModification, long id, Long age, Profil profil, String email, TypeUtilisateur typeUtilisateur, Utilisateur utilisateurParent) {
 		this.dateCreation = dateCreation;
 		this.dateModification = dateModification;
 		this.id = id;
@@ -142,7 +142,7 @@ public class Utilisateur {
 		this.profil = profil;
 		this.email = email;
 		this.typeUtilisateur = typeUtilisateur;
-		this.utilisateurJumeau = utilisateurJumeau;
+		this.utilisateurParent = utilisateurParent;
 	}
 
 	/**
@@ -209,12 +209,12 @@ public class Utilisateur {
 	}
 
 	/**
-	 * Getter for utilisateurJumeau.
+	 * Getter for utilisateurParent.
 	 *
-	 * @return value of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#utilisateurJumeau utilisateurJumeau}.
+	 * @return value of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#utilisateurParent utilisateurParent}.
 	 */
-	public Utilisateur getUtilisateurJumeau() {
-		return this.utilisateurJumeau;
+	public Utilisateur getUtilisateurParent() {
+		return this.utilisateurParent;
 	}
 
 	/**
@@ -274,11 +274,11 @@ public class Utilisateur {
 	}
 
 	/**
-	 * Set the value of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#utilisateurJumeau utilisateurJumeau}.
-	 * @param utilisateurJumeau value to set
+	 * Set the value of {@link topmodel.exemple.name.entities.utilisateur.Utilisateur#utilisateurParent utilisateurParent}.
+	 * @param utilisateurParent value to set
 	 */
-	public void setUtilisateurJumeau(Utilisateur utilisateurJumeau) {
-		this.utilisateurJumeau = utilisateurJumeau;
+	public void setUtilisateurParent(Utilisateur utilisateurParent) {
+		this.utilisateurParent = utilisateurParent;
 	}
 
 	/**
@@ -310,6 +310,6 @@ public class Utilisateur {
         PROFIL, //
         EMAIL, //
         TYPE_UTILISATEUR, //
-        UTILISATEUR_JUMEAU
+        UTILISATEUR_PARENT
 	}
 }

--- a/docs/exemple/js/appgenerated/api/securite/utilisateur/utilisateur-api.ts
+++ b/docs/exemple/js/appgenerated/api/securite/utilisateur/utilisateur-api.ts
@@ -64,35 +64,31 @@ export class UtilisateurApiService {
 
 	/**
 	 * Recherche des utilisateurs
-	 * @param utiUtilisateurId Id technique
-	 * @param utilisateurAge Age en années de l'utilisateur
-	 * @param utilisateurProfilId Profil de l'utilisateur
-	 * @param utilisateuremail Email de l'utilisateur
-	 * @param utilisateurTypeUtilisateurCode Type d'utilisateur en Many to one
-	 * @param utilisateurUtilisateurIdJumeau Utilisateur jumeau
+	 * @param utiId Id technique
+	 * @param age Age en années de l'utilisateur
+	 * @param profilId Profil de l'utilisateur
+	 * @param email Email de l'utilisateur
+	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @param options Options pour 'fetch'.
 	 * @returns Utilisateurs matchant les critères
 	 */
-	search(utiUtilisateurId?: number utilisateurAge?: number utilisateurProfilId?: number utilisateuremail?: string utilisateurTypeUtilisateurCode?: TypeUtilisateurCode utilisateurUtilisateurIdJumeau?: number , queryParams: any = {}): Observable<Page<UtilisateurDto>> {
+	search(utiId?: number age?: number profilId?: number email?: string typeUtilisateurCode?: TypeUtilisateurCode , queryParams: any = {}): Observable<Page<UtilisateurDto>> {
 		const httpParams = new HttpParams({fromObject : queryParams});
 		const httpOptions = { params: httpParams }
-		if(utiUtilisateurId !== null) {
-			httpOptions.params.set('utiUtilisateurId', utiUtilisateurId)
+		if(utiId !== null) {
+			httpOptions.params.set('utiId', utiId)
 		}
-		if(utilisateurAge !== null) {
-			httpOptions.params.set('utilisateurAge', utilisateurAge)
+		if(age !== null) {
+			httpOptions.params.set('age', age)
 		}
-		if(utilisateurProfilId !== null) {
-			httpOptions.params.set('utilisateurProfilId', utilisateurProfilId)
+		if(profilId !== null) {
+			httpOptions.params.set('profilId', profilId)
 		}
-		if(utilisateuremail !== null) {
-			httpOptions.params.set('utilisateuremail', utilisateuremail)
+		if(email !== null) {
+			httpOptions.params.set('email', email)
 		}
-		if(utilisateurTypeUtilisateurCode !== null) {
-			httpOptions.params.set('utilisateurTypeUtilisateurCode', utilisateurTypeUtilisateurCode)
-		}
-		if(utilisateurUtilisateurIdJumeau !== null) {
-			httpOptions.params.set('utilisateurUtilisateurIdJumeau', utilisateurUtilisateurIdJumeau)
+		if(typeUtilisateurCode !== null) {
+			httpOptions.params.set('typeUtilisateurCode', typeUtilisateurCode)
 		}
 
 		return this.http.post<Page<UtilisateurDto>>(`/utilisateur/search`, httpOptions);

--- a/docs/exemple/js/appgenerated/model/utilisateur/utilisateur-dto.ts
+++ b/docs/exemple/js/appgenerated/model/utilisateur/utilisateur-dto.ts
@@ -7,57 +7,49 @@ import {DO_CODE, DO_EMAIL, DO_ID, DO_NUMBER} from "@domains";
 import {TypeUtilisateurCode} from "./references";
 
 export interface UtilisateurDto {
-    utilisateurId?: number,
-    utilisateurAge?: number,
-    utilisateurProfilId?: number,
-    utilisateuremail?: string,
-    utilisateurTypeUtilisateurCode?: TypeUtilisateurCode,
-    utilisateurUtilisateurIdJumeau?: number,
+    id?: number,
+    age?: number,
+    profilId?: number,
+    email?: string,
+    typeUtilisateurCode?: TypeUtilisateurCode,
     utilisateurParent?: UtilisateurDto
 }
 
 export const UtilisateurDtoEntity = {
-    utilisateurId: {
+    id: {
         type: "field",
-        name: "utilisateurId",
+        name: "id",
         domain: DO_ID,
-        isRequired: true,
+        isRequired: false,
         label: "utilisateur.utilisateur.id"
     },
-    utilisateurAge: {
+    age: {
         type: "field",
-        name: "utilisateurAge",
+        name: "age",
         domain: DO_NUMBER,
         isRequired: false,
         label: "utilisateur.utilisateur.age"
     },
-    utilisateurProfilId: {
+    profilId: {
         type: "field",
-        name: "utilisateurProfilId",
+        name: "profilId",
         domain: DO_ID,
         isRequired: false,
         label: "utilisateur.utilisateur.profilId"
     },
-    utilisateuremail: {
+    email: {
         type: "field",
-        name: "utilisateuremail",
+        name: "email",
         domain: DO_EMAIL,
         isRequired: false,
         label: "utilisateur.utilisateur.email"
     },
-    utilisateurTypeUtilisateurCode: {
+    typeUtilisateurCode: {
         type: "field",
-        name: "utilisateurTypeUtilisateurCode",
+        name: "typeUtilisateurCode",
         domain: DO_CODE,
         isRequired: false,
         label: "utilisateur.utilisateur.typeUtilisateurCode"
-    },
-    utilisateurUtilisateurIdJumeau: {
-        type: "field",
-        name: "utilisateurUtilisateurIdJumeau",
-        domain: DO_ID,
-        isRequired: false,
-        label: "utilisateur.utilisateur.utilisateurIdJumeau"
     },
     utilisateurParent: {
         type: "object",

--- a/docs/exemple/js/appgenerated/resources/utilisateur.ts
+++ b/docs/exemple/js/appgenerated/resources/utilisateur.ts
@@ -12,7 +12,6 @@ export const utilisateur = {
         age: "Age",
         profilId: "ProfilId",
         email: "email",
-        typeUtilisateurCode: "TypeUtilisateurCode",
-        utilisateurIdJumeau: "UtilisateurIdJumeau"
+        typeUtilisateurCode: "TypeUtilisateurCode"
     }
 };

--- a/docs/exemple/pg/01_tables.sql
+++ b/docs/exemple/pg/01_tables.sql
@@ -78,7 +78,7 @@ create table UTILISATEUR (
 	PRO_ID int8,
 	UTI_EMAIL varchar(50),
 	TUT_CODE varchar(3),
-	UTI_ID_JUMEAU int8,
+	UTI_ID_PARENT int8,
 	constraint PK_UTILISATEUR primary key (UTI_ID)
 )
 ;

--- a/docs/exemple/pg/02_fk_indexes.sql
+++ b/docs/exemple/pg/02_fk_indexes.sql
@@ -104,18 +104,18 @@ alter table UTILISATEUR
 ;
 
 /**
-  * Création de l'index de clef étrangère pour UTILISATEUR.UTI_ID_JUMEAU
+  * Création de l'index de clef étrangère pour UTILISATEUR.UTI_ID_PARENT
  **/
-create index IDX_UTI_UTI_ID_JUMEAU_FK on UTILISATEUR (
-	UTI_ID_JUMEAU ASC
+create index IDX_UTI_UTI_ID_PARENT_FK on UTILISATEUR (
+	UTI_ID_PARENT ASC
 )
 ;
 
 /**
-  * Génération de la contrainte de clef étrangère pour UTILISATEUR.UTI_ID_JUMEAU
+  * Génération de la contrainte de clef étrangère pour UTILISATEUR.UTI_ID_PARENT
  **/
 alter table UTILISATEUR
-	add constraint FK_UTI_UTI_ID_JUMEAU foreign key (UTI_ID_JUMEAU)
+	add constraint FK_UTI_UTI_ID_PARENT foreign key (UTI_ID_PARENT)
 		references UTILISATEUR (UTI_ID)
 ;
 

--- a/docs/exemple/pg/03_unique_keys.sql
+++ b/docs/exemple/pg/03_unique_keys.sql
@@ -7,5 +7,5 @@
 --   Script Name		:	03_unique_keys.sql
 --   Description		:	Script de création des index uniques.
 -- =========================================================================================== 
-alter table UTILISATEUR add constraint UK_UTILISATEUR_UTI_ID_JUMEAU unique (UTI_ID_JUMEAU);
+alter table UTILISATEUR add constraint UK_UTILISATEUR_UTI_ID_PARENT unique (UTI_ID_PARENT);
 

--- a/docs/exemple/topmodel.lock
+++ b/docs/exemple/topmodel.lock
@@ -2,7 +2,7 @@
 # ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 #
 
-version: 1.12.1
+version: 1.12.3
 generatedFiles:
   - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IDtosController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IEntitiesController.java


### PR DESCRIPTION
Fix #146 

Il est désormais possible de définir certains mappings sur des compositions de la classe qui définit les mappers. 

Les mappings possibles sont : 
- Un paramètre entier d'un mapping `from`, si la classe composée est la même que le paramètre. 

  Exemple :
 
  ```yaml
  # classe "ContactDTO"
  from:
    - params:
      - class: Contact
      - class: AdresseDTO
        mappings:
          Adresse: this
  ```
- Une association (ou alias vers une association) dont la clé primaire et de même domaine que celle de la classe composée. 
  
  Exemple :
  
  ```yaml
  # classe "ContactDTO"
  to:
   - class: Contact
     mappings:
       Adresse: AdresseId
     ```
  Ce mapping est possible dans les deux sens :
  - En C#, le mapping ne concerne que la clé primaire (`from` crée une nouvelle instance en renseignant simplement la PK, `to` récupère la clé primaire)
  - En JPA, il faut avoir défini un mapper entre les deux classes (celle de l'association et celle de la composition), et le mapping généré mappe la classe dans l'autre dans le sens demandé. Les types de l'association et de la composition doivent également correspondre (`oneToOne`/`manyToOne` <> `object`, `oneToMany`/`manyToMany` <> `list`).