### PR TITLE
[VSCode] Références et renommage (partiel) de propriétés 

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -44,12 +44,12 @@ public class ModelFile
         }))
         .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[]
         {
-            (p.ClassReference, p.OriginalProperty?.Class),
+            (p.Reference, p.OriginalProperty?.Class),
             (p.PropertyReference, p.OriginalProperty),
             (p.ListDomainReference, p.ListDomain)
         }))
         .Concat(Properties.OfType<AliasProperty>()
-            .SelectMany(p => (p?.ClassReference as AliasReference)?.ExcludeReferences?
+            .SelectMany(p => p?.Reference?.ExcludeReferences?
                 .Select(er => (er, p?.OriginalProperty?.Class?.Properties?.FirstOrDefault(p => p?.Name == er?.ReferenceName) as object))
             ?? new List<(Reference, object)>()))
         .Concat(Classes.SelectMany(c => new[] { c.DefaultPropertyReference, c.OrderPropertyReference, c.FlagPropertyReference }.Select(r => (r, (object)c.Properties.FirstOrDefault(p => p.Name == r?.ReferenceName)))))
@@ -70,7 +70,7 @@ public class ModelFile
             .Contains(use.ReferenceName))
         .ToList();
 
-    internal IList<IProperty> Properties => Classes.Where(c => !ResolvedAliases.Contains(c)).SelectMany(c => c.Properties)
+    public IList<IProperty> Properties => Classes.Where(c => !ResolvedAliases.Contains(c)).SelectMany(c => c.Properties)
         .Concat(Endpoints.Where(e => !ResolvedAliases.Contains(e)).SelectMany(e => e.Params))
         .Concat(Endpoints.Where(e => !ResolvedAliases.Contains(e)).Select(e => e.Returns))
         .Concat(Decorators.SelectMany(e => e.Properties))

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -160,7 +160,7 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                 break;
 
             case Scalar { Value: "alias" } s:
-                var aliasRelation = new AliasReference();
+                var aliasReference = new AliasReference();
 
                 parser.Consume<Scalar>();
                 parser.Consume<MappingStart>();
@@ -173,20 +173,20 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                     switch (prop)
                     {
                         case "class":
-                            aliasRelation.Start = ((Scalar)next).Start;
-                            aliasRelation.End = ((Scalar)next).End;
-                            aliasRelation.ReferenceName = ((Scalar)next).Value;
+                            aliasReference.Start = ((Scalar)next).Start;
+                            aliasReference.End = ((Scalar)next).End;
+                            aliasReference.ReferenceName = ((Scalar)next).Value;
                             break;
                         case "include" or "property" when next is Scalar pValue:
-                            aliasRelation.AddInclude(pValue);
+                            aliasReference.AddInclude(pValue);
                             break;
                         case "exclude" when next is Scalar eValue:
-                            aliasRelation.AddExclude(eValue);
+                            aliasReference.AddExclude(eValue);
                             break;
                         case "include" or "property" when next is SequenceStart:
                             while (parser.Current is not SequenceEnd)
                             {
-                                aliasRelation.AddInclude(parser.Consume<Scalar>());
+                                aliasReference.AddInclude(parser.Consume<Scalar>());
                             }
 
                             parser.Consume<SequenceEnd>();
@@ -194,7 +194,7 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                         case "exclude" when next is SequenceStart:
                             while (parser.Current is not SequenceEnd)
                             {
-                                aliasRelation.AddExclude(parser.Consume<Scalar>());
+                                aliasReference.AddExclude(parser.Consume<Scalar>());
                             }
 
                             parser.Consume<SequenceEnd>();
@@ -220,10 +220,10 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                     switch (prop)
                     {
                         case "prefix":
-                            alp.Prefix = value.Value == "true" ? aliasRelation.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Prefix = value.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "suffix":
-                            alp.Suffix = value.Value == "true" ? aliasRelation.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Suffix = value.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "label":
                             alp.Label = value.Value;
@@ -248,7 +248,7 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                     }
                 }
 
-                alp.Reference = aliasRelation;
+                alp.Reference = aliasReference;
                 yield return alp;
                 break;
 

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -79,8 +79,6 @@ public class AliasProperty : IFieldProperty
 
     public IFieldProperty? OriginalProperty => _property;
 
-    public ClassReference? ClassReference { get; set; }
-
     public AliasReference? Reference { get; set; }
 
     public Reference? PropertyReference { get; set; }
@@ -137,7 +135,7 @@ public class AliasProperty : IFieldProperty
         {
             Property = prop,
             Location = Location,
-            ClassReference = Reference,
+            Reference = Reference,
             PropertyReference = includeReference,
             Class = Class,
             Decorator = Decorator,

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -24,9 +24,9 @@ public static class OmnisharpExtensions
     }
 
 
-    public static IEnumerable<(Reference Reference, ModelFile File)>? GetReferencesForPositionInFile(this ModelStore modelStore, Position position, ModelFile file)
+    public static References? GetReferencesForPositionInFile(this ModelStore modelStore, Position position, ModelFile file)
     {
-        object? objet = null;
+        object? referencedObject = null;
 
         var matchedReference = file.References.Keys.SingleOrDefault(reference =>
             reference.Start.Line - 1 <= position.Line && position.Line <= reference.End.Line - 1
@@ -34,24 +34,42 @@ public static class OmnisharpExtensions
 
         if (matchedReference != null)
         {
-            objet = file.References[matchedReference];
-        }
-        else
-        {
-            objet =
-                (object?)file.Classes.SingleOrDefault(c => c.Name.GetLocation()!.Start.Line - 1 == position.Line || c.GetLocation()!.Start.Line - 1 == position.Line)
-                ?? (object?)file.Domains.SingleOrDefault(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line)
-                ?? file.Decorators.SingleOrDefault(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line);
+            referencedObject = file.References[matchedReference];
         }
 
+        var definedObjects = file.Classes.Where(c => c.Name.GetLocation()!.Start.Line - 1 == position.Line || c.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>()
+            .Concat(file.Domains.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
+            .Concat(file.Decorators.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
+            .Concat(file.Properties.Where(p => p.GetLocation()!.Start.Line - 1 == position.Line));
+
+        var definedObject = definedObjects.Count() == 1 ? definedObjects.Single() : null;
+
+        return new References(definedObject ?? referencedObject, new[] { definedObject!, referencedObject! }
+            .Where(o => o != null)
+            .SelectMany(objet => objet switch
+            {
+                Class classe => new[] { (Reference: classe.Name.GetLocation()!, File: classe.GetFile()!) }
+                    .Concat(modelStore.GetClassReferences(classe).Select(c => (Reference: (Reference)c.Reference, c.File))),
+                Domain domain => new[] { (Reference: domain.Name.GetLocation()!, File: domain.GetFile()!) }
+                    .Concat(modelStore.GetDomainReferences(domain).Select(d => (Reference: (Reference)d.Reference, d.File))),
+                Decorator decorator => new[] { (Reference: decorator.Name.GetLocation()!, File: decorator.GetFile()!) }
+                    .Concat(modelStore.GetDecoratorReferences(decorator).Select(d => (Reference: (Reference)d.Reference, d.File))),
+                IProperty property => new[] { (Reference: property.GetLocation()!, File: property.GetFile()!) }
+                    .Concat(modelStore.GetPropertyReferences(property).Select(d => (d.Reference, d.File))),
+                _ => null!
+            })
+            .Distinct());
+    }
+
+    public static string? GetName(this object objet)
+    {
         return objet switch
         {
-            Class classe => new[] { (Reference: classe.Name.GetLocation()!, File: classe.GetFile()!) }
-                .Concat(modelStore.GetClassReferences(classe).Select(c => (Reference: (Reference)c.Reference, c.File))),
-            Domain domain => new[] { (Reference: domain.Name.GetLocation()!, File: domain.GetFile()!) }
-                .Concat(modelStore.GetDomainReferences(domain).Select(d => (Reference: (Reference)d.Reference, d.File))),
-            Decorator decorator => new[] { (Reference: decorator.Name.GetLocation()!, File: decorator.GetFile()!) }
-                .Concat(modelStore.GetDecoratorReferences(decorator).Select(d => (Reference: (Reference)d.Reference, d.File))),
+            Class classe => classe.Name,
+            Domain domain => domain.Name,
+            Decorator decorator => decorator.Name,
+            AliasProperty property => property.OriginalProperty?.Name ?? property.Name,
+            IProperty property => property.Name,
             _ => null
         };
     }

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -24,7 +24,7 @@ public static class OmnisharpExtensions
     }
 
 
-    public static References? GetReferencesForPositionInFile(this ModelStore modelStore, Position position, ModelFile file)
+    public static References? GetReferencesForPositionInFile(this ModelStore modelStore, Position position, ModelFile file, bool includeTransitive = false)
     {
         object? referencedObject = null;
 
@@ -55,7 +55,7 @@ public static class OmnisharpExtensions
                 Decorator decorator => new[] { (Reference: decorator.Name.GetLocation()!, File: decorator.GetFile()!) }
                     .Concat(modelStore.GetDecoratorReferences(decorator).Select(d => (Reference: (Reference)d.Reference, d.File))),
                 IProperty property => new[] { (Reference: property.GetLocation()!, File: property.GetFile()!) }
-                    .Concat(modelStore.GetPropertyReferences(property).Select(d => (d.Reference, d.File))),
+                    .Concat(modelStore.GetPropertyReferences(property, includeTransitive).Select(d => (d.Reference, d.File))),
                 _ => null!
             })
             .Distinct());

--- a/TopModel.LanguageServer/References.cs
+++ b/TopModel.LanguageServer/References.cs
@@ -1,0 +1,15 @@
+﻿#nullable disable
+
+using TopModel.Core.FileModel;
+
+namespace TopModel.LanguageServer;
+
+public class References : List<(Reference Reference, ModelFile File)>
+{
+    public References(object objet, IEnumerable<(Reference Reference, ModelFile File)> enumerable) : base(enumerable)
+    {
+        Objet = objet;
+    }
+
+    public object Objet { get; }
+}

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -25,7 +25,7 @@ public class RenameHandler : RenameHandlerBase
         var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
         if (file != null)
         {
-            var references = _modelStore.GetReferencesForPositionInFile(request.Position, file);
+            var references = _modelStore.GetReferencesForPositionInFile(request.Position, file, true);
             if (references != null && references.All(r => r.Reference.ReferenceName == references.Objet.GetName() || r.Reference is ClassReference))
             {
                 return Task.FromResult<WorkspaceEdit?>(new WorkspaceEdit

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -3,6 +3,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
+using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
@@ -25,11 +26,12 @@ public class RenameHandler : RenameHandlerBase
         if (file != null)
         {
             var references = _modelStore.GetReferencesForPositionInFile(request.Position, file);
-            if (references != null)
+            if (references != null && references.All(r => r.Reference.ReferenceName == references.Objet.GetName() || r.Reference is ClassReference))
             {
-                return Task.FromResult<WorkspaceEdit?>(new WorkspaceEdit()
+                return Task.FromResult<WorkspaceEdit?>(new WorkspaceEdit
                 {
                     Changes = references
+                        .Where(r => r.Reference.ReferenceName == references.Objet.GetName())
                         .Select(r => new Location { Uri = new Uri(_facade.GetFilePath(r.File)), Range = r.Reference.ToRange()! })
                         .Select(c => new
                         {


### PR DESCRIPTION
Fix #9 
Traite partiellement #10

Il est désormais possible de faire "Find All References" sur les propriétés, depuis n'importe quelle référence, pour avoir la liste exhaustive des références directes vers une propriété. Une propriété référencée indirectement (alias d'alias par exemple) ne sera pas listée, puisque ce n'est pas la même propriété. Les références de propriétés sur un `exclude` sont bien listées, malgré le fait que la propriété n'existe pas sur la classe cible, et les `include` implicites sont "redirigés" vers la référence de la classe de l'alias.

Certaines localisations peuvent donc maintenant référencer deux objets en même temps : 
- La définition d'une association est à la fois une référence vers la classe associée et une référence vers la propriété déclarée
- La définition d'un alias est à la fois une référence vers la propriété aliasée et une référence vers la propriété déclarée

Dans ce cas, les références des deux objets seront listées et mélangées dans le résultat de la requête.

Le renommage des propriétés a aussi été partiellement implémenté. A l'inverse du listing des références, le renommage agit également sur les références indirectes : renommer un alias d'alias va renommer la propriété initiale, et inversement. En revanche, le renommage échouera si toutes les références n'ont pas le même nom (à cause d'une référence qui utilise un préfixe ou suffixe d'alias par exemple).

L'issue #10 reste donc ouverte pour lever cette limitation, au moins dans le sens "parent" => "enfant" où il est facile de recalculer le nom de la propriété après renommage (dans l'autre sens il faudrait vérifier que le nom choisi corresponde aux différents préfixes et suffixes, ce qui semble loin d'être immédiat, d'autant plus que la fonctionnalité n'a à priori pas beaucoup de valeur). On traitera aussi par la même occasion le renommage de classe qui ne renomme pas les alias vers une association, puisque c'est un peu le même problème.