### PR TITLE
Gideruette/issue161

### DIFF
--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -22,7 +22,7 @@ public class SpringClientApiGenerator : GeneratorBase
 
     public override string Name => "SpringApiClientGen";
 
-    public override IEnumerable<string> GeneratedFiles => Files.Select(f => GetFilePath(f.Value));
+    public override IEnumerable<string> GeneratedFiles => Files.Where(f => f.Value.Endpoints.Any()).Select(f => GetFilePath(f.Value));
 
     protected override void HandleFiles(IEnumerable<ModelFile> files)
     {

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
@@ -41,11 +41,11 @@ public class SpringServerApiGenerator : GeneratorBase
     {
         if (file.Options?.Endpoints?.FileName != null)
         {
-            return $"I{file.Options.Endpoints.FileName.ToFirstUpper()}Controller";
+            return $"{file.Options.Endpoints.FileName.ToFirstUpper()}Controller";
         }
 
         var filePath = file.Name.Split("/").Last();
-        return $"I{string.Join('_', filePath.Split("_").Skip(filePath.Contains('_') ? 1 : 0)).ToFirstUpper()}Controller";
+        return $"{string.Join('_', filePath.Split("_").Skip(filePath.Contains('_') ? 1 : 0)).ToFirstUpper()}Controller";
     }
 
     private string GetFileName(ModelFile file)

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
@@ -22,7 +22,7 @@ public class SpringServerApiGenerator : GeneratorBase
 
     public override string Name => "SpringApiServerGen";
 
-    public override IEnumerable<string> GeneratedFiles => Files.Select(f => GetFilePath(f.Value));
+    public override IEnumerable<string> GeneratedFiles => Files.Where(f => f.Value.Endpoints.Any()).Select(f => GetFilePath(f.Value));
 
     protected override void HandleFiles(IEnumerable<ModelFile> files)
     {

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/UtilisateurApiController.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/api/securite/utilisateur/UtilisateurApiController.java
@@ -23,7 +23,7 @@ import topmodel.exemple.name.entities.utilisateur.TypeUtilisateur;
 
 @RequestMapping("utilisateur")
 @Generated("TopModel : https://github.com/klee-contrib/topmodel")
-public interface IUtilisateurApiController {
+public interface UtilisateurApiController {
 
 
 	/**

--- a/docs/exemple/topmodel.lock
+++ b/docs/exemple/topmodel.lock
@@ -4,15 +4,8 @@
 
 version: 1.15.11
 generatedFiles:
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\DtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\EntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\ReferencesController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\AbstractUtilisateurApiClient.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\UtilisateurApiController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\DecoratorsController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\DtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\EntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\ReferencesController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\DroitsDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\ProfilDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\ProfilDtoDAO.java

--- a/docs/exemple/topmodel.lock
+++ b/docs/exemple/topmodel.lock
@@ -4,15 +4,15 @@
 
 version: 1.15.11
 generatedFiles:
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IDtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IEntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\IReferencesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\DtosController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\EntitiesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\ReferencesController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\AbstractUtilisateurApiClient.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\IUtilisateurApiController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IDecoratorsController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IDtosController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IEntitiesController.java
-  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\IReferencesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\securite\utilisateur\UtilisateurApiController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\DecoratorsController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\DtosController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\EntitiesController.java
+  - .\jpa\src\main\javagen\topmodel\exemple\name\api\utilisateur\ReferencesController.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\DroitsDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\ProfilDAO.java
   - .\jpa\src\main\javagen\topmodel\exemple\name\daos\securite\ProfilDtoDAO.java


### PR DESCRIPTION
Respect la convention de nommage Java pour les interfaces. Actuellement TopModel génère les interface d'API serveur en les préfixant par 'I'. L'idée est de retirer ce préfix, et d'ajouter dans l'implémentation le suffix "Impl"

Fix: #161 