### PR TITLE
`required` sur les paramètres de mapper `from`

### DIFF
--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -138,6 +138,9 @@ public class ClassLoader
                                                                 classScalar = parser.Consume<Scalar>();
                                                                 param.ClassReference = new ClassReference(classScalar);
                                                                 break;
+                                                            case "required":
+                                                                param.Required = parser.Consume<Scalar>().Value == "true";
+                                                                break;
                                                             case "comment":
                                                                 param.Comment = parser.Consume<Scalar>().Value;
                                                                 break;

--- a/TopModel.Core/Model/ClassMappings.cs
+++ b/TopModel.Core/Model/ClassMappings.cs
@@ -11,6 +11,8 @@ public class ClassMappings
 
     public ClassReference ClassReference { get; set; }
 
+    public bool Required { get; set; } = true;
+
 #nullable enable
     public string? Comment { get; set; }
 

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -754,6 +754,10 @@
                               "type": "string",
                               "description": "Classe depuis laquelle recopier des propriétés."
                             },
+                            "required": {
+                              "type": "boolean",
+                              "description": "Paramètre obligatoire. 'true' par défaut."
+                            },
                             "comment": {
                               "type": "string",
                               "description": "Commentaire facultatif du mapper."

--- a/TopModel.Generator/CSharp/MapperGenerator.cs
+++ b/TopModel.Generator/CSharp/MapperGenerator.cs
@@ -113,6 +113,16 @@ public class MapperGenerator : GeneratorBase
 
             w.WriteLine(2, $"public static {classe} Create{classe}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name}"))})");
             w.WriteLine(2, "{");
+
+            foreach (var param in mapper.Params.Where(p => p.Required))
+            {
+                w.WriteLine(3, $"if ({param.Name} is null)");
+                w.WriteLine(3, "{");
+                w.WriteLine(4, $"throw new ArgumentNullException(nameof({param.Name}));");
+                w.WriteLine(3, "}");
+                w.WriteLine();
+            }
+
             w.WriteLine(3, $"return new {classe}");
             w.WriteLine(3, "{");
 
@@ -133,10 +143,10 @@ public class MapperGenerator : GeneratorBase
                         {
                             if (mapping.Key is CompositionProperty cp)
                             {
-                                w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                                w.Write($"{(!param.Required ? $"{param.Name} is null ? null : " : string.Empty)}new() {{ {cp.Composition.PrimaryKey?.Name} = ");
                             }
 
-                            w.Write($"{mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}.{mapping.Value.Name}");
+                            w.Write($"{mapper.Params[mapper.ParentMapper.Params.IndexOf(param)].Name}{(!param.Required && mapping.Key is not CompositionProperty ? "?" : string.Empty)}.{mapping.Value.Name}");
 
                             if (mapping.Key is CompositionProperty)
                             {
@@ -169,10 +179,10 @@ public class MapperGenerator : GeneratorBase
                     {
                         if (mapping.Key is CompositionProperty cp)
                         {
-                            w.Write($"new() {{ {cp.Composition.PrimaryKey?.Name} = ");
+                            w.Write($"{(!param.Required ? $"{param.Name} is null ? null : " : string.Empty)}new() {{ {cp.Composition.PrimaryKey?.Name} = ");
                         }
 
-                        w.Write($"{param.Name}.{mapping.Value.Name}");
+                        w.Write($"{param.Name}{(!param.Required && mapping.Key is not CompositionProperty ? "?" : string.Empty)}.{mapping.Value.Name}");
 
                         if (mapping.Key is CompositionProperty)
                         {

--- a/TopModel.Generator/CSharp/MapperGenerator.cs
+++ b/TopModel.Generator/CSharp/MapperGenerator.cs
@@ -111,7 +111,7 @@ public class MapperGenerator : GeneratorBase
 
             w.WriteReturns(2, $"Une nouvelle instance de '{classe}'");
 
-            w.WriteLine(2, $"public static {classe} Create{classe}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name}"))})");
+            w.WriteLine(2, $"public static {classe} Create{classe}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name}{(!p.Required ? " = null" : string.Empty)}"))})");
             w.WriteLine(2, "{");
 
             foreach (var param in mapper.Params.Where(p => p.Required))

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
@@ -286,7 +286,8 @@ public class JpaModelConstructorGenerator
                                     else if (cp.Composition.FromMappers.Any(f => f.Params.Count == 1 && f.Params.First().Class == ap.Association))
                                     {
                                         var cpMapper = cp.Composition.FromMappers.Find(f => f.Params.Count == 1 && f.Params.First().Class == ap.Association);
-                                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = new {cp.Composition.Name.ToFirstUpper()}({param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}());");
+                                        var getter = $"{param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}()";
+                                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {getter} != null ? null : new {cp.Composition.Name.ToFirstUpper()}({getter});");
                                     }
                                     else
                                     {
@@ -336,7 +337,16 @@ public class JpaModelConstructorGenerator
                                     else if (cp.Composition.FromMappers.Any(f => f.Params.Count == 1 && f.Params.First().Class == ap.Association))
                                     {
                                         var cpMapper = cp.Composition.FromMappers.Find(f => f.Params.Count == 1 && f.Params.First().Class == ap.Association);
-                                        fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = new {cp.Composition.Name.ToFirstUpper()}({param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}());");
+                                        var getter = $"{param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}()";
+                                        if (ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany)
+                                        {
+                                            fw.AddImport("java.util.stream.Collectors");
+                                            fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {getter} == null ? null : {getter}.stream().map({cp.Composition.Name.ToFirstUpper()}::new).collect(Collectors.toList());");
+                                        }
+                                        else
+                                        {
+                                            fw.WriteLine(3, $"this.{mapping.Key.GetJavaName()} = {getter} == null ? null : new {cp.Composition.Name.ToFirstUpper()}({getter});");
+                                        }
                                     }
                                     else
                                     {

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
@@ -246,7 +246,7 @@ public class JpaModelConstructorGenerator
 
             foreach (var param in mapper.Params.Where(p => p.Mappings.Count > 0))
             {
-                fw.WriteLine(2, $"if({param.Name.ToFirstLower()} != null) {{");
+                fw.WriteLine(2, $"if ({param.Name.ToFirstLower()} != null) {{");
                 var mappings = param.Mappings.ToList();
                 foreach (var mapping in mappings)
                 {
@@ -259,7 +259,7 @@ public class JpaModelConstructorGenerator
                             {
                                 if (mapping.Key is IFieldProperty)
                                 {
-                                    fw.WriteLine(3, $"if({param.Name.ToFirstLower()}.{getterPrefix}{mapping.Value.GetJavaName().ToFirstUpper()}() != null) {{");
+                                    fw.WriteLine(3, $"if ({param.Name.ToFirstLower()}.{getterPrefix}{mapping.Value.GetJavaName().ToFirstUpper()}() != null) {{");
                                     if (ap.Type == AssociationType.OneToOne || ap.Type == AssociationType.ManyToOne)
                                     {
                                         fw.WriteLine(4, $"this.{mapping.Key.GetJavaName()} = {param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}().{getterPrefix}{ap.Property.Name.ToFirstUpper()}();");
@@ -271,7 +271,11 @@ public class JpaModelConstructorGenerator
                                     }
 
                                     fw.WriteLine(3, "}");
-                                    fw.WriteLine();
+
+                                    if (mappings.IndexOf(mapping) < mappings.Count - 1)
+                                    {
+                                        fw.WriteLine();
+                                    }
                                 }
                                 else if (mapping.Key is CompositionProperty cp)
                                 {
@@ -305,7 +309,7 @@ public class JpaModelConstructorGenerator
                                 }
                                 else if (mapping.Key is IFieldProperty)
                                 {
-                                    fw.WriteLine(3, $"if({param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}() != null) {{");
+                                    fw.WriteLine(3, $"if ({param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}() != null) {{");
                                     if (ap.Type == AssociationType.OneToOne || ap.Type == AssociationType.ManyToOne)
                                     {
                                         fw.WriteLine(4, $"this.{mapping.Key.GetJavaName()} = {param.Name.ToFirstLower()}.{getterPrefix}{ap.GetJavaName().ToFirstUpper()}().{getterPrefix}{ap.Property.Name.ToFirstUpper()}();");
@@ -317,7 +321,11 @@ public class JpaModelConstructorGenerator
                                     }
 
                                     fw.WriteLine(3, "}");
-                                    fw.WriteLine();
+
+                                    if (mappings.IndexOf(mapping) < mappings.Count - 1)
+                                    {
+                                        fw.WriteLine();
+                                    }
                                 }
                                 else if (mapping.Key is CompositionProperty cp)
                                 {
@@ -348,8 +356,18 @@ public class JpaModelConstructorGenerator
                     }
                 }
 
+                if (param.Required)
+                {
+                    fw.WriteLine(2, "} else {");
+                    fw.WriteLine(3, $"throw new IllegalArgumentException(\"{param.Name} cannot not be null\");");
+                }
+
                 fw.WriteLine(2, "}");
-                fw.WriteLine();
+
+                if (mapper.Params.IndexOf(param) < mapper.Params.Count - 1)
+                {
+                    fw.WriteLine();
+                }
             }
 
             fw.WriteLine(1, "}");

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/securite/ProfilDto.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/securite/ProfilDto.java
@@ -106,22 +106,22 @@ public class ProfilDto implements Serializable {
 	 * @param profil Instance de 'Profil'.
 	 */
 	protected void from(Profil profil) {
-		if(profil != null) {
+		if (profil != null) {
 			this.id = profil.getId();
-			if(profil.getTypeProfil() != null) {
+			if (profil.getTypeProfil() != null) {
 				this.typeProfilCode = profil.getTypeProfil().getCode();
 			}
 
-			if(profil.getDroits() != null) {
+			if (profil.getDroits() != null) {
 				this.droits = profil.getDroits().stream().filter(t -> t != null).map(droits -> droits.getCode()).collect(Collectors.toList());
 			}
 
-			if(profil.getSecteurs() != null) {
+			if (profil.getSecteurs() != null) {
 				this.secteurs = profil.getSecteurs().stream().filter(t -> t != null).map(secteurs -> secteurs.getId()).collect(Collectors.toList());
 			}
-
+		} else {
+			throw new IllegalArgumentException("profil cannot not be null");
 		}
-
 	}
 
 	/**

--- a/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/UtilisateurDto.java
+++ b/docs/exemple/jpa/src/main/javagen/topmodel/exemple/name/dtos/utilisateur/UtilisateurDto.java
@@ -133,23 +133,23 @@ public class UtilisateurDto implements Serializable, IUtilisateurDto {
 	 * @param utilisateur Instance de 'Utilisateur'.
 	 */
 	protected void from(Utilisateur utilisateur) {
-		if(utilisateur != null) {
+		if (utilisateur != null) {
 			this.utilisateurParent = new UtilisateurDto(utilisateur.getUtilisateurParent());
 			this.dateCreation = utilisateur.getDateCreation();
 			this.dateModification = utilisateur.getDateModification();
 			this.id = utilisateur.getId();
 			this.age = utilisateur.getAge();
-			if(utilisateur.getProfil() != null) {
+			if (utilisateur.getProfil() != null) {
 				this.profilId = utilisateur.getProfil().getId();
 			}
 
 			this.email = utilisateur.getEmail();
-			if(utilisateur.getTypeUtilisateur() != null) {
+			if (utilisateur.getTypeUtilisateur() != null) {
 				this.typeUtilisateurCode = utilisateur.getTypeUtilisateur().getCode();
 			}
-
+		} else {
+			throw new IllegalArgumentException("utilisateur cannot not be null");
 		}
-
 	}
 
 	/**

--- a/docs/model/mappers.md
+++ b/docs/model/mappers.md
@@ -30,6 +30,7 @@ Chaque définition de mapping (qui correspond à un paramètre d'un `from` ou la
 - Un nom, `name`, facultatif :
   - Pour un `from`, il s'agit du nom du paramètre, qui est par défaut renseigné par le nom de la classe en camelCase. Il devient nécessaire si la même classe est utilisée pour plusieurs paramètres.
   - Pour un `to`, il s'agit du nom du mapper, par défaut `To{{ClasseCible}}`. Il devient nécessaire si plusieurs mappers `to` sont définis vers la même classe.
+- Un paramètre de mapper `from` peut également définir le caractère obligatoire du paramètre via `required`. **Tous les paramètres sont obligatoires** par défaut, il conviendra donc de spécifier `required: false` dans le cas contraire.
 - Des correspondances de champs personnalisées, `mappings`, facultatifs tant qu'il n'y a pas d'ambiguïté dans les correspondances.
 
 ## Mappings de champs entre classes


### PR DESCRIPTION
Les paramètres de mappers `from` peuvent désormais spécifier leur caractère obligatoire. Auparavant, c'était laissé à la libre interprétation du générateur, et les générateurs C# et Java n'étaient pas d'accord : c'était implicitement obligatoire pour le premier (sauf pour les paramètres `this`) et implicitement facultatif pour le second.

La propriété `required` peut donc désormais être spécifiée sur un paramètre de mapper `from`, et **sa valeur par défaut vaut `true`, ce qui implique sur les paramètres sont désormais obligatoires par défaut**. Des exceptions propres (`ArgumentNullException`/`IllegalArgumentException`) sont désormais générées dans le cas où le paramètre est obligatoire mais null.