### PR TITLE
Fusion des fichiers d'endpoints de même nom et de même module

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -14,7 +14,7 @@ public class ModelFile
 
     public string Path { get; set; }
 
-    public ModelFileOptions Options { get; set; }
+    public ModelFileOptions Options { get; set; } = new();
 
     public List<Class> Classes { get; } = new();
 

--- a/TopModel.Core/FileModel/ModelFileOptions.cs
+++ b/TopModel.Core/FileModel/ModelFileOptions.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-#pragma warning disable SA1402
+﻿#pragma warning disable SA1402
 
 namespace TopModel.Core.FileModel;
 
@@ -10,8 +9,9 @@ public class ModelFileOptions
 
 public class EndpointOptions
 {
+#nullable disable
+    public string FileName { get; set; }
 #nullable enable
-    public string? FileName { get; set; }
 
     public string? Prefix { get; set; }
 }

--- a/TopModel.Core/FileModel/ModelFileOptions.cs
+++ b/TopModel.Core/FileModel/ModelFileOptions.cs
@@ -13,5 +13,5 @@ public class EndpointOptions
     public string FileName { get; set; }
 #nullable enable
 
-    public string? Prefix { get; set; }
+    public LocatedString? Prefix { get; set; }
 }

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -71,7 +71,6 @@ public class ModelFileLoader
                 case "options":
                     parser.Consume<MappingStart>();
                     var scalar = parser.Consume<Scalar>();
-                    var fileOptions = new ModelFileOptions();
                     if (scalar.Value == "endpoints")
                     {
                         parser.ConsumeMapping(() =>
@@ -81,16 +80,15 @@ public class ModelFileLoader
                             switch (prop)
                             {
                                 case "fileName":
-                                    fileOptions.Endpoints.FileName = value!.Value;
+                                    file.Options.Endpoints.FileName = value!.Value;
                                     break;
                                 case "prefix":
-                                    fileOptions.Endpoints.Prefix = value!.Value;
+                                    file.Options.Endpoints.Prefix = value!.Value;
                                     break;
                             }
                         });
                     }
 
-                    file.Options = fileOptions;
                     parser.Consume<MappingEnd>();
                     break;
             }
@@ -229,6 +227,8 @@ public class ModelFileLoader
             endpoint.ModelFile = file;
             endpoint.Namespace = ns;
         }
+
+        file.Options.Endpoints.FileName ??= file.Name.Split('/').Last();
 
         return file;
     }

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -83,7 +83,7 @@ public class ModelFileLoader
                                     file.Options.Endpoints.FileName = value!.Value;
                                     break;
                                 case "prefix":
-                                    file.Options.Endpoints.Prefix = value!.Value;
+                                    file.Options.Endpoints.Prefix = new LocatedString(value!);
                                     break;
                             }
                         });

--- a/TopModel.Core/ModelErrorType.cs
+++ b/TopModel.Core/ModelErrorType.cs
@@ -133,6 +133,11 @@ public enum ModelErrorType
     TMD1020,
 
     /// <summary>
+    /// Le préfixe d'endpoint '{file.Options.Endpoints.Prefix}' doit être identique à celui de tous les fichiers de même nom et de même module.
+    /// </summary>
+    TMD1021,
+
+    /// <summary>
     /// L'import {} n'est pas utilisé.
     /// </summary>
     TMD9001,

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -1226,6 +1226,21 @@ public class ModelStore
         {
             yield return new ModelError(decorator, $"Le décorateur '{decorator.Name}' n'est pas utilisé.") { IsError = false, ModelErrorType = ModelErrorType.TMD9005 };
         }
+
+        foreach (var files in Files.GroupBy(file => new { file.Options.Endpoints.FileName, file.Module }).Where(files => files.Select(file => file.Options.Endpoints.Prefix).Distinct().Count() > 1))
+        {
+            foreach (var file in files)
+            {
+                if (file.Options.Endpoints.Prefix != null)
+                {
+                    yield return new ModelError(file, $"Le préfixe d'endpoint '{file.Options.Endpoints.Prefix}' doit être identique à celui de tous les fichiers de même nom et de même module.", file.Options.Endpoints.Prefix?.GetLocation()) { ModelErrorType = ModelErrorType.TMD1021 };
+                }
+                else
+                {
+                    yield return new ModelError(file, $"Le fichier ne définit pas de préfixe d'endpoint alors que d'autres fichiers de même nom et de même module le font.") { ModelErrorType = ModelErrorType.TMD1021 };
+                }
+            }
+        }
     }
 
     private void LoadTranslations()

--- a/docs/model/endpoints.md
+++ b/docs/model/endpoints.md
@@ -38,7 +38,7 @@ Le type de paramètre (body, query, route) est automatiquement déterminé :
 
 Tous les générateurs vont générer **un fichier client ou serveur par fichier de modèle qui contient des endpoints**, qui reflétera le chemin et le nom du fichier de modèle en question. A l'inverse des générateurs de classes qui vont utiliser le module, ici il n'est pas important.
 
-Il est possible de paramétrer le nom du fichier généré, ainsi que d'ajouter un préfix aux routes. Pour cela, dans les méta-data du fichier (au niveau de `module`,`tags`, `uses`...), vous pouvez ajouter des options :
+Il est possible de paramétrer le nom du fichier généré, ainsi que d'ajouter un préfixe aux routes. Pour cela, dans les méta-data du fichier (au niveau de `module`,`tags`, `uses`...), vous pouvez ajouter des options :
 
 ```yaml
 ---
@@ -54,4 +54,8 @@ options:
     fileName: UtilisateurApi
 ```
 
-Ainsi, toutes les routes décrites dans ce fichier auront le préfix `utilisateur`. Le fichier généré se nommera `UtilisateurApi` (en fonction des spécificité des générateurs).
+Ainsi, toutes les routes décrites dans ce fichier auront le préfixe `utilisateur`. Le fichier généré se nommera `UtilisateurApi` (éventuellement complété du suffixe du générateur utilisé, par exemple `Controller` ou `Client`).
+
+**Si des fichiers de modèle de même module ont le même nom** (que ça soit le vrai nom de fichier dans des dossiers différents où bien une surcharge comme décrite précédemment), alors **les endpoints générés pour ces fichiers seront regroupés dans le même fichier cible**, pour tous les générateurs clients et serveurs.
+
+Une erreur sera levée si des fichiers de même nom ne définissent pas le même préfixe pour les routes. De même, deux endpoints de même fichier cible ne peuvent pas avoir le même nom.


### PR DESCRIPTION
Si des fichiers de modèle et de même module ont le même nom (que ça soit le vrai nom de fichier dans des dossiers différents où bien une surcharge comme celle-ci :)

```yaml
---
module: Web
options:
  endpoints:
    fileName: MyService
```

Alors les endpoints générés pour ces deux fichiers seront regroupés dans le même fichier cible, pour tous les générateurs clients et serveurs. Auparavant le cas n'était pas géré et l'un des fichiers aurait écrasé les autres, puisque le nom de fichier généré est totalement défini par le nom du fichier source, le module (et les tags).

Une erreur sera levée si des fichiers de même nom ne définissent pas le même préfixe pour les routes.