### PR TITLE
`tagConfigOverrides` et implé pour le générateur JS

### DIFF
--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -377,6 +377,26 @@
               "description": "Catégorie de fichier que le générateur doit lire."
             }
           },
+          "tagConfigOverrides": {
+            "type": "object",
+            "description": "Surcharge par tag du token {tag} pour les différents paramètres du générateur.",
+            "patternProperties": {
+              ".*": {
+                "type": "object",
+                "properties": {
+                  "modelRootPath": {
+                    "type": "string"
+                  },
+                  "resourceRootPath": {
+                    "type": "string"
+                  },
+                  "apiClientRootPath": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
           "outputDirectory": {
             "type": "string",
             "description": "Racine du répertoire de génération."

--- a/TopModel.Generator/CSharp/CSharpApiClientGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpApiClientGenerator.cs
@@ -6,7 +6,7 @@ using TopModel.Utils;
 
 namespace TopModel.Generator.CSharp;
 
-public class CSharpApiClientGenerator : GeneratorBase
+public class CSharpApiClientGenerator : GeneratorBase<object>
 {
     private readonly CSharpConfig _config;
     private readonly ILogger<CSharpApiClientGenerator> _logger;

--- a/TopModel.Generator/CSharp/CSharpApiServerGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpApiServerGenerator.cs
@@ -10,7 +10,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace TopModel.Generator.CSharp;
 
-public class CSharpApiServerGenerator : GeneratorBase
+public class CSharpApiServerGenerator : GeneratorBase<object>
 {
     private readonly CSharpConfig _config;
     private readonly ILogger<CSharpApiServerGenerator> _logger;

--- a/TopModel.Generator/CSharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpClassGenerator.cs
@@ -7,7 +7,7 @@ namespace TopModel.Generator.CSharp;
 
 using static CSharpUtils;
 
-public class CSharpClassGenerator : GeneratorBase
+public class CSharpClassGenerator : GeneratorBase<object>
 {
     private readonly CSharpConfig _config;
     private readonly ILogger<CSharpClassGenerator> _logger;

--- a/TopModel.Generator/CSharp/CSharpConfig.cs
+++ b/TopModel.Generator/CSharp/CSharpConfig.cs
@@ -6,7 +6,7 @@ namespace TopModel.Generator.CSharp;
 /// <summary>
 /// Paramètres pour la génération du C#.
 /// </summary>
-public class CSharpConfig : GeneratorConfigBase
+public class CSharpConfig : GeneratorConfigBase<object>
 {
     private string? _referencesModelPath;
 

--- a/TopModel.Generator/CSharp/DbContextGenerator.cs
+++ b/TopModel.Generator/CSharp/DbContextGenerator.cs
@@ -4,7 +4,7 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.Generator.CSharp;
 
-public class DbContextGenerator : GeneratorBase
+public class DbContextGenerator : GeneratorBase<object>
 {
     private readonly string _appName;
     private readonly CSharpConfig _config;

--- a/TopModel.Generator/CSharp/MapperGenerator.cs
+++ b/TopModel.Generator/CSharp/MapperGenerator.cs
@@ -4,7 +4,7 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.Generator.CSharp;
 
-public class MapperGenerator : GeneratorBase
+public class MapperGenerator : GeneratorBase<object>
 {
     private readonly CSharpConfig _config;
     private readonly ILogger<MapperGenerator> _logger;

--- a/TopModel.Generator/CSharp/ReferenceAccessorGenerator.cs
+++ b/TopModel.Generator/CSharp/ReferenceAccessorGenerator.cs
@@ -4,7 +4,7 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.Generator.CSharp;
 
-public class ReferenceAccessorGenerator : GeneratorBase
+public class ReferenceAccessorGenerator : GeneratorBase<object>
 {
     private readonly CSharpConfig _config;
     private readonly ILogger<ReferenceAccessorGenerator> _logger;

--- a/TopModel.Generator/GeneratorBase.cs
+++ b/TopModel.Generator/GeneratorBase.cs
@@ -4,12 +4,12 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.Generator;
 
-public abstract class GeneratorBase : IModelWatcher
+public abstract class GeneratorBase<T> : IModelWatcher
 {
-    private readonly GeneratorConfigBase _config;
+    private readonly GeneratorConfigBase<T> _config;
     private readonly ILogger _logger;
 
-    protected GeneratorBase(ILogger logger, GeneratorConfigBase config)
+    protected GeneratorBase(ILogger logger, GeneratorConfigBase<T> config)
     {
         _config = config;
         _logger = logger;

--- a/TopModel.Generator/GeneratorConfigBase.cs
+++ b/TopModel.Generator/GeneratorConfigBase.cs
@@ -1,7 +1,7 @@
 ﻿#nullable disable
 namespace TopModel.Generator;
 
-public abstract class GeneratorConfigBase
+public abstract class GeneratorConfigBase<T>
 {
     /// <summary>
     /// Racine du répertoire de génération.
@@ -12,4 +12,29 @@ public abstract class GeneratorConfigBase
     /// Tags du générateur.
     /// </summary>
     public IList<string> Tags { get; set; }
+
+    /// <summary>
+    /// Surcharge par tag du token {tag} pour les différents paramètres du générateur.
+    /// </summary>
+    public Dictionary<string, T> TagConfigOverrides { get; set; } = new();
+
+    /// <summary>
+    /// Récupère la valeur du token {tag} pour une propriété donnée.
+    /// </summary>
+    /// <param name="tag">Valeur du tag.</param>
+    /// <param name="property">Propriété.</param>
+    /// <returns>Valeur.</returns>
+    public string GetTagValue(string tag, Func<T, string> property)
+    {
+        if (TagConfigOverrides.TryGetValue(tag, out var value))
+        {
+            var tagOverride = property(value);
+            if (tagOverride != null)
+            {
+                return tagOverride;
+            }
+        }
+
+        return tag;
+    }
 }

--- a/TopModel.Generator/Javascript/AngularApiClientGenerator.cs
+++ b/TopModel.Generator/Javascript/AngularApiClientGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Javascript;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class AngularApiClientGenerator : GeneratorBase
+public class AngularApiClientGenerator : GeneratorBase<JavascriptTagConfig>
 {
     private readonly JavascriptConfig _config;
     private readonly ILogger<AngularApiClientGenerator> _logger;

--- a/TopModel.Generator/Javascript/JavascriptApiClientGenerator.cs
+++ b/TopModel.Generator/Javascript/JavascriptApiClientGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Javascript;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class JavascriptApiClientGenerator : GeneratorBase
+public class JavascriptApiClientGenerator : GeneratorBase<JavascriptTagConfig>
 {
     private readonly JavascriptConfig _config;
     private readonly ILogger<JavascriptApiClientGenerator> _logger;

--- a/TopModel.Generator/Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator/Javascript/JavascriptConfig.cs
@@ -7,7 +7,7 @@ namespace TopModel.Generator.Javascript;
 /// <summary>
 /// Paramètres pour la génération du Javascript.
 /// </summary>
-public class JavascriptConfig : GeneratorConfigBase
+public class JavascriptConfig : GeneratorConfigBase<JavascriptTagConfig>
 {
     /// <summary>
     /// Localisation du modèle, relative au répertoire de génération. Si non renseigné, aucun fichier ne sera généré.
@@ -56,7 +56,7 @@ public class JavascriptConfig : GeneratorConfigBase
 
     public string GetClassFileName(Class classe, string tag)
     {
-        var rootPath = Path.Combine(OutputDirectory, ModelRootPath!.Replace("{tag}", tag.ToKebabCase())).Replace("\\", "/");
+        var rootPath = Path.Combine(OutputDirectory, ModelRootPath!.Replace("{tag}", GetTagValue(tag, c => c.ModelRootPath).ToKebabCase())).Replace("\\", "/");
         return $"{rootPath}/{string.Join('/', classe.Namespace.Module.Split('.').Select(m => m.ToKebabCase()))}/{classe.Name.ToDashCase()}.ts";
     }
 
@@ -87,7 +87,7 @@ public class JavascriptConfig : GeneratorConfigBase
         var modulePath = Path.Combine(file.Module.Split('.').Select(m => m.ToKebabCase()).ToArray());
         var filePath = ApiClientFilePath.Replace("{module}", modulePath);
         var fileName = file.Options.Endpoints.FileName.ToKebabCase();
-        return Path.Combine(OutputDirectory, ApiClientRootPath!.Replace("{tag}", tag.ToKebabCase()), filePath, $"{fileName}.ts").Replace("\\", "/");
+        return Path.Combine(OutputDirectory, ApiClientRootPath!.Replace("{tag}", GetTagValue(tag, c => c.ApiClientRootPath).ToKebabCase()), filePath, $"{fileName}.ts").Replace("\\", "/");
     }
 
     public List<(string Import, string Path)> GetEndpointImports(IEnumerable<ModelFile> files, string tag, IEnumerable<Class> availableClasses)
@@ -147,12 +147,12 @@ public class JavascriptConfig : GeneratorConfigBase
 
     public string GetReferencesFileName(string module, string tag)
     {
-        var rootPath = Path.Combine(OutputDirectory, ModelRootPath!.Replace("{tag}", tag.ToKebabCase())).Replace("\\", "/");
+        var rootPath = Path.Combine(OutputDirectory, ModelRootPath!.Replace("{tag}", GetTagValue(tag, c => c.ModelRootPath).ToKebabCase())).Replace("\\", "/");
         return $"{rootPath}/{string.Join('/', module.Split('.').Select(m => m.ToKebabCase()))}/references.ts";
     }
 
     public string GetResourcesFilePath(string module, string tag, string lang)
     {
-        return Path.Combine(OutputDirectory, ResourceRootPath!.Replace("{tag}", tag.ToKebabCase()), lang, Path.Combine(module.Split(".").Select(part => part.ToKebabCase()).ToArray())) + (ResourceMode == ResourceMode.JS ? ".ts" : ".json");
+        return Path.Combine(OutputDirectory, ResourceRootPath!.Replace("{tag}", GetTagValue(tag, c => c.ResourceRootPath).ToKebabCase()), lang, Path.Combine(module.Split(".").Select(part => part.ToKebabCase()).ToArray())) + (ResourceMode == ResourceMode.JS ? ".ts" : ".json");
     }
 }

--- a/TopModel.Generator/Javascript/JavascriptResourceGenerator.cs
+++ b/TopModel.Generator/Javascript/JavascriptResourceGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Javascript;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class JavascriptResourceGenerator : GeneratorBase
+public class JavascriptResourceGenerator : GeneratorBase<JavascriptTagConfig>
 {
     private readonly JavascriptConfig _config;
     private readonly ILogger<JavascriptResourceGenerator> _logger;

--- a/TopModel.Generator/Javascript/JavascriptTagConfig.cs
+++ b/TopModel.Generator/Javascript/JavascriptTagConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace TopModel.Generator.Javascript;
+
+public class JavascriptTagConfig
+{
+    public string? ModelRootPath { get; set; }
+
+    public string? ResourceRootPath { get; set; }
+
+    public string? ApiClientRootPath { get; set; }
+}

--- a/TopModel.Generator/Javascript/TypescriptDefinitionGenerator.cs
+++ b/TopModel.Generator/Javascript/TypescriptDefinitionGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Javascript;
 /// <summary>
 /// Générateur de définitions Typescript.
 /// </summary>
-public class TypescriptDefinitionGenerator : GeneratorBase
+public class TypescriptDefinitionGenerator : GeneratorBase<JavascriptTagConfig>
 {
     private readonly JavascriptConfig _config;
     private readonly ILogger<TypescriptDefinitionGenerator> _logger;

--- a/TopModel.Generator/Jpa/Config/JpaConfig.cs
+++ b/TopModel.Generator/Jpa/Config/JpaConfig.cs
@@ -2,7 +2,7 @@
 
 namespace TopModel.Generator.Jpa;
 
-public class JpaConfig : GeneratorConfigBase
+public class JpaConfig : GeneratorConfigBase<object>
 {
     /// <summary>
     /// Localisation du modèle, relative au répertoire de génération.

--- a/TopModel.Generator/Jpa/JpaDaoGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaDaoGenerator.cs
@@ -7,7 +7,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur de DAOs JPA.
 /// </summary>
-public class JpaDaoGenerator : GeneratorBase
+public class JpaDaoGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<JpaDaoGenerator> _logger;

--- a/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelGenerator/JpaModelGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur de fichiers de modèles JPA.
 /// </summary>
-public class JpaModelGenerator : GeneratorBase
+public class JpaModelGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<JpaModelGenerator> _logger;

--- a/TopModel.Generator/Jpa/JpaModelInterfaceGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaModelInterfaceGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur de DAOs JPA.
 /// </summary>
-public class JpaModelInterfaceGenerator : GeneratorBase
+public class JpaModelInterfaceGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<JpaModelInterfaceGenerator> _logger;

--- a/TopModel.Generator/Jpa/JpaResourceGenerator.cs
+++ b/TopModel.Generator/Jpa/JpaResourceGenerator.cs
@@ -9,7 +9,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class JpaResourceGenerator : GeneratorBase
+public class JpaResourceGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<JpaResourceGenerator> _logger;

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class SpringClientApiGenerator : GeneratorBase
+public class SpringClientApiGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<SpringClientApiGenerator> _logger;

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringServerApiGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class SpringServerApiGenerator : GeneratorBase
+public class SpringServerApiGenerator : GeneratorBase<object>
 {
     private readonly JpaConfig _config;
     private readonly ILogger<SpringServerApiGenerator> _logger;

--- a/TopModel.Generator/ProceduralSql/ProceduralSqlConfig.cs
+++ b/TopModel.Generator/ProceduralSql/ProceduralSqlConfig.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Paramètres pour la génération de SQL procédural.
 /// </summary>
-public class ProceduralSqlConfig : GeneratorConfigBase
+public class ProceduralSqlConfig : GeneratorConfigBase<object>
 {
     /// <summary>
     /// SGBD cible ("postgre" ou "sqlserver").

--- a/TopModel.Generator/ProceduralSql/ProceduralSqlGenerator.cs
+++ b/TopModel.Generator/ProceduralSql/ProceduralSqlGenerator.cs
@@ -5,7 +5,7 @@ using TopModel.Utils;
 
 namespace TopModel.Generator.ProceduralSql;
 
-public class ProceduralSqlGenerator : GeneratorBase
+public class ProceduralSqlGenerator : GeneratorBase<object>
 {
     private readonly ProceduralSqlConfig _config;
     private readonly ILogger<ProceduralSqlGenerator> _logger;

--- a/TopModel.Generator/Ssdt/SsdtConfig.cs
+++ b/TopModel.Generator/Ssdt/SsdtConfig.cs
@@ -5,7 +5,7 @@ namespace TopModel.Generator.Ssdt;
 /// <summary>
 /// Paramètres pour la génération SSDT.
 /// </summary>
-public class SsdtConfig : GeneratorConfigBase
+public class SsdtConfig : GeneratorConfigBase<object>
 {
     /// <summary>
     /// Dossier du projet pour les scripts de déclaration de table.

--- a/TopModel.Generator/Ssdt/SsdtGenerator.cs
+++ b/TopModel.Generator/Ssdt/SsdtGenerator.cs
@@ -5,7 +5,7 @@ using TopModel.Generator.Ssdt.Scripter;
 
 namespace TopModel.Generator.Ssdt;
 
-public class SsdtGenerator : GeneratorBase
+public class SsdtGenerator : GeneratorBase<object>
 {
     private readonly SsdtConfig _config;
     private readonly ILogger<SsdtGenerator> _logger;

--- a/TopModel.Generator/Translation/TranslationConfig.cs
+++ b/TopModel.Generator/Translation/TranslationConfig.cs
@@ -2,7 +2,7 @@
 
 namespace TopModel.Generator.Translation;
 
-public class TranslationConfig : GeneratorConfigBase
+public class TranslationConfig : GeneratorConfigBase<object>
 {
     /// <summary>
     /// liste des langues de l'application

--- a/TopModel.Generator/Translation/TranslationOutGenerator.cs
+++ b/TopModel.Generator/Translation/TranslationOutGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Translation;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class TranslationOutGenerator : GeneratorBase
+public class TranslationOutGenerator : GeneratorBase<object>
 {
     private readonly TranslationConfig _config;
 


### PR DESCRIPTION
Solution pour implémenter #138 sur les autres générateurs

La génération par tag a été implémentée sur le générateur JS en utilisant le placeholder `{tag}` dans les chemins de fichiers cibles (modèle, clients, traductions). Cette solution est satisfaisante, quoi que limitée par le fait qu'il faut utiliser le libellé du tag directement dans le chemin quelque part. En revanche, pour les autres usages de la fonctionnalité envisagées pour les générateurs C# et Java, l'utilisation directe du tag ne pourra pas vraiment fonctionner selon le même (en particulier pour "Client" et "Server" pour le mode de génération d'API).

La solution proposée consiste dp,c à ajouter, potentiellement à chaque générateur, une nouvelle section de configuration appelée `tagConfigOverrides`, qui permet pour chaque tag de **remplacer la valeur du placeholder `{tag}` pour un ou plusieurs paramètres**.

Par exemple : 
```yaml
- tags:
      - Interne
      - Externe
    tagConfigOverrides:
      Interne:
        modelRootPath: SpaInterne
      Externe:
        modelRootPath: SpaExterne
    outputDirectory: ../sources/front/src
    modelRootPath: "{tag}/model"
    resourceRootPath: "{tag}/locale"
    apiClientRootPath: "{tag}/services"
 ```

Pour la résolution du chemin de `modelRootPath`, le tag `Interne` sera `spa-interne/model` (au lieu de `interne-model`), alors que pour les deux autres ils seront toujours résolus comme `interne/locale` et `interne/services`. Si l'intégralité du chemin ou de la valeur du paramètre doit dépendre du tag, alors il suffit de mettre `{tag}` comme valeur et de définir pour chaque tag la valeur que l'on souhaite.

Cette solution évite de changer le format du fichier de config et n'oblige pas à spécifier les valeurs pour tous les tags si on en a pas besoin.