### PR TITLE
Génération des APIs Client/Server par tag

### DIFF
--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -304,6 +304,20 @@
               }
             }
           },
+          "tagVariables": {
+            "type": "object",
+            "description": "Définitions de variables par tag à utiliser dans les différents paramètres du générateur.",
+            "patternProperties": {
+              ".*": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
           "outputDirectory": {
             "type": "string",
             "description": "Racine du répertoire de génération."

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -565,6 +565,20 @@
               }
             }
           },
+          "tagVariables": {
+            "type": "object",
+            "description": "Définitions de variables par tag à utiliser dans les différents paramètres du générateur.",
+            "patternProperties": {
+              ".*": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
           "outputDirectory": {
             "type": "string",
             "description": "Racine du répertoire de génération."

--- a/TopModel.Generator/CSharp/CSharpConfig.cs
+++ b/TopModel.Generator/CSharp/CSharpConfig.cs
@@ -118,6 +118,13 @@ public class CSharpConfig : GeneratorConfigBase
     /// </summary>
     public bool UseEFComments { get; set; }
 
+    public override string[] PropertiesWithTagVariableSupport => new[]
+    {
+        nameof(ApiGeneration),
+        nameof(ApiRootPath),
+        nameof(ApiFilePath)
+    };
+
     /// <summary>
     /// Détermine si une classe utilise une enum pour sa clé primaire.
     /// </summary>

--- a/TopModel.Generator/CSharp/ServiceExtensions.cs
+++ b/TopModel.Generator/CSharp/ServiceExtensions.cs
@@ -41,15 +41,19 @@ public static class ServiceExtensions
                     new ReferenceAccessorGenerator(p.GetRequiredService<ILogger<ReferenceAccessorGenerator>>(), config) { Number = number });
             }
 
-            if (config.ApiGeneration == ApiGeneration.Server)
+            if (config.ApiGeneration != null)
             {
-                services.AddSingleton<IModelWatcher>(p =>
-                    new CSharpApiServerGenerator(p.GetRequiredService<ILogger<CSharpApiServerGenerator>>(), config) { Number = number });
-            }
-            else if (config.ApiGeneration == ApiGeneration.Client)
-            {
-                services.AddSingleton<IModelWatcher>(p =>
-                    new CSharpApiClientGenerator(p.GetRequiredService<ILogger<CSharpApiClientGenerator>>(), config) { Number = number });
+                if (config.ApiGeneration != ApiGeneration.Client)
+                {
+                    services.AddSingleton<IModelWatcher>(p =>
+                        new CSharpApiServerGenerator(p.GetRequiredService<ILogger<CSharpApiServerGenerator>>(), config) { Number = number });
+                }
+
+                if (config.ApiGeneration != ApiGeneration.Server)
+                {
+                    services.AddSingleton<IModelWatcher>(p =>
+                        new CSharpApiClientGenerator(p.GetRequiredService<ILogger<CSharpApiClientGenerator>>(), config) { Number = number });
+                }
             }
         });
 

--- a/TopModel.Generator/EndpointsGeneratorBase.cs
+++ b/TopModel.Generator/EndpointsGeneratorBase.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Core.FileModel;
+
+namespace TopModel.Generator;
+
+public abstract class EndpointsGeneratorBase : GeneratorBase
+{
+    private readonly GeneratorConfigBase _config;
+
+    public EndpointsGeneratorBase(ILogger<EndpointsGeneratorBase> logger, GeneratorConfigBase config)
+        : base(logger, config)
+    {
+        _config = config;
+    }
+
+    public override List<string> GeneratedFiles => EndpointsFiles
+        .SelectMany(file => _config.Tags.Intersect(file.Tags.Where(FilterTag)).Select(tag => GetFileName(file, tag)))
+        .Distinct()
+        .ToList();
+
+    private IEnumerable<ModelFile> EndpointsFiles => Files.Values
+        .Where(f => f.Tags.Any(FilterTag)
+            && f.Endpoints.Any(endpoint => endpoint.ModelFile == f || !Files.ContainsKey(endpoint.ModelFile.Name)));
+
+    protected abstract string GetFileName(ModelFile file, string tag);
+
+    protected abstract void HandleFile(string fileName, string tag, IEnumerable<ModelFile> files, IList<Endpoint> endpoints);
+
+    protected virtual bool FilterTag(string tag)
+    {
+        return true;
+    }
+
+    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    {
+        foreach (var file in files.Where(file => EndpointsFiles.Contains(file)).GroupBy(file => new { file.Options.Endpoints.FileName, file.Module }))
+        {
+            HandleFileBase(file.First(), file.SelectMany(f => f.Tags.Where(FilterTag)).Distinct());
+        }
+    }
+
+    private void HandleFileBase(ModelFile file, IEnumerable<string> tags)
+    {
+        foreach (var (tag, fileName) in _config.Tags.Intersect(tags)
+           .Select(tag => (tag, fileName: GetFileName(file, tag)))
+           .DistinctBy(t => t.fileName))
+        {
+            var files = Files.Values.Where(f => f.Options.Endpoints.FileName == file.Options.Endpoints.FileName && f.Module == file.Module && f.Tags.Contains(tag));
+            var endpoints = files
+                .SelectMany(f => f.Endpoints)
+                .OrderBy(e => e.Name, StringComparer.Ordinal)
+                .ToList();
+
+            HandleFile(fileName, tag, files, endpoints);
+        }
+    }
+}

--- a/TopModel.Generator/GeneratorConfigBase.cs
+++ b/TopModel.Generator/GeneratorConfigBase.cs
@@ -107,6 +107,17 @@ public abstract class GeneratorConfigBase
             }
         }
 
+        foreach (var tagVariables in TagVariables.Values)
+        {
+            foreach (var tagVarName in tagVariables.Keys)
+            {
+                foreach (var varName in GlobalVariableNames)
+                {
+                    tagVariables[tagVarName] = ReplaceVariable(tagVariables[tagVarName], varName, Variables[varName]);
+                }
+            }
+        }
+
         if (hasMissingVar)
         {
             Console.WriteLine();

--- a/TopModel.Generator/Javascript/TypescriptDefinitionGenerator.cs
+++ b/TopModel.Generator/Javascript/TypescriptDefinitionGenerator.cs
@@ -426,6 +426,7 @@ public class TypescriptDefinitionGenerator : GeneratorBase
 
                 fw.WriteLine("\r\n}");
             }
+
             if (reference.Reference)
             {
                 fw.Write("export interface ");

--- a/TopModel.Generator/Jpa/Config/JpaConfig.cs
+++ b/TopModel.Generator/Jpa/Config/JpaConfig.cs
@@ -75,4 +75,11 @@ public class JpaConfig : GeneratorConfigBase
     {
         Mode = IdentityMode.IDENTITY
     };
+
+    public override string[] PropertiesWithTagVariableSupport => new[]
+    {
+        nameof(ApiGeneration),
+        nameof(ApiRootPath),
+        nameof(ApiPackageName)
+    };
 }

--- a/TopModel.Generator/Jpa/ServiceExtensions.cs
+++ b/TopModel.Generator/Jpa/ServiceExtensions.cs
@@ -39,15 +39,16 @@ public static class ServiceExtensions
                         new JpaResourceGenerator(p.GetRequiredService<ILogger<JpaResourceGenerator>>(), config, p.GetRequiredService<TranslationStore>()) { Number = number });
             }
 
-            if (config.ApiRootPath != null)
+            if (config.ApiRootPath != null && config.ApiGeneration != null)
             {
-                if (config.ApiGeneration == ApiGeneration.Server)
+                if (config.ApiGeneration != ApiGeneration.Client)
                 {
                     services
                         .AddSingleton<IModelWatcher>(p =>
                             new SpringServerApiGenerator(p.GetRequiredService<ILogger<SpringServerApiGenerator>>(), config) { Number = number });
                 }
-                else if (config.ApiGeneration == ApiGeneration.Client)
+
+                if (config.ApiGeneration != ApiGeneration.Server)
                 {
                     services
                         .AddSingleton<IModelWatcher>(p =>

--- a/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
+++ b/TopModel.Generator/Jpa/SpringApiGenerator/SpringClientApiGenerator.cs
@@ -8,7 +8,7 @@ namespace TopModel.Generator.Jpa;
 /// <summary>
 /// Générateur des objets de traduction javascripts.
 /// </summary>
-public class SpringClientApiGenerator : GeneratorBase
+public class SpringClientApiGenerator : EndpointsGeneratorBase
 {
     private readonly JpaConfig _config;
     private readonly ILogger<SpringClientApiGenerator> _logger;
@@ -22,66 +22,32 @@ public class SpringClientApiGenerator : GeneratorBase
 
     public override string Name => "SpringApiClientGen";
 
-    public override IEnumerable<string> GeneratedFiles => Files.Values.Where(f => f.Endpoints.Any()).Select(f => GetFilePath(f.Options.Endpoints.FileName, f.Module)).Distinct();
-
-    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    protected override bool FilterTag(string tag)
     {
-        foreach (var file in files.GroupBy(file => new { file.Options.Endpoints.FileName, file.Module }))
-        {
-            GenerateClient(file.Key.FileName, file.Key.Module);
-        }
+        return _config.ResolveTagVariables(tag, _config.ApiGeneration) == ApiGeneration.Client;
     }
 
-    private string GetDestinationFolder(string module)
+    protected override string GetFileName(ModelFile file, string tag)
     {
-        return Path.Combine(_config.OutputDirectory, Path.Combine(_config.ApiRootPath!.ToLower().Split(".")), Path.Combine(_config.ApiPackageName.Split('.')), Path.Combine(module.ToLower().Split(".")));
+        return Path.Combine(GetDestinationFolder(file.Module, tag), $"{GetClassName(file.Options.Endpoints.FileName)}.java");
     }
 
-    private string GetClassName(string fileName)
+    protected override void HandleFile(string fileName, string tag, IEnumerable<ModelFile> files, IList<Endpoint> endpoints)
     {
-        return $"Abstract{fileName.ToPascalCase()}Client";
-    }
-
-    private string GetFileName(string fileName)
-    {
-        return $"{GetClassName(fileName)}.java";
-    }
-
-    private string GetFilePath(string fileName, string module)
-    {
-        return Path.Combine(GetDestinationFolder(module), GetFileName(fileName));
-    }
-
-    private void GenerateClient(string fileName, string module)
-    {
-        var files = Files.Values
-            .Where(file => file.Options.Endpoints.FileName == fileName && file.Module == module);
-
-        var endpoints = files
-            .SelectMany(file => file.Endpoints)
-            .OrderBy(endpoint => endpoint.Name, StringComparer.Ordinal)
-            .ToList();
-
-        if (!endpoints.Any() || _config.ApiRootPath == null)
-        {
-            return;
-        }
-
         foreach (var endpoint in endpoints)
         {
             CheckEndpoint(endpoint);
         }
 
-        var destFolder = GetDestinationFolder(module);
-        Directory.CreateDirectory(destFolder);
-        var packageName = $"{_config.ApiPackageName}.{module.ToLower()}";
-        using var fw = new JavaWriter($"{GetFilePath(fileName, module)}", _logger, packageName, null);
+        var className = GetClassName(files.First().Options.Endpoints.FileName);
+        var packageName = $"{_config.ResolveTagVariables(tag, _config.ApiPackageName)}.{files.First().Module.ToLower()}";
+        using var fw = new JavaWriter(fileName, _logger, packageName, null);
 
         WriteImports(files, fw);
         fw.WriteLine();
 
         fw.WriteLine("@Generated(\"TopModel : https://github.com/klee-contrib/topmodel\")");
-        fw.WriteLine($"public abstract class {GetClassName(fileName)} {{");
+        fw.WriteLine($"public abstract class {className} {{");
 
         fw.WriteLine();
 
@@ -93,26 +59,40 @@ public class SpringClientApiGenerator : GeneratorBase
         fw.WriteLine(1, " * @param restTemplate");
         fw.WriteLine(1, " * @param host");
         fw.WriteDocEnd(1);
-        fw.WriteLine(1, $"protected {GetClassName(fileName)}(RestTemplate restTemplate, String host) {{");
+        fw.WriteLine(1, $"protected {className}(RestTemplate restTemplate, String host) {{");
         fw.WriteLine(2, $"this.restTemplate = restTemplate;");
         fw.WriteLine(2, $"this.host = host;");
         fw.WriteLine(1, $"}}");
 
-        GetClassName(fileName);
         fw.WriteLine();
         fw.WriteDocStart(1, "Méthode de récupération des headers");
         fw.WriteLine(1, " * @return les headers à ajouter à la requête");
         fw.WriteDocEnd(1);
         fw.WriteLine(1, $"protected abstract HttpHeaders getHeaders();");
+
         foreach (var endpoint in endpoints)
         {
-            WriteEndPoint(fw, endpoint);
+            WriteEndpoint(fw, endpoint);
         }
 
         fw.WriteLine("}");
     }
 
-    private void WriteEndPoint(JavaWriter fw, Endpoint endpoint)
+    private string GetClassName(string fileName)
+    {
+        return $"Abstract{fileName.ToPascalCase()}Client";
+    }
+
+    private string GetDestinationFolder(string module, string tag)
+    {
+        return Path.Combine(
+            _config.OutputDirectory,
+            Path.Combine(_config.ResolveTagVariables(tag, _config.ApiRootPath!).ToLower().Split(".")),
+            Path.Combine(_config.ResolveTagVariables(tag, _config.ApiPackageName).Split('.')),
+            Path.Combine(module.ToLower().Split(".")));
+    }
+
+    private void WriteEndpoint(JavaWriter fw, Endpoint endpoint)
     {
         fw.WriteLine();
         WriteUriBuilderMethod(fw, endpoint);

--- a/samples/generators/csharp/src/Clients/CSharp.Clients.External/Securite/Utilisateur/generated/UtilisateurApiClient.cs
+++ b/samples/generators/csharp/src/Clients/CSharp.Clients.External/Securite/Utilisateur/generated/UtilisateurApiClient.cs
@@ -1,0 +1,160 @@
+﻿////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CSharp.Clients.Db.Models.Securite;
+using Models.CSharp.Utilisateur.Models;
+
+namespace Clients.CSharp.Clients.External.Securite.Utilisateur;
+
+/// <summary>
+/// Client Securite.Utilisateur.
+/// </summary>
+public partial class UtilisateurApiClient
+{
+    private readonly HttpClient _client;
+    private readonly JsonSerializerOptions _jsOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    /// <summary>
+    /// Constructeur.
+    /// </summary>
+    /// <param name="client">HttpClient injecté.</param>
+    public UtilisateurApiClient(HttpClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Recherche des utilisateurs.
+    /// </summary>
+    /// <param name="utiId">Id technique.</param>
+    /// <returns>Task.</returns>
+    public async Task deleteAll(int[] utiId = null)
+    {
+        await EnsureAuthentication();
+        var query = await new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+        }.Concat(Id?.Select(i => new KeyValuePair<string, string>("Id", i.ToString(CultureInfo.InvariantCulture))) ?? new Dictionary<string, string>())
+         .Where(kv => kv.Value != null)).ReadAsStringAsync();
+        using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"utilisateur/deleteAll?{query}"));
+        await EnsureSuccess(res);
+    }
+
+    /// <summary>
+    /// Charge le détail d'un utilisateur.
+    /// </summary>
+    /// <param name="utiId">Id technique.</param>
+    /// <returns>Le détail de l'utilisateur.</returns>
+    public async Task<UtilisateurDto> find(int utiId)
+    {
+        await EnsureAuthentication();
+        using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Get, $"utilisateur/{utiId}"), HttpCompletionOption.ResponseHeadersRead);
+        await EnsureSuccess(res);
+        return await Deserialize<UtilisateurDto>(res);
+    }
+
+    /// <summary>
+    /// Charge une liste d'utilisateurs par leur type.
+    /// </summary>
+    /// <param name="typeUtilisateurCode">Type d'utilisateur en Many to one.</param>
+    /// <returns>Liste des utilisateurs.</returns>
+    public async Task<IEnumerable<UtilisateurDto>> findAllByType(TypeUtilisateur.Codes typeUtilisateurCode = TypeUtilisateur.Codes.ADM)
+    {
+        await EnsureAuthentication();
+        var query = await new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["typeUtilisateurCode"] = typeUtilisateurCode?.ToString(CultureInfo.InvariantCulture),
+        }.Where(kv => kv.Value != null)).ReadAsStringAsync();
+        using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Get, $"utilisateur/list?{query}"), HttpCompletionOption.ResponseHeadersRead);
+        await EnsureSuccess(res);
+        return await Deserialize<IEnumerable<UtilisateurDto>>(res);
+    }
+
+    /// <summary>
+    /// Sauvegarde un utilisateur.
+    /// </summary>
+    /// <param name="utilisateur">Utilisateur à sauvegarder.</param>
+    /// <returns>Utilisateur sauvegardé.</returns>
+    public async Task<UtilisateurDto> save(UtilisateurDto utilisateur)
+    {
+        await EnsureAuthentication();
+        using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"utilisateur/save") { Content = GetBody(utilisateur) }, HttpCompletionOption.ResponseHeadersRead);
+        await EnsureSuccess(res);
+        return await Deserialize<UtilisateurDto>(res);
+    }
+
+    /// <summary>
+    /// Recherche des utilisateurs.
+    /// </summary>
+    /// <param name="utiId">Id technique.</param>
+    /// <param name="age">Age en années de l'utilisateur.</param>
+    /// <param name="profilId">Profil de l'utilisateur.</param>
+    /// <param name="email">Email de l'utilisateur.</param>
+    /// <param name="nom">Nom de l'utilisateur.</param>
+    /// <param name="typeUtilisateurCode">Type d'utilisateur en Many to one.</param>
+    /// <param name="dateCreation">Date de création de l'utilisateur.</param>
+    /// <param name="dateModification">Date de modification de l'utilisateur.</param>
+    /// <returns>Utilisateurs matchant les critères.</returns>
+    public async Task<ICollection<UtilisateurDto>> search(int? utiId = null, decimal age = 6l, int? profilId = null, string email = null, string nom = "Jabx", TypeUtilisateur.Codes typeUtilisateurCode = TypeUtilisateur.Codes.ADM, DateOnly? dateCreation = null, DateOnly? dateModification = null)
+    {
+        await EnsureAuthentication();
+        var query = await new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["utiId"] = utiId?.ToString(CultureInfo.InvariantCulture),
+            ["age"] = age?.ToString(CultureInfo.InvariantCulture),
+            ["profilId"] = profilId?.ToString(CultureInfo.InvariantCulture),
+            ["email"] = email,
+            ["nom"] = nom,
+            ["typeUtilisateurCode"] = typeUtilisateurCode?.ToString(CultureInfo.InvariantCulture),
+            ["dateCreation"] = dateCreation?.ToString(CultureInfo.InvariantCulture),
+            ["dateModification"] = dateModification?.ToString(CultureInfo.InvariantCulture),
+        }.Where(kv => kv.Value != null)).ReadAsStringAsync();
+        using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"utilisateur/search?{query}"), HttpCompletionOption.ResponseHeadersRead);
+        await EnsureSuccess(res);
+        return await Deserialize<ICollection<UtilisateurDto>>(res);
+    }
+
+    /// <summary>
+    /// Déserialize le contenu d'une réponse HTTP.
+    /// </summary>
+    /// <typeparam name="T">Type de destination.</typeparam>
+    /// <param name="response">Réponse HTTP.</param>
+    /// <returns>Contenu.</returns>
+    private async Task<T> Deserialize<T>(HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.NoContent)
+        {
+            return default;
+        }
+
+        using var res = await response.Content.ReadAsStreamAsync();
+        return await JsonSerializer.DeserializeAsync<T>(res, _jsOptions);
+    }
+
+    /// <summary>
+    /// Assure que l'authentification est configurée.
+    /// </summary>
+    private partial Task EnsureAuthentication();
+
+    /// <summary>
+    /// Gère les erreurs éventuelles retournées par l'API appelée.
+    /// </summary>
+    /// <param name="response">Réponse HTTP.</param>
+    private partial Task EnsureSuccess(HttpResponseMessage response);
+
+    /// <summary>
+    /// Récupère le body d'une requête pour l'objet donné.
+    /// </summary>
+    /// <typeparam name="T">Type source.</typeparam>
+    /// <param name="input">Entrée.</param>
+    /// <returns>Contenu.</returns>
+    private StringContent GetBody<T>(T input)
+    {
+        return new StringContent(JsonSerializer.Serialize(input, _jsOptions), Encoding.UTF8, "application/json");
+    }
+}

--- a/samples/generators/csharp/topmodel.config
+++ b/samples/generators/csharp/topmodel.config
@@ -5,15 +5,23 @@ lockFileName: csharp.topmodel.lock
 csharp:
   - tags:
       - back
+      - api-client
     variables:
       clientsDb: Clients/{app}.Clients.Db
+    tagVariables:
+      back:
+        apiGeneration: Server
+        apiRootPath: CSharp.Api
+      api-client:
+        apiGeneration: Client
+        apiRootPath: Clients/{app}.Clients.External
     outputDirectory: src
     dbContextPath: "{clientsDb}"
     persistantModelPath: "{clientsDb}/Models/{module}"
     persistantReferencesModelPath: Models/CSharp.{module}.Models
     nonPersistantModelPath: Models/CSharp.{module}.Models
-    apiRootPath: CSharp.Api
-    apiGeneration: Server
+    apiRootPath: "{apiRootPath}"
+    apiGeneration: "{apiGeneration}"
     enumsForStaticReferences: true
     useEFMigrations: true
     useEFComments: true

--- a/samples/generators/jpa/topmodel.config
+++ b/samples/generators/jpa/topmodel.config
@@ -5,8 +5,16 @@ lockFileName: translation.topmodel.lock
 jpa:
   - tags:
       - back
+      - api-client
     variables:
       rootPackageName: topmodel.jpa.sample.demo
+    tagVariables:
+      back:
+        apiGeneration: Server
+        apiPackageName: "{rootPackageName}.api.server"
+      api-client:
+        apiGeneration: Client
+        apiPackageName: "{rootPackageName}.api.client"
     outputDirectory: src/main
     modelRootPath: javagen
     daosPackageName: "{rootPackageName}.daos"
@@ -14,18 +22,8 @@ jpa:
     entitiesPackageName: "{rootPackageName}.entities"
     apiRootPath: javagen
     resourceRootPath: resources/i18n/model/{module}
-    apiPackageName: "{rootPackageName}.api.server"
-    apiGeneration: Server
+    apiPackageName: "{apiPackageName}"
+    apiGeneration: "{apiGeneration}"
     fieldsEnum: Persisted_Dto
     enumShortcutMode: false
-    persistenceMode: Jakarta
-  - tags:
-      - api-client
-    outputDirectory: src/main
-    modelRootPath: javagen
-    entitiesPackageName: topmodel.jpa.sample.demo.entities
-    dtosPackageName: topmodel.jpa.sample.demo.dtos
-    apiRootPath: javagen
-    apiPackageName: topmodel.jpa.sample.demo.api.client
-    apiGeneration: Client
     persistenceMode: Jakarta

--- a/samples/model/csharp.topmodel.lock
+++ b/samples/model/csharp.topmodel.lock
@@ -15,6 +15,7 @@ generatedFiles:
   - ../generators/csharp/src/Clients/CSharp.Clients.Db/Reference/generated/IUtilisateurReferenceAccessors.cs
   - ../generators/csharp/src/Clients/CSharp.Clients.Db/Reference/generated/SecuriteReferenceAccessors.cs
   - ../generators/csharp/src/Clients/CSharp.Clients.Db/Reference/generated/UtilisateurReferenceAccessors.cs
+  - ../generators/csharp/src/Clients/CSharp.Clients.External/Securite/Utilisateur/generated/UtilisateurApiClient.cs
   - ../generators/csharp/src/CSharp.Api/Controllers/Securite/Utilisateur/UtilisateurApiController.cs
   - ../generators/csharp/src/Models/CSharp.Securite.Models/generated/Droit.cs
   - ../generators/csharp/src/Models/CSharp.Securite.Models/generated/ProfilDto.cs


### PR DESCRIPTION
Encore un bout de #138

Côté C#, on peut utiliser des variables par tag pour `apiGeneration`, `apiRootPath` et `apiFilePath`.
Côté Java, c'est `apiGeneration`, `apiRootPath` et `apiPackageName`.

Ca marche comme l'implé en JS, d'ailleurs j'ai fait un `EndpointsGeneratorBase` pour mettre en commun la logique qui permet de trouver les fichiers à générer et avec quels endpoints (vu que la combinatoire n'est pas évidente et que c'est toujours la même chose...)

Ce n'est pas encore l'ensemble de ce qu'on voulait faire puisqu'il faudrait (au moins) gérer encore les classes, mappers, traductions, accesseurs de références... mais c'était probablement le plus important ;)