### PR TITLE
`modgen` avec configs multiples

### DIFF
--- a/TopModel.Core/IModelWatcher.cs
+++ b/TopModel.Core/IModelWatcher.cs
@@ -14,5 +14,5 @@ public interface IModelWatcher
 
     void OnErrors(IDictionary<ModelFile, IEnumerable<ModelError>> errors);
 
-    void OnFilesChanged(IEnumerable<ModelFile> files);
+    void OnFilesChanged(IEnumerable<ModelFile> files, ModelStoreConfig? storeConfig = null);
 }

--- a/TopModel.Core/ModelStoreConfig.cs
+++ b/TopModel.Core/ModelStoreConfig.cs
@@ -1,0 +1,3 @@
+﻿namespace TopModel.Core;
+
+public record ModelStoreConfig(int Number, ConsoleColor Color);

--- a/TopModel.Generator/GeneratorBase.cs
+++ b/TopModel.Generator/GeneratorBase.cs
@@ -25,9 +25,10 @@ public abstract class GeneratorBase : IModelWatcher
     {
     }
 
-    public void OnFilesChanged(IEnumerable<ModelFile> files)
+    public void OnFilesChanged(IEnumerable<ModelFile> files, ModelStoreConfig? storeConfig = null)
     {
         using var scope = _logger.BeginScope(((IModelWatcher)this).FullName);
+        using var scope2 = _logger.BeginScope(storeConfig);
         HandleFiles(files.Where(file => _config.Tags.Intersect(file.Tags).Any()));
     }
 

--- a/TopModel.Generator/LoggerProvider.cs
+++ b/TopModel.Generator/LoggerProvider.cs
@@ -20,6 +20,8 @@ public class LoggerProvider : ILoggerProvider
 
         private readonly string _categoryName;
         private string? _generatorName;
+        private int? _storeNumber;
+        private ConsoleColor? _storeColor;
 
         public ConsoleLogger(string categoryName)
         {
@@ -43,7 +45,13 @@ public class LoggerProvider : ILoggerProvider
                     return;
                 }
 
-                var name = ((_generatorName ?? _categoryName) + " ").PadRight(19, '-');
+                if (_storeNumber != null && _storeColor != null)
+                {
+                    Console.ForegroundColor = _storeColor.Value;
+                    Console.Write($"#{_storeNumber.Value} ");
+                }
+
+                var name = ((_generatorName ?? _categoryName) + " ").PadRight(22, '-');
                 var split = name.Split(" ");
                 Console.ForegroundColor = _generatorName != null ? ConsoleColor.Magenta : ConsoleColor.DarkGray;
                 Console.Write(split[0]);
@@ -106,7 +114,16 @@ public class LoggerProvider : ILoggerProvider
 
         public IDisposable BeginScope<TState>(TState state)
         {
-            _generatorName = state as string;
+            if (state is ModelStoreConfig scope)
+            {
+                _storeNumber = scope.Number;
+                _storeColor = scope.Color;
+            }
+            else if (state is string generatorName)
+            {
+                _generatorName = generatorName;
+            }
+
             return null!;
         }
     }

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -1,7 +1,6 @@
 ﻿#pragma warning disable SA1516
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TopModel.Core;
@@ -17,193 +16,242 @@ using static TopModel.Utils.ModelUtils;
 
 var fileChecker = new FileChecker("schema.config.json");
 
-FullConfig? config = null;
-string dn = null!;
+var configs = new List<(FullConfig Config, string FullPath, string DirectoryName)>();
 var watchMode = false;
 
-var command = new RootCommand
-{
-    new Argument<FileInfo>("configFile", () => new FileInfo("topmodel.config"), "Chemin vers le fichier de config."),
-    new Option<bool>(new[] { "-w", "--watch" }, "Lance le générateur en mode 'watch'")
-};
+var command = new RootCommand("Lance le générateur topmodel.") { Name = "modgen" };
 
-command.Name = "modgen";
-
-command.Handler = CommandHandler.Create<FileInfo, bool>((configFile, watch) =>
-{
-    if (!configFile.Exists)
+var fileOption = new Option<IEnumerable<FileInfo>>(new[] { "-f", "--file" }, "Chemin vers un fichier de config.");
+var watchOption = new Option<bool>(new[] { "-w", "--watch" }, "Lance le générateur en mode 'watch'");
+command.AddOption(fileOption);
+command.AddOption(watchOption);
+command.SetHandler(
+    (files, watch) =>
     {
-        Console.ForegroundColor = ConsoleColor.Red;
-        Console.WriteLine($"Le fichier '{configFile.FullName}' est introuvable.");
-    }
-    else
-    {
-        config = fileChecker.Deserialize<FullConfig>(configFile.OpenText().ReadToEnd());
-        dn = configFile.DirectoryName!;
         watchMode = watch;
-    }
-});
 
-command.Invoke(args);
-
-if (config == null)
-{
-    return;
-}
-
-if (config.AllowCompositePrimaryKey && config.Csharp != null)
-{
-    throw new ArgumentException("Impossible de spécifier 'allowCompositePrimaryKey' avec 'csharp'.");
-}
-
-var services = new ServiceCollection()
-    .AddModelStore(fileChecker, config, dn)
-    .AddLogging(builder => builder.AddProvider(new LoggerProvider()));
-
-if (config.ProceduralSql != null)
-{
-    foreach (var pSqlConfig in config.ProceduralSql)
-    {
-        CombinePath(dn, pSqlConfig, c => c.CrebasFile);
-        CombinePath(dn, pSqlConfig, c => c.IndexFKFile);
-        CombinePath(dn, pSqlConfig, c => c.InitListFile);
-        CombinePath(dn, pSqlConfig, c => c.TypeFile);
-        CombinePath(dn, pSqlConfig, c => c.UniqueKeysFile);
-
-        services.AddSingleton<IModelWatcher>(p =>
-            new ProceduralSqlGenerator(p.GetRequiredService<ILogger<ProceduralSqlGenerator>>(), pSqlConfig));
-    }
-}
-
-if (config.Ssdt != null)
-{
-    foreach (var ssdtConfig in config.Ssdt)
-    {
-        CombinePath(dn, ssdtConfig, c => c.InitListScriptFolder);
-        CombinePath(dn, ssdtConfig, c => c.TableScriptFolder);
-        CombinePath(dn, ssdtConfig, c => c.TableTypeScriptFolder);
-
-        services.AddSingleton<IModelWatcher>(p =>
-            new SsdtGenerator(p.GetRequiredService<ILogger<SsdtGenerator>>(), ssdtConfig));
-    }
-}
-
-if (config.Csharp != null)
-{
-    foreach (var csharpConfig in config.Csharp)
-    {
-        CombinePath(dn, csharpConfig, c => c.OutputDirectory);
-
-        services.AddSingleton<IModelWatcher>(p =>
-            new CSharpGenerator(p.GetRequiredService<ILogger<CSharpGenerator>>(), csharpConfig));
-
-        if (csharpConfig.ApiGeneration == ApiGeneration.Server)
+        if (files.Any())
         {
-            services.AddSingleton<IModelWatcher>(p =>
-                new CSharpApiServerGenerator(p.GetRequiredService<ILogger<CSharpApiServerGenerator>>(), csharpConfig));
-        }
-        else if (csharpConfig.ApiGeneration == ApiGeneration.Client)
-        {
-            services.AddSingleton<IModelWatcher>(p =>
-                new CSharpApiClientGenerator(p.GetRequiredService<ILogger<CSharpApiClientGenerator>>(), csharpConfig));
-        }
-    }
-}
-
-if (config.Javascript != null)
-{
-    foreach (var jsConfig in config.Javascript)
-    {
-        CombinePath(dn, jsConfig, c => c.ModelOutputDirectory);
-        CombinePath(dn, jsConfig, c => c.ResourceOutputDirectory);
-        CombinePath(dn, jsConfig, c => c.ApiClientOutputDirectory);
-
-        if (jsConfig.ModelOutputDirectory != null)
-        {
-            services.AddSingleton<IModelWatcher>(p =>
-                new TypescriptDefinitionGenerator(p.GetRequiredService<ILogger<TypescriptDefinitionGenerator>>(), jsConfig));
-
-            if (jsConfig.ApiClientOutputDirectory != null)
+            foreach (var file in files)
             {
-                if (jsConfig.TargetFramework == TargetFramework.ANGULAR)
+                if (!file.Exists)
                 {
-                    services.AddSingleton<IModelWatcher>(p =>
-                       new AngularApiClientGenerator(p.GetRequiredService<ILogger<AngularApiClientGenerator>>(), jsConfig));
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"Le fichier '{file.FullName}' est introuvable.");
                 }
                 else
                 {
-                    services.AddSingleton<IModelWatcher>(p =>
-                       new JavascriptApiClientGenerator(p.GetRequiredService<ILogger<JavascriptApiClientGenerator>>(), jsConfig));
+                    configs.Add((fileChecker.Deserialize<FullConfig>(file.OpenText().ReadToEnd()), file.FullName, file.DirectoryName!));
                 }
             }
         }
-
-        if (jsConfig.ResourceOutputDirectory != null)
+        else
         {
+            foreach (var fileName in Directory.GetFiles(Directory.GetCurrentDirectory(), "topmodel*.config", SearchOption.AllDirectories))
+            {
+                var foundFile = new FileInfo(fileName);
+                if (foundFile != null)
+                {
+                    configs.Add((fileChecker.Deserialize<FullConfig>(foundFile.OpenText().ReadToEnd()), fileName, foundFile.DirectoryName!));
+                }
+            }
+        }
+    },
+    fileOption,
+    watchOption);
+
+await command.InvokeAsync(args);
+
+if (!configs.Any())
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.WriteLine("Aucun fichier de config trouvé.");
+    return;
+}
+
+var fullVersion = System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!;
+var version = $"{fullVersion.Major}.{fullVersion.Minor}.{fullVersion.Build}";
+
+var colors = new[] { ConsoleColor.DarkCyan, ConsoleColor.DarkYellow, ConsoleColor.Cyan, ConsoleColor.Yellow };
+
+Console.WriteLine($"========= TopModel v{version} =========");
+Console.WriteLine();
+Console.WriteLine("Configuration trouvées :");
+
+for (var i = 0; i < configs.Count; i++)
+{
+    var (_, fullName, _) = configs[i];
+    Console.ForegroundColor = colors[i % colors.Length];
+    Console.Write($"#{i + 1} - ");
+    Console.WriteLine(Path.GetRelativePath(Directory.GetCurrentDirectory(), fullName));
+}
+
+var disposables = new List<IDisposable>();
+
+for (var i = 0; i < configs.Count; i++)
+{
+    var (config, _, dn) = configs[i];
+
+    Console.WriteLine();
+
+    if (config.AllowCompositePrimaryKey && config.Csharp != null)
+    {
+        throw new ArgumentException("Impossible de spécifier 'allowCompositePrimaryKey' avec 'csharp'.");
+    }
+
+    var services = new ServiceCollection()
+        .AddModelStore(fileChecker, config, dn)
+        .AddLogging(builder => builder.AddProvider(new LoggerProvider()));
+
+    if (config.ProceduralSql != null)
+    {
+        foreach (var pSqlConfig in config.ProceduralSql)
+        {
+            CombinePath(dn, pSqlConfig, c => c.CrebasFile);
+            CombinePath(dn, pSqlConfig, c => c.IndexFKFile);
+            CombinePath(dn, pSqlConfig, c => c.InitListFile);
+            CombinePath(dn, pSqlConfig, c => c.TypeFile);
+            CombinePath(dn, pSqlConfig, c => c.UniqueKeysFile);
+
             services.AddSingleton<IModelWatcher>(p =>
-                new JavascriptResourceGenerator(p.GetRequiredService<ILogger<JavascriptResourceGenerator>>(), jsConfig));
+                new ProceduralSqlGenerator(p.GetRequiredService<ILogger<ProceduralSqlGenerator>>(), pSqlConfig));
         }
     }
-}
 
-if (config.Jpa != null)
-{
-    foreach (var jpaConfig in config.Jpa)
+    if (config.Ssdt != null)
     {
-        CombinePath(dn, jpaConfig, c => c.ModelOutputDirectory);
-        CombinePath(dn, jpaConfig, c => c.ApiOutputDirectory);
-
-        if (jpaConfig.EntitiesPackageName != null || jpaConfig.DtosPackageName != null)
+        foreach (var ssdtConfig in config.Ssdt)
         {
-            services
-                .AddSingleton<IModelWatcher>(p =>
-                    new JpaModelGenerator(p.GetRequiredService<ILogger<JpaModelGenerator>>(), jpaConfig));
-            services
-                .AddSingleton<IModelWatcher>(p =>
-                    new JpaModelInterfaceGenerator(p.GetRequiredService<ILogger<JpaModelInterfaceGenerator>>(), jpaConfig));
+            CombinePath(dn, ssdtConfig, c => c.InitListScriptFolder);
+            CombinePath(dn, ssdtConfig, c => c.TableScriptFolder);
+            CombinePath(dn, ssdtConfig, c => c.TableTypeScriptFolder);
+
+            services.AddSingleton<IModelWatcher>(p =>
+                new SsdtGenerator(p.GetRequiredService<ILogger<SsdtGenerator>>(), ssdtConfig));
         }
+    }
 
-        if (jpaConfig.DaosPackageName != null)
+    if (config.Csharp != null)
+    {
+        foreach (var csharpConfig in config.Csharp)
         {
-            services
-                .AddSingleton<IModelWatcher>(p =>
-                    new JpaDaoGenerator(p.GetRequiredService<ILogger<JpaDaoGenerator>>(), jpaConfig));
-        }
+            CombinePath(dn, csharpConfig, c => c.OutputDirectory);
 
-        if (jpaConfig.ApiOutputDirectory != null)
-        {
-            if (jpaConfig.ApiGeneration == ApiGeneration.Server)
+            services.AddSingleton<IModelWatcher>(p =>
+                new CSharpGenerator(p.GetRequiredService<ILogger<CSharpGenerator>>(), csharpConfig));
+
+            if (csharpConfig.ApiGeneration == ApiGeneration.Server)
             {
-                services
-                    .AddSingleton<IModelWatcher>(p =>
-                        new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), jpaConfig));
+                services.AddSingleton<IModelWatcher>(p =>
+                    new CSharpApiServerGenerator(p.GetRequiredService<ILogger<CSharpApiServerGenerator>>(), csharpConfig));
             }
-            else if (jpaConfig.ApiGeneration == ApiGeneration.Client)
+            else if (csharpConfig.ApiGeneration == ApiGeneration.Client)
             {
-                services
-                    .AddSingleton<IModelWatcher>(p =>
-                        new SpringClientApiGenerator(p.GetRequiredService<ILogger<SpringClientApiGenerator>>(), jpaConfig));
+                services.AddSingleton<IModelWatcher>(p =>
+                    new CSharpApiClientGenerator(p.GetRequiredService<ILogger<CSharpApiClientGenerator>>(), csharpConfig));
             }
         }
     }
-}
 
-if (config.Kasper != null)
-{
-    foreach (var kasperConfig in config.Kasper)
+    if (config.Javascript != null)
     {
-        CombinePath(dn, kasperConfig, c => c.SourcesDirectory);
+        foreach (var jsConfig in config.Javascript)
+        {
+            CombinePath(dn, jsConfig, c => c.ModelOutputDirectory);
+            CombinePath(dn, jsConfig, c => c.ResourceOutputDirectory);
+            CombinePath(dn, jsConfig, c => c.ApiClientOutputDirectory);
 
-        services.AddSingleton<IModelWatcher>(p =>
-            new KasperGenerator(p.GetRequiredService<ILogger<KasperGenerator>>(), kasperConfig));
+            if (jsConfig.ModelOutputDirectory != null)
+            {
+                services.AddSingleton<IModelWatcher>(p =>
+                    new TypescriptDefinitionGenerator(p.GetRequiredService<ILogger<TypescriptDefinitionGenerator>>(), jsConfig));
+
+                if (jsConfig.ApiClientOutputDirectory != null)
+                {
+                    if (jsConfig.TargetFramework == TargetFramework.ANGULAR)
+                    {
+                        services.AddSingleton<IModelWatcher>(p =>
+                           new AngularApiClientGenerator(p.GetRequiredService<ILogger<AngularApiClientGenerator>>(), jsConfig));
+                    }
+                    else
+                    {
+                        services.AddSingleton<IModelWatcher>(p =>
+                           new JavascriptApiClientGenerator(p.GetRequiredService<ILogger<JavascriptApiClientGenerator>>(), jsConfig));
+                    }
+                }
+            }
+
+            if (jsConfig.ResourceOutputDirectory != null)
+            {
+                services.AddSingleton<IModelWatcher>(p =>
+                    new JavascriptResourceGenerator(p.GetRequiredService<ILogger<JavascriptResourceGenerator>>(), jsConfig));
+            }
+        }
+    }
+
+    if (config.Jpa != null)
+    {
+        foreach (var jpaConfig in config.Jpa)
+        {
+            CombinePath(dn, jpaConfig, c => c.ModelOutputDirectory);
+            CombinePath(dn, jpaConfig, c => c.ApiOutputDirectory);
+
+            if (jpaConfig.EntitiesPackageName != null || jpaConfig.DtosPackageName != null)
+            {
+                services
+                    .AddSingleton<IModelWatcher>(p =>
+                        new JpaModelGenerator(p.GetRequiredService<ILogger<JpaModelGenerator>>(), jpaConfig));
+                services
+                    .AddSingleton<IModelWatcher>(p =>
+                        new JpaModelInterfaceGenerator(p.GetRequiredService<ILogger<JpaModelInterfaceGenerator>>(), jpaConfig));
+            }
+
+            if (jpaConfig.DaosPackageName != null)
+            {
+                services
+                    .AddSingleton<IModelWatcher>(p =>
+                        new JpaDaoGenerator(p.GetRequiredService<ILogger<JpaDaoGenerator>>(), jpaConfig));
+            }
+
+            if (jpaConfig.ApiOutputDirectory != null)
+            {
+                if (jpaConfig.ApiGeneration == ApiGeneration.Server)
+                {
+                    services
+                        .AddSingleton<IModelWatcher>(p =>
+                            new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), jpaConfig));
+                }
+                else if (jpaConfig.ApiGeneration == ApiGeneration.Client)
+                {
+                    services
+                        .AddSingleton<IModelWatcher>(p =>
+                            new SpringClientApiGenerator(p.GetRequiredService<ILogger<SpringClientApiGenerator>>(), jpaConfig));
+                }
+            }
+        }
+    }
+
+    if (config.Kasper != null)
+    {
+        foreach (var kasperConfig in config.Kasper)
+        {
+            CombinePath(dn, kasperConfig, c => c.SourcesDirectory);
+
+            services.AddSingleton<IModelWatcher>(p =>
+                new KasperGenerator(p.GetRequiredService<ILogger<KasperGenerator>>(), kasperConfig));
+        }
+    }
+
+    var provider = services.BuildServiceProvider();
+    disposables.Add(provider);
+
+    var modelStore = provider.GetRequiredService<ModelStore>();
+    var watcher = modelStore.LoadFromConfig(watchMode, new(i + 1, colors[i % colors.Length]));
+    if (watcher != null)
+    {
+        disposables.Add(watcher);
     }
 }
-
-using var provider = services.BuildServiceProvider();
-
-var modelStore = provider.GetRequiredService<ModelStore>();
-
-modelStore.LoadFromConfig(watchMode);
 
 if (watchMode)
 {
@@ -214,4 +262,9 @@ if (watchMode)
         autoResetEvent.Set();
     };
     autoResetEvent.WaitOne();
+}
+
+foreach (var provider in disposables)
+{
+    provider.Dispose();
 }

--- a/TopModel.Generator/TopModel.Generator.csproj
+++ b/TopModel.Generator/TopModel.Generator.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
 

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -5,6 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
+using TopModel.LanguageServer;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 class CodeActionHandler : CodeActionHandlerBase
@@ -12,11 +13,14 @@ class CodeActionHandler : CodeActionHandlerBase
     private readonly ILanguageServerFacade _facade;
     private readonly ModelStore _modelStore;
     private readonly ModelFileCache _fileCache;
-    public CodeActionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache modelFileCache)
+    private readonly ModelConfig _config;
+
+    public CodeActionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache modelFileCache, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
         _fileCache = modelFileCache;
+        _config = config;
     }
 
     public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
@@ -95,7 +99,7 @@ class CodeActionHandler : CodeActionHandlerBase
     {
         return new()
         {
-            DocumentSelector = DocumentSelector.ForPattern("**/*.tmd"),
+            DocumentSelector = _config.GetDocumentSelector(),
             ResolveProvider = true,
             CodeActionKinds = new List<CodeActionKind>
             {

--- a/TopModel.LanguageServer/CodeLensHandler.cs
+++ b/TopModel.LanguageServer/CodeLensHandler.cs
@@ -4,16 +4,19 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.LanguageServer;
 
 class CodeLensHandler : CodeLensHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
@@ -76,7 +79,7 @@ class CodeLensHandler : CodeLensHandlerBase
     {
         return new CodeLensRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -4,18 +4,21 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.LanguageServer;
 
 class CompletionHandler : CompletionHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
     private readonly ModelFileCache _fileCache;
+    private readonly ModelConfig _config;
 
-    public CompletionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache fileCache)
+    public CompletionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache fileCache, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
         _fileCache = fileCache;
+        _config = config;
     }
 
     public override Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
@@ -395,7 +398,7 @@ class CompletionHandler : CompletionHandlerBase
     {
         return new CompletionRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -3,16 +3,19 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.LanguageServer;
 
 class DefinitionHandler : DefinitionHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public DefinitionHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public DefinitionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     public override Task<LocationOrLocationLinks> Handle(DefinitionParams request, CancellationToken cancellationToken)
@@ -74,7 +77,7 @@ class DefinitionHandler : DefinitionHandlerBase
     {
         return new DefinitionRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -3,16 +3,19 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.LanguageServer;
 
 class HoverHandler : HoverHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public HoverHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public HoverHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     public override Task<Hover?> Handle(HoverParams request, CancellationToken cancellationToken)
@@ -53,7 +56,7 @@ class HoverHandler : HoverHandlerBase
     {
         return new HoverRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/MermaidHandler.cs
+++ b/TopModel.LanguageServer/MermaidHandler.cs
@@ -2,13 +2,14 @@ using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
 public class MermaidHandler : IRequestHandler<MermaidRequest, Mermaid>, IJsonRpcHandler
 {
-    ModelStore _modelStore;
-    ILanguageServerFacade _facade;
+    private readonly ModelStore _modelStore;
+    private readonly ILanguageServerFacade _facade;
 
     public MermaidHandler(ModelStore modelStore, ILanguageServerFacade facade)
     {
@@ -20,10 +21,10 @@ public class MermaidHandler : IRequestHandler<MermaidRequest, Mermaid>, IJsonRpc
     {
         var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.Uri);
         var result = GenerateDiagramFile(file!);
-        return Task.FromResult<Mermaid>(new Mermaid(result, file!.Name));
+        return Task.FromResult(new Mermaid(result, file!.Name));
     }
 
-    public string GenerateDiagramFile(TopModel.Core.FileModel.ModelFile file)
+    public static string GenerateDiagramFile(ModelFile file)
     {
         string diagram = string.Empty;
         var classes = file.Classes

--- a/TopModel.LanguageServer/MermaidRequest.cs
+++ b/TopModel.LanguageServer/MermaidRequest.cs
@@ -1,12 +1,14 @@
-using OmniSharp.Extensions.JsonRpc;
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
 namespace TopModel.LanguageServer;
 
 public class MermaidRequest : IJsonRpcRequest, IRequest<Mermaid>
 {
-    public string Uri { get; init; }
     public MermaidRequest(string uri)
     {
-        this.Uri = uri;
+        Uri = uri;
     }
+
+    public string Uri { get; init; }
 }

--- a/TopModel.LanguageServer/ModelConfigExtensions.cs
+++ b/TopModel.LanguageServer/ModelConfigExtensions.cs
@@ -1,11 +1,12 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using TopModel.Core;
 
-public static class ModelConfigExtensions {
+namespace TopModel.LanguageServer;
 
+public static class ModelConfigExtensions
+{
     public static DocumentSelector GetDocumentSelector(this ModelConfig config)
     {
         return DocumentSelector.ForPattern($"{config.ModelRoot}/**/*.tmd");
-
     }
 }

--- a/TopModel.LanguageServer/ModelFileCache.cs
+++ b/TopModel.LanguageServer/ModelFileCache.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Concurrent;
 
+namespace TopModel.LanguageServer;
+
 public class ModelFileCache
 {
     private readonly ConcurrentDictionary<string, string[]> _fileCache = new();

--- a/TopModel.LanguageServer/ModelWatcher.cs
+++ b/TopModel.LanguageServer/ModelWatcher.cs
@@ -48,7 +48,7 @@ public class ModelWatcher : IModelWatcher
         }
     }
 
-    public void OnFilesChanged(IEnumerable<ModelFile> files)
+    public void OnFilesChanged(IEnumerable<ModelFile> files, ModelStoreConfig? storeConfig = null)
     {
         _facade.SendNotification("filesChanged");
     }

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -3,6 +3,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
 
+namespace TopModel.LanguageServer;
+
 public static class OmnisharpExtensions
 {
     public static OmniSharp.Extensions.LanguageServer.Protocol.Models.Range? ToRange(this Reference? loc)

--- a/TopModel.LanguageServer/ReferencesHandler.cs
+++ b/TopModel.LanguageServer/ReferencesHandler.cs
@@ -4,15 +4,20 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 
+namespace TopModel.LanguageServer;
+
+
 class ReferencesHandler : ReferencesHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public ReferencesHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public ReferencesHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     public override Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
@@ -39,7 +44,7 @@ class ReferencesHandler : ReferencesHandlerBase
     {
         return new ReferenceRegistrationOptions()
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -4,15 +4,19 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 
-class RenameHandler : RenameHandlerBase
+namespace TopModel.LanguageServer;
+
+public class RenameHandler : RenameHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public RenameHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public RenameHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     public override Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
@@ -49,7 +53,7 @@ class RenameHandler : RenameHandlerBase
     {
         return new RenameRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml")
+            DocumentSelector = _config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -5,22 +5,26 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
 
-class SemanticTokensHandler : SemanticTokensHandlerBase
+namespace TopModel.LanguageServer;
+
+public class SemanticTokensHandler : SemanticTokensHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
+    private readonly ModelConfig _config;
 
-    public SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade facade)
+    public SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
     {
         _modelStore = modelStore;
         _facade = facade;
+        _config = config;
     }
 
     protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(SemanticTokensCapability capability, ClientCapabilities clientCapabilities)
     {
         return new SemanticTokensRegistrationOptions
         {
-            DocumentSelector = DocumentSelector.ForLanguage("yaml"),
+            DocumentSelector = _config.GetDocumentSelector(),
             Legend = new()
             {
                 TokenModifiers = capability.TokenModifiers,

--- a/TopModel.LanguageServer/TextDocumentSyncHandler.cs
+++ b/TopModel.LanguageServer/TextDocumentSyncHandler.cs
@@ -6,11 +6,14 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 using TopModel.Core;
 
+namespace TopModel.LanguageServer;
+
 class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 {
     private readonly ModelFileCache _fileCache;
     private readonly ModelStore _modelStore;
     private readonly ModelConfig _config;
+
     public TextDocumentSyncHandler(ModelStore modelStore, ModelFileCache fileCache, ModelConfig config)
     {
         _fileCache = fileCache;

--- a/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
+++ b/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
@@ -4,7 +4,9 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using TopModel.Core;
 
-class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
+namespace TopModel.LanguageServer;
+
+public class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
 {
     private readonly ModelStore _modelStore;
     private readonly ILanguageServerFacade _facade;
@@ -74,6 +76,6 @@ class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
 
     protected override WorkspaceSymbolRegistrationOptions CreateRegistrationOptions(WorkspaceSymbolCapability capability, ClientCapabilities clientCapabilities)
     {
-        return new WorkspaceSymbolRegistrationOptions();
+        return new();
     }
 }

--- a/TopModel.UI/ModelFileProvider.cs
+++ b/TopModel.UI/ModelFileProvider.cs
@@ -30,7 +30,7 @@ public class ModelFileProvider : IModelWatcher
 
     public IEnumerable<string>? GeneratedFiles => null;
 
-    public void OnFilesChanged(IEnumerable<ModelFile> files)
+    public void OnFilesChanged(IEnumerable<ModelFile> files, ModelStoreConfig? storeConfig = null)
     {
         foreach (var file in files)
         {

--- a/TopModel.VSCode/src/application.ts
+++ b/TopModel.VSCode/src/application.ts
@@ -35,7 +35,7 @@ export class Application {
         }
 
         this.terminal.sendText(
-            `modgen ${path}` + (watch ? " --watch" : "")
+            `modgen -f ${path}` + (watch ? " --watch" : "")
         );
         this.terminal.show();
     }
@@ -55,20 +55,8 @@ export class Application {
         configFolderA.pop();
         const configFolder = configFolderA.join('/');
         this.modelRoot = this.config.modelRoot || configFolder;
-        // Options to control the language client
-        let clientOptions: LanguageClientOptions = {
-            // Register the server for plain text documents
-            documentSelector: [
-                { scheme: 'file', pattern: `/${this.modelRoot}/**.tmd` }
-            ],
-
-            synchronize: {
-                fileEvents: [workspace.createFileSystemWatcher(`/${this.modelRoot}/**.tmd`)]
-            },
-        };
-
         // Create the language client and start the client.
-        this.client = new LanguageClient(`TopModel - ${this.config.app}`, `TopModel - ${this.config.app}`, serverOptions, clientOptions);
+        this.client = new LanguageClient(`TopModel - ${this.config.app}`, `TopModel - ${this.config.app}`, serverOptions, {});
         await this.client.start();
         addPreviewApplication(this);
         this.status = "STARTED";


### PR DESCRIPTION
La commande `modgen` récupère désormais tous les fichiers de configuration dans le répertoire dans lequel elle est lancée, exactement de la même façon que l'extension VSCode (pattern `**/topmodel*.config`), et lance une génération par configuration trouvée.

Il est toujours possible de spécifier un fichier en particulier avec l'option `-f` ou `--file` (qui remplace l'ancien argument pour choisir le fichier). On peut spécifier plusieurs fois cette option pour générer plusieurs fichiers.