### PR TITLE
Paramètres de décorateurs

### DIFF
--- a/TopModel.Core/FileModel/DecoratorReference.cs
+++ b/TopModel.Core/FileModel/DecoratorReference.cs
@@ -8,4 +8,6 @@ public class DecoratorReference : Reference
         : base(scalar)
     {
     }
+
+    public List<Reference> ParameterReferences { get; set; } = new();
 }

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -27,7 +27,7 @@ public class ModelFile
     public List<object> ResolvedAliases { get; } = new();
 
     public IDictionary<Reference, object> References => Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object))
-        .Concat(Classes.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Name == dr.ReferenceName) as object))))
+        .Concat(Classes.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
         .Concat(Properties.OfType<RegularProperty>().Select(p => (p.DomainReference as Reference, p.Domain as object)))
         .Concat(Properties.OfType<AssociationProperty>().SelectMany(p => new (Reference, object)[]
         {
@@ -55,7 +55,7 @@ public class ModelFile
         .Concat(Classes.SelectMany(c => c.FromMappers.SelectMany(m => m.Params).Concat(c.ToMappers)).Select(p => (p.ClassReference as Reference, (object)p.Class)))
         .Concat(Classes.SelectMany(c => c.FromMappers.SelectMany(m => m.Params).Concat(c.ToMappers).SelectMany(m => m.MappingReferences.SelectMany(mr => new[] { (mr.Key, (object)c.Properties.FirstOrDefault(k => k.Name == mr.Key.ReferenceName)), (mr.Value, mr.Value.ReferenceName == "this" || mr.Value.ReferenceName == "false" ? new Keyword { ModelFile = c.ModelFile } : m.Mappings.Values.FirstOrDefault(k => k.Name == mr.Value.ReferenceName)) }))))
         .Concat(Aliases.SelectMany(a => a.Classes).Select(c => (c as Reference, ResolvedAliases.OfType<Class>().FirstOrDefault(ra => ra.Name == c.ReferenceName) as object)))
-        .Where(t => t.Item1 != null && t.Item2 != null)
+        .Where(t => t.Item1 is not null && t.Item2 is not null && t.Item2 is not (null, null))
         .DistinctBy(t => t.Item1)
         .ToDictionary(t => t.Item1, t => t.Item2);
 

--- a/TopModel.Core/FileModel/ModelFileOptions.cs
+++ b/TopModel.Core/FileModel/ModelFileOptions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+#pragma warning disable SA1402
 
 namespace TopModel.Core.FileModel;
 

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -63,7 +63,24 @@ public class ClassLoader
                 case "decorators":
                     parser.ConsumeSequence(() =>
                     {
-                        classe.DecoratorReferences.Add(new DecoratorReference(parser.Consume<Scalar>()));
+                        if (parser.Current is MappingStart)
+                        {
+                            parser.ConsumeMapping(() =>
+                            {
+                                var decorator = new DecoratorReference(parser.Consume<Scalar>());
+
+                                parser.ConsumeSequence(() =>
+                                {
+                                    decorator.ParameterReferences.Add(new Reference(parser.Consume<Scalar>()));
+                                });
+
+                                classe.DecoratorReferences.Add(decorator);
+                            });
+                        }
+                        else
+                        {
+                            classe.DecoratorReferences.Add(new DecoratorReference(parser.Consume<Scalar>()));
+                        }
                     });
                     break;
                 case "properties":

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -20,7 +20,7 @@ public class Class
 #nullable enable
     public Class? Extends { get; set; }
 
-    public List<Decorator> Decorators { get; } = new();
+    public List<(Decorator Decorator, string[] Parameters)> Decorators { get; } = new();
 
     public string? Label { get; set; }
 

--- a/TopModel.Core/Model/TemplateExtension.cs
+++ b/TopModel.Core/Model/TemplateExtension.cs
@@ -52,7 +52,7 @@ public static class TemplateExtension
         return result;
     }
 
-    public static string ParseTemplate(this string template, Class c)
+    public static string ParseTemplate(this string template, Class c, string[] parameters)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains("{"))
         {
@@ -62,7 +62,7 @@ public static class TemplateExtension
         var result = template;
         foreach (Match t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), c));
+            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), c, parameters));
         }
 
         return result;
@@ -126,32 +126,37 @@ public static class TemplateExtension
     private static string ResolveVariable(this string input, CompositionProperty cp)
     {
         var transform = input.GetTransformation();
-        var result = input.Split(':').First()
+        return input.Split(':').First()
             .Replace("class.name", transform(cp.Class?.Name.ToString() ?? string.Empty))
             .Replace("composition.name", transform(cp.Composition?.Name.ToString() ?? string.Empty))
             .Replace("name", transform(cp.Name ?? string.Empty))
             .Replace("label", transform(cp.Label ?? string.Empty))
             .Replace("comment", transform(cp.Comment));
-        return result;
     }
 
-    private static string ResolveVariable(this string input, Class c)
+    private static string ResolveVariable(this string input, Class c, string[] parameters)
     {
         var transform = input.GetTransformation();
         var result = input.Split(':').First()
-            .Replace("primaryKey.name", transform(c.PrimaryKey?.Name ?? string.Empty))
-            .Replace("trigram", transform(c.Trigram))
-            .Replace("name", transform(c.Name))
-            .Replace("comment", transform(c.Comment))
-            .Replace("label", transform(c.Label ?? string.Empty))
-            .Replace("pluralName", transform(c.PluralName ?? string.Empty))
-            .Replace("module", transform(c.ModelFile.Module ?? string.Empty));
+             .Replace("primaryKey.name", transform(c.PrimaryKey?.Name ?? string.Empty))
+             .Replace("trigram", transform(c.Trigram))
+             .Replace("name", transform(c.Name))
+             .Replace("comment", transform(c.Comment))
+             .Replace("label", transform(c.Label ?? string.Empty))
+             .Replace("pluralName", transform(c.PluralName ?? string.Empty))
+             .Replace("module", transform(c.ModelFile.Module ?? string.Empty));
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            result = result.Replace($"${i}", parameters[i]);
+        }
+
         return result;
     }
 
     private static MatchCollection ExtractVariables(this string input)
     {
-        var regex = new Regex(@"(\{[a-zA-Z0-9:.]+\})");
+        var regex = new Regex(@"(\{[$a-zA-Z0-9:.]+\})");
         return regex.Matches(input);
     }
 }

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -17,6 +17,7 @@ public static class ModelExtensions
             Alias alias => alias.ModelFile,
             Domain domain => domain.ModelFile,
             Decorator decorator => decorator.ModelFile,
+            (Decorator decorator, _) => decorator.ModelFile,
             Keyword keyword => keyword.ModelFile,
             _ => throw new ArgumentException("Type d'objet non supporté.")
         };
@@ -37,6 +38,7 @@ public static class ModelExtensions
             Domain d => d.Location,
             LocatedString l => l.Location,
             Decorator d => d.Location,
+            (Decorator d, _) => d.Location,
             FromMapper m => m.Reference.Location,
             ClassMappings c => c.Name.Location,
             _ => null
@@ -98,7 +100,7 @@ public static class ModelExtensions
 
     public static IEnumerable<(DecoratorReference Reference, ModelFile File)> GetDecoratorReferences(this ModelStore modelStore, Decorator decorator)
     {
-        return modelStore.Classes.Where(c => c.Decorators.Contains(decorator))
+        return modelStore.Classes.Where(c => c.Decorators.Select(d => d.Decorator).Contains(decorator))
             .Select(c => (
                 Reference: c.DecoratorReferences.First(dr => dr.ReferenceName == decorator.Name),
                 File: c.GetFile()))

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -414,20 +414,20 @@ public class ModelStore
                 }
                 else
                 {
-                    if (classe.Decorators.Contains(decorator))
+                    if (classe.Decorators.Any(d => d.Decorator == decorator))
                     {
                         isError = true;
                         yield return new ModelError(classe, $"Le décorateur '{decoratorRef.ReferenceName}' est déjà présent dans la liste des décorateurs de la classe '{classe}'.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1009 };
                     }
                     else
                     {
-                        if ((decorator.CSharp?.Extends != null || decorator.Java?.Extends != null) && (classe.Extends != null || classe.Decorators.Any(d => decorator.CSharp?.Extends != null && d.CSharp?.Extends != null || decorator.Java?.Extends != null && d.Java?.Extends != null)))
+                        if ((decorator.CSharp?.Extends != null || decorator.Java?.Extends != null) && (classe.Extends != null || classe.Decorators.Any(d => decorator.CSharp?.Extends != null && d.Decorator.CSharp?.Extends != null || decorator.Java?.Extends != null && d.Decorator.Java?.Extends != null)))
                         {
                             isError = true;
                             yield return new ModelError(classe, $"Impossible d'appliquer le décorateur '{decoratorRef.ReferenceName}' à la classe '{classe}' : seul un 'extends' peut être spécifié.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1010 };
                         }
 
-                        classe.Decorators.Add(decorator);
+                        classe.Decorators.Add((decorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
                     }
                 }
             }
@@ -673,7 +673,7 @@ public class ModelStore
                     classe.Properties.Remove(prop);
                 }
 
-                foreach (var prop in classe.Decorators.SelectMany(d => d.Properties).Reverse())
+                foreach (var prop in classe.Decorators.SelectMany(d => d.Decorator.Properties).Reverse())
                 {
                     classe.Properties.Insert(0, prop.CloneWithClass(classe));
                 }

--- a/TopModel.Core/TopModel.Core.csproj
+++ b/TopModel.Core/TopModel.Core.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.5.2" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="NJsonSchema" Version="10.8.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -692,8 +692,23 @@
               "type": "array",
               "description": "Décorateurs de la classe",
               "items": {
-                "type": "string",
-                "description": "Nom du décorateur"
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Nom du décorateur"
+                  },
+                  {
+                    "type": "object",
+                    "description": "Nom du décorateur",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "Paramètre du décorator"
+                      }
+                    }
+                  }
+                ]          
               }
             },
             "properties": {

--- a/TopModel.Generator/CSharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpClassGenerator.cs
@@ -400,12 +400,16 @@ public class CSharpClassGenerator : GeneratorBase
             }
         }
 
-        foreach (var annotation in item.Decorators.SelectMany(d => d.CSharp?.Annotations ?? Array.Empty<string>()).Select(a => a.ParseTemplate(item)).Distinct())
+        foreach (var annotation in item.Decorators.SelectMany(d => (d.Decorator.CSharp?.Annotations ?? Array.Empty<string>()).Select(a => a.ParseTemplate(item, d.Parameters)).Distinct()))
         {
             w.WriteAttribute(1, annotation);
         }
 
-        w.WriteClassDeclaration(item.Name, item.Extends?.Name ?? item.Decorators.SingleOrDefault(d => d.CSharp?.Extends != null)?.CSharp?.Extends!.ParseTemplate(item), item.Decorators.SelectMany(d => d.CSharp?.Implements ?? Array.Empty<string>()).Distinct().Select(i => i.ParseTemplate(item)).ToArray());
+        var extendsDecorator = item.Decorators.SingleOrDefault(d => d.Decorator.CSharp?.Extends != null);
+        w.WriteClassDeclaration(
+            item.Name,
+            item.Extends?.Name ?? extendsDecorator.Decorator?.CSharp?.Extends!.ParseTemplate(item, extendsDecorator.Parameters),
+            item.Decorators.SelectMany(d => (d.Decorator.CSharp?.Implements ?? Array.Empty<string>()).Select(i => i.ParseTemplate(item, d.Parameters)).Distinct()).ToArray());
 
         if (!_config.CanClassUseEnums(item))
         {
@@ -599,7 +603,7 @@ public class CSharpClassGenerator : GeneratorBase
             usings.Add(_config.GetNamespace(item.Extends));
         }
 
-        foreach (var @using in item.Decorators.SelectMany(d => d.CSharp?.Usings ?? Array.Empty<string>()).Select(u => u.ParseTemplate(item)).Distinct())
+        foreach (var @using in item.Decorators.SelectMany(d => (d.Decorator.CSharp?.Usings ?? Array.Empty<string>()).Select(u => u.ParseTemplate(item, d.Parameters)).Distinct()))
         {
             usings.Add(@using);
         }

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelConstructorGenerator.cs
@@ -21,7 +21,7 @@ public class JpaModelConstructorGenerator
         fw.WriteDocStart(1, "No arg constructor");
         fw.WriteDocEnd(1);
         fw.WriteLine(1, $"public {classe.Name}() {{");
-        if (classe.Extends != null || classe.Decorators.Any(d => d.Java?.Extends is not null))
+        if (classe.Extends != null || classe.Decorators.Any(d => d.Decorator.Java?.Extends is not null))
         {
             fw.WriteLine(2, $"super();");
         }
@@ -54,7 +54,7 @@ public class JpaModelConstructorGenerator
             var parentAllArgConstructorArguments = string.Join(", ", GetAllArgsProperties(classe.Extends, availableClasses).Select(p => $"{p.GetJavaName()}"));
             fw.WriteLine(2, $"super({parentAllArgConstructorArguments});");
         }
-        else if (classe.Decorators.Any(d => d.Java?.Extends is not null))
+        else if (classe.Decorators.Any(d => d.Decorator.Java?.Extends is not null))
         {
             fw.WriteLine(2, $"super();");
         }
@@ -97,7 +97,7 @@ public class JpaModelConstructorGenerator
             var parentAllArgConstructorArguments = string.Join(", ", GetAllArgsProperties(classe.Extends, availableClasses).Select(p => $"{p.GetJavaName()}"));
             fw.WriteLine(2, $"super({parentAllArgConstructorArguments});");
         }
-        else if (classe.Decorators.Any(d => d.Java?.Extends is not null))
+        else if (classe.Decorators.Any(d => d.Decorator.Java?.Extends is not null))
         {
             fw.WriteLine(2, $"super();");
         }
@@ -130,7 +130,7 @@ public class JpaModelConstructorGenerator
             var parentAllArgConstructorArguments = string.Join(", ", GetAllArgsProperties(classe.Extends, availableClasses).Select(p => $"{p.GetJavaName()}"));
             fw.WriteLine(2, $"super({classe.Name.ToFirstLower()});");
         }
-        else if (classe.Decorators.Any(d => d.Java?.Extends is not null))
+        else if (classe.Decorators.Any(d => d.Decorator.Java?.Extends is not null))
         {
             fw.WriteLine(2, $"super();");
         }
@@ -236,7 +236,7 @@ public class JpaModelConstructorGenerator
 
             fw.WriteDocEnd(1);
             fw.WriteLine(1, $"protected void from({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name.ToFirstLower()}"))}) {{");
-            if (classe.Extends != null || classe.Decorators.Any(d => d.Java?.Extends is not null))
+            if (classe.Extends != null || classe.Decorators.Any(d => d.Decorator.Java?.Extends is not null))
             {
                 if (mapper.ParentMapper != null)
                 {

--- a/TopModel.Generator/Jpa/JpaModelInterfaceGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelInterfaceGenerator.cs
@@ -58,7 +58,7 @@ public class JpaModelInterfaceGenerator : GeneratorBase
     private void GenerateModule(string module)
     {
         var classes = Classes
-            .Where(c => c.Decorators.Any(d => d.Java != null && d.Java.GenerateInterface))
+            .Where(c => c.Decorators.Any(d => d.Decorator.Java != null && d.Decorator.Java.GenerateInterface))
             .Where(c => c.Namespace.Module == module);
         foreach (var classe in classes)
         {
@@ -71,9 +71,10 @@ public class JpaModelInterfaceGenerator : GeneratorBase
             WriteImports(fw, classe);
             fw.WriteLine();
 
-            var extends = (classe.Extends?.Name ?? classe.Decorators.Find(d => d.Java?.Extends is not null)?.Java!.Extends!.ParseTemplate(classe)) ?? null;
+            var extendsDecorator = classe.Decorators.SingleOrDefault(d => d.Decorator.Java?.Extends != null);
+            var extends = (classe.Extends?.Name ?? extendsDecorator.Decorator?.Java!.Extends!.ParseTemplate(classe, extendsDecorator.Parameters)) ?? null;
 
-            var implements = classe.Decorators.SelectMany(d => d.Java!.Implements).Select(i => i.ParseTemplate(classe)).Distinct().ToList();
+            var implements = classe.Decorators.SelectMany(d => d.Decorator.Java!.Implements.Select(i => i.ParseTemplate(classe, d.Parameters))).Distinct().ToList();
 
             fw.WriteLine("@Generated(\"TopModel : https://github.com/klee-contrib/topmodel\")");
             fw.WriteLine($"public interface I{classe.Name} {{");

--- a/TopModel.Generator/TopModel.Generator.csproj
+++ b/TopModel.Generator/TopModel.Generator.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -42,7 +42,7 @@ class DefinitionHandler : DefinitionHandlerBase
                     TargetRange = objet switch
                     {
                         Class or Endpoint or Domain => selectionRange with { End = new() { Line = selectionRange.Start.Line + 2, Character = 200 } },
-                        Decorator => selectionRange with { End = new() { Line = selectionRange.Start.Line + 1, Character = 200 } },
+                        Decorator or (Decorator, _) => selectionRange with { End = new() { Line = selectionRange.Start.Line + 1, Character = 200 } },
                         _ => selectionRange with { End = new() { Line = selectionRange.Start.Line, Character = 200 } }
                     },
                     TargetSelectionRange = selectionRange,

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -43,6 +43,7 @@ class HoverHandler : HoverHandlerBase
                         AliasProperty p => p.Comment,
                         Domain d => d.Label,
                         Decorator d => d.Description,
+                        (Decorator d, _) => d.Description,
                         _ => string.Empty
                     }))
                 });

--- a/TopModel.LanguageServer/TopModel.LanguageServer.csproj
+++ b/TopModel.LanguageServer/TopModel.LanguageServer.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 

--- a/TopModel.UI/TopModel.UI.csproj
+++ b/TopModel.UI/TopModel.UI.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TopModel.Core\TopModel.Core.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TopModel.Utils/TopModel.Utils.csproj
+++ b/TopModel.Utils/TopModel.Utils.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Il est désormais possible de spécifier des paramètres lors de l'instanciation d'un décorateur :
```
class:
  name: MyClass
  decorators:
    - MyDecorator: [Param1, Param2]
    - OtherDecorator
 ```
Les paramètres seront utilisés dans la résolution des variables `$0`, `$1`... dans les templates du décorateur.

Par exemple :
```
decorator:
  name: MyDecorator
  csharp:
    annotations:
      - MyAnnotation("{$0}", "{$1}"))
```
Génèrera l'annotation `[MyAnnotation("Param1", "Param2")]` sur `MyClass`. Si les paramètres ne sont pas renseignés, les variables `$0`, `$1` ne seront simplement pas remplacées. Et bien entendu, rien ne se passera si on passe des paramètres alors que le décorateur ne les utilise pas.