### PR TITLE
Surcharge de domaine dans un alias

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -46,7 +46,8 @@ public class ModelFile
         .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[]
         {
             (p.Reference, p.OriginalProperty?.Class),
-            (p.PropertyReference, p.OriginalProperty)
+            (p.PropertyReference, p.OriginalProperty),
+            (p.DomainReference, p.Domain)
         }))
         .Concat(Properties.OfType<AliasProperty>()
             .SelectMany(p => p?.Reference?.ExcludeReferences?

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -228,6 +228,9 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                         case "label":
                             alp.Label = value.Value;
                             break;
+                        case "domain":
+                            alp.DomainReference = new DomainReference(value);
+                            break;
                         case "required":
                             alp.Required = value.Value == "true";
                             break;

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -58,7 +58,12 @@ public class AliasProperty : IFieldProperty
 #nullable disable
     public Domain Domain
     {
-        get => _domain ?? (AsList ? _property?.Domain?.ListDomain : _property?.Domain);
+        get
+        {
+            var domain = _domain ?? _property?.Domain;
+            return AsList ? domain?.ListDomain : domain;
+        }
+
         set => _domain = value;
     }
 #nullable enable

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -6,6 +6,7 @@ public class AliasProperty : IFieldProperty
 {
     private string? _comment;
     private string? _defaultValue;
+    private Domain? _domain;
     private string? _label;
     private bool? _required;
 
@@ -55,8 +56,14 @@ public class AliasProperty : IFieldProperty
     }
 
 #nullable disable
-    public Domain Domain => AsList ? _property?.Domain?.ListDomain : _property?.Domain;
+    public Domain Domain
+    {
+        get => _domain ?? (AsList ? _property?.Domain?.ListDomain : _property?.Domain);
+        set => _domain = value;
+    }
 #nullable enable
+
+    public DomainReference? DomainReference { get; set; }
 
     public string Comment
     {
@@ -110,6 +117,11 @@ public class AliasProperty : IFieldProperty
             UseLegacyRoleName = UseLegacyRoleName
         };
 
+        if (_domain != null)
+        {
+            alp.Domain = _domain;
+        }
+
         if (_required.HasValue)
         {
             alp.Required = _required.Value;
@@ -133,6 +145,7 @@ public class AliasProperty : IFieldProperty
             PropertyReference = includeReference,
             Class = Class,
             Decorator = Decorator,
+            DomainReference = DomainReference,
             Endpoint = Endpoint,
             Prefix = Prefix,
             Suffix = Suffix,
@@ -143,6 +156,11 @@ public class AliasProperty : IFieldProperty
             OriginalAliasProperty = this,
             UseLegacyRoleName = UseLegacyRoleName
         };
+
+        if (_domain != null)
+        {
+            alp.Domain = _domain;
+        }
 
         if (_required.HasValue)
         {

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -84,12 +84,14 @@ public static class ModelExtensions
             .Concat(modelStore.Endpoints.SelectMany(e => e.Properties))
             .Where(p =>
                 p is RegularProperty rp && rp.Domain == domain
+                || p is AliasProperty alp && alp.DomainReference != null && alp.Domain == domain
                 || p is CompositionProperty cp && cp.DomainKind == domain)
             .Select(p =>
             {
                 return (Reference: p switch
                 {
                     RegularProperty rp => rp.DomainReference,
+                    AliasProperty alp => alp.DomainReference!,
                     CompositionProperty cp => cp.DomainKindReference!,
                     _ => null! // Impossible
                 }, File: p.GetFile());

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -237,6 +237,10 @@
                 }
               ]
             },
+            "domain": {
+              "type": "string",
+              "description": "Surcharge le domaine de la propriété aliasée. Le domaine choisi doit être convertible depuis/vers le domaine initial. Incompatible avec 'asList'."
+            },
             "label": {
               "type": "string",
               "description": "Surcharge le libellé de la propriété aliasée."
@@ -251,7 +255,7 @@
             },
             "asList": {
               "type": "boolean",
-              "description": "Crée une liste du type de la propriété aliasée au lieu d'un champ simple."
+              "description": "Crée une liste du type de la propriété aliasée au lieu d'un champ simple. Incompatible avec 'domain'."
             },
             "defaultValue": {
               "description": "Surcharge la valeur par défaut de la propriété."

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -239,7 +239,7 @@
             },
             "domain": {
               "type": "string",
-              "description": "Surcharge le domaine de la propriété aliasée. Le domaine choisi doit être convertible depuis/vers le domaine initial. Incompatible avec 'asList'."
+              "description": "Surcharge le domaine de la propriété aliasée."
             },
             "label": {
               "type": "string",
@@ -255,7 +255,7 @@
             },
             "asList": {
               "type": "boolean",
-              "description": "Crée une liste du type de la propriété aliasée au lieu d'un champ simple. Incompatible avec 'domain'."
+              "description": "Utilise le `listDomain` du domaine de la propriété (original ou surchargé) comme domaine de la propriété d'alias."
             },
             "defaultValue": {
               "description": "Surcharge la valeur par défaut de la propriété."


### PR DESCRIPTION
Il est désormais possible de spécifier une surcharge de domaine dans un alias (via la propriété `domain`), au même titre que la plupart des propriétés de la propriété originale.

Il n'y a pas de contrainte particulière sur le domaine qui remplace, mais s'il n'est pas convertible vers le domaine original aucun mapping ne pourra être généré entre les deux champs.

La fonctionnalité est également compatible avec `asList: true` : le domaine de l'alias sera donc le `listDomain` du domaine spécifié.