### PR TITLE
[C#/JS] Values pour clés uniques simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,43 @@
 # TopModel.Generator (`modgen`)
 
-## Prochaine version (1.24.0)
+## 1.24.0
 
-- [#218](https://github.com/klee-contrib/topmodel/pull/218) - [JPA] Classes abstraites et propriétés readonly
-  - Suppression de l'option `generateInterface` dans les décorateurs `java`
-  
-**Breaking change (JPA)** : Pour générer une interface, l'option `generateInterface` sur les décorateurs a été remplacée par la propriété `abstract: true` dans la classe, et ajouter l'attribut `readonly: true` sur toutes les propriétés.
+- Classes abstraites et propriétés readonly :
 
-- [#190](https://github.com/klee-contrib/topmodel/pull/190) - [Core + C#] Classes abstraites et propriétés readonly
+  - [#190](https://github.com/klee-contrib/topmodel/pull/190) - Core + C#
+  - [#218](https://github.com/klee-contrib/topmodel/pull/218) - JPA
 
-- [#212](https://github.com/klee-contrib/topmodel/pull/212) - Clarification utilisation de `values` et `enum`s explicites
+  **Breaking change (JPA)** : Pour générer une interface, l'option `generateInterface` sur les décorateurs a été retirée. Il est possible de faire la même chose via une classe abstraite (`abstract: true` dans la classe, et ajouter l'attribut `readonly: true` sur toutes les propriétés).
 
-  **Impacts génération** (ne devraient être des breaking changes, mais on sait jamais)
+- Évolutions sur `values` et `enum`s explicites :
 
-  - [C#] On ne génère plus de constantes pour les values avec PK autogénérée sur la clé d'unicité (puisqu'elle n'est plus demandée)
-  - [C#] L'annotation `DefaultProperty` n'est désormais placée sur sur les classes `reference`.
+  - [#212](https://github.com/klee-contrib/topmodel/pull/212) - Clarification utilisation de `values` et `enum`s explicites
+  - [#219](https://github.com/klee-contrib/topmodel/pull/219) - [C#/JS] Values pour clés uniques simples
+
+  **Breaking changes (C#)** :
+
+  - Les constantes générées pour les values avec une clé d'unicité sont désormais suffixées du nom de la propriété.
+  - Avec `enumForStaticReferences: true`, on génère désormais une vraie enum pour les propriétés de classe enum qui ont une clé d'unicité simple.
+
+  **Autres impacts génération** (qui ne sont normalement pas des breaking changes)
+
+  - [C#]
+    - On génère des constantes pour toutes les clés d'unicité simple d'une classe si elle a des values et qu'on ne peut pas générer d'enum dessus (le cas enum est décrit dans le breaking change juste au-dessus)
+    - L'annotation `DefaultProperty` n'est désormais placée que sur les classes `reference`.
   - [JS] Dans `references.ts` :
     - Ne génère plus de type pour la PK si la classe n'est pas une `enum` (le type était auparavant un alias inutile vers le type de la PK)
     - Ne génère plus de définition de référence (le type + l'objet `{valueKey, labelKey}` ou la liste des valeurs) si la classe n'est pas une `reference`
+    - On génère un type pour les propriétés de classe enum qui ont une clé d'unicité simple.
 
 - [#208](https://github.com/klee-contrib/topmodel/pull/208) - Utilisation domain list pour oneToMany et ManyToMany
 
   **Breaking change (JPA)** : Les domaines de propriétés de PK utilisées dans des associations _one to many_ et _many to many_ doivent maintenant spécifier un `listDomain` correspondant
 
 - [#214](https://github.com/klee-contrib/topmodel/pull/214) - [JPA] Génération de mappers statiques
-  
+
   **Impacts génération (JPA)** : Les mappers sont désormais générés dans des classes statiques, qui sont ensuite appelés dans les constructeurs (mappers `from`) et dans les méthodes `to` (mappers `to`), qui contenaient au prélable les implémentations. Leurs signatures sont inchangées donc cela ne devrait avoir aucun impact sur leur utilisation.
+
+- [#217](https://github.com/klee-contrib/topmodel/pull/217) - Variables par tag pour traductions (JPA/TranslationOut) + DbContext/ReferenceAccessor en C#
 
 - [#196](https://github.com/klee-contrib/topmodel/pull/196) - [JPA] Valoriser le orderProperty dans les associations oneToMany et manyToMany
 
@@ -36,6 +48,8 @@
   **Breaking change (JPA)** : Pour les utilisateurs de la propriété `fieldsEnum: true`, remplacer `true` par `Persisted`.
 
 - [`81389b7`](https://github.com/klee-contrib/topmodel/commit/81389b71e90cecfa3d46bdb2afd0bce8eb103231) - [SSDT] Support pour oneToMany/manyToMany (idem proceduralSql)
+
+- [`354b869`](https://github.com/klee-contrib/topmodel/commit/354b8697d1f535539416ed33314319dfed76bffb) - **Impact génération** : [C#] Ce commit technique modifie le contenu du summary des clients d'API (d'un truc inutile vers un autre truc un peu moins inutile...).
 
 - [`be8f10e`](https://github.com/klee-contrib/topmodel/commit/be8f10e8dba8f3f5f7cb8a4c20f225d8f6b3ba3d) - [C#] Gestion oneToMany/manyToMany **minimale** (histoire que ça ne fasse pas d'erreurs de génération, mais ce n'est toujours pas, et ne sera jamais, géré par ce qu'on génère pour EF Core)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
     - Ne génère plus de définition de référence (le type + l'objet `{valueKey, labelKey}` ou la liste des valeurs) si la classe n'est pas une `reference`
     - On génère un type pour les propriétés de classe enum qui ont une clé d'unicité simple.
 
+  **Remarque** :
+
+  Si vous avez défini une clé d'unicité sur la PK, vous aurez probablement des choses générés en double, et qui peuvent avoir le même nom (les enums C#/unions TS en particulier). Il est inutile de déclarer une clé d'unicité sur une PK donc vous pouvez simplement la supprimer (peut être que topmodel devrait mettre une erreur dessus ?).
+
 - [#208](https://github.com/klee-contrib/topmodel/pull/208) - Utilisation domain list pour oneToMany et ManyToMany
 
   **Breaking change (JPA)** : Les domaines de propriétés de PK utilisées dans des associations _one to many_ et _many to many_ doivent maintenant spécifier un `listDomain` correspondant

--- a/TopModel.Core/Model/DependenciesExtensions.cs
+++ b/TopModel.Core/Model/DependenciesExtensions.cs
@@ -6,7 +6,7 @@ internal static class DependenciesExtensions
     {
         return properties.OfType<AssociationProperty>().Select(p => new ClassDependency(p.Association, p))
             .Concat(properties.OfType<AliasProperty>().Select(p => p.Property is AssociationProperty ap ? new ClassDependency(ap.Association, p) : null))
-            .Concat(properties.OfType<AliasProperty>().Select(p => p.Property == p.Property.Class.EnumKey ? new ClassDependency(p.Property.Class, p) : null))
+            .Concat(properties.OfType<AliasProperty>().Select(p => p.Property == p.Property.Class.EnumKey || p.Property.Class.UniqueKeys.Where(uk => uk.Count == 1).Select(uk => uk.Single()).Contains(p.Property) ? new ClassDependency(p.Property.Class, p) : null))
             .Concat(properties.OfType<CompositionProperty>().Where(p => p.Composition != currentClass).Select(p => new ClassDependency(p.Composition, p)))
             .Where(d => d != null)!;
     }

--- a/TopModel.Generator/CSharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpClassGenerator.cs
@@ -74,29 +74,6 @@ public class CSharpClassGenerator : GeneratorBase
     }
 
     /// <summary>
-    /// Génération des constantes statiques.
-    /// </summary>
-    /// <param name="w">Writer.</param>
-    /// <param name="item">La classe générée.</param>
-    private static void GenerateConstProperties(CSharpWriter w, Class item)
-    {
-        if (item.EnumKey != null)
-        {
-            foreach (var refValue in item.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
-            {
-                var code = refValue.Value[item.EnumKey];
-                var label = item.DefaultProperty != null
-                    ? refValue.Value[item.DefaultProperty]
-                    : refValue.Name;
-
-                w.WriteSummary(2, label);
-                w.WriteLine(2, string.Format("public const string {0} = \"{1}\";", refValue.Name, code));
-                w.WriteLine();
-            }
-        }
-    }
-
-    /// <summary>
     /// Génère les constructeurs.
     /// </summary>
     /// <param name="w">Writer.</param>
@@ -284,40 +261,6 @@ public class CSharpClassGenerator : GeneratorBase
     }
 
     /// <summary>
-    /// Génère l'enum pour les valeurs statiques de références.
-    /// </summary>
-    /// <param name="w">Writer.</param>
-    /// <param name="item">La classe générée.</param>
-    private static void GenerateEnumValues(CSharpWriter w, Class item)
-    {
-        w.WriteSummary(2, $"Valeurs possibles de la liste de référence {item}.");
-        w.WriteLine(2, $"public enum {item.EnumKey!.Name}s");
-        w.WriteLine(2, "{");
-
-        var refs = item.Values.OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
-        foreach (var refValue in refs)
-        {
-            var code = refValue.Value[item.EnumKey];
-
-            var label = item.DefaultProperty != null
-                ? refValue.Value[item.DefaultProperty]
-                : refValue.Name;
-
-            w.WriteSummary(3, label);
-            w.Write(3, code);
-
-            if (refs.IndexOf(refValue) != refs.Count - 1)
-            {
-                w.WriteLine(",");
-            }
-
-            w.WriteLine();
-        }
-
-        w.WriteLine(2, "}");
-    }
-
-    /// <summary>
     /// Génère les flags d'une liste de référence statique.
     /// </summary>
     /// <param name="w">Writer.</param>
@@ -352,6 +295,95 @@ public class CSharpClassGenerator : GeneratorBase
             w.WriteLine(2, "}");
             w.WriteLine();
             w.WriteLine(2, "#endregion");
+        }
+    }
+
+    /// <summary>
+    /// Génération des constantes statiques.
+    /// </summary>
+    /// <param name="w">Writer.</param>
+    /// <param name="item">La classe générée.</param>
+    private void GenerateConstProperties(CSharpWriter w, Class item)
+    {
+        foreach (var refValue in item.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            if (!_config.CanClassUseEnums(item) && item.EnumKey != null)
+            {
+                var code = refValue.Value[item.EnumKey];
+                var label = item.DefaultProperty != null
+                    ? refValue.Value[item.DefaultProperty]
+                    : refValue.Name;
+
+                w.WriteSummary(2, label);
+                w.WriteLine(2, $"public const string {refValue.Name} = \"{code}\";");
+                w.WriteLine();
+            }
+
+            foreach (var uk in item.UniqueKeys.Where(uk =>
+                uk.Count == 1
+                && uk.Single().Domain.CSharp!.Type == "string"
+                && refValue.Value.ContainsKey(uk.Single())))
+            {
+                var prop = uk.Single();
+
+                if (!_config.CanClassUseEnums(item, prop))
+                {
+                    var code = refValue.Value[prop];
+                    var label = item.DefaultProperty != null
+                        ? refValue.Value[item.DefaultProperty]
+                        : refValue.Name;
+
+                    w.WriteSummary(2, label);
+                    w.WriteLine(2, $"public const string {refValue.Name}{prop.Name} = \"{code}\";");
+                    w.WriteLine();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Génère l'enum pour les valeurs statiques de références.
+    /// </summary>
+    /// <param name="w">Writer.</param>
+    /// <param name="item">La classe générée.</param>
+    private void GenerateEnumValues(CSharpWriter w, Class item)
+    {
+        var refs = item.Values.OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
+
+        void WriteEnum(IFieldProperty prop)
+        {
+            w.WriteSummary(2, $"Valeurs possibles de la liste de référence {item}.");
+            w.WriteLine(2, $"public enum {prop}s");
+            w.WriteLine(2, "{");
+
+            foreach (var refValue in refs)
+            {
+                var code = refValue.Value[prop];
+
+                var label = item.DefaultProperty != null
+                    ? refValue.Value[item.DefaultProperty]
+                    : refValue.Name;
+
+                w.WriteSummary(3, label);
+                w.Write(3, code);
+
+                if (refs.IndexOf(refValue) != refs.Count - 1)
+                {
+                    w.WriteLine(",");
+                }
+
+                w.WriteLine();
+            }
+
+            w.WriteLine(2, "}");
+        }
+
+        WriteEnum(item.EnumKey!);
+
+        foreach (var uk in item.UniqueKeys.Where(uk => uk.Count == 1 && _config.CanClassUseEnums(item, uk.Single())))
+        {
+            w.WriteLine();
+            WriteEnum(uk.Single());
         }
     }
 
@@ -423,11 +455,7 @@ public class CSharpClassGenerator : GeneratorBase
                 extends,
                 implements);
 
-            if (!_config.CanClassUseEnums(item))
-            {
-                GenerateConstProperties(w, item);
-            }
-
+            GenerateConstProperties(w, item);
             GenerateConstructors(w, item);
 
             if (_config.DbContextPath == null && item.IsPersistent && !_config.NoPersistance)

--- a/TopModel.Generator/CSharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator/CSharp/CSharpClassGenerator.cs
@@ -305,18 +305,18 @@ public class CSharpClassGenerator : GeneratorBase
     /// <param name="item">La classe générée.</param>
     private void GenerateConstProperties(CSharpWriter w, Class item)
     {
-        foreach (var refValue in item.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
+        var consts = new List<(string Name, string Code, string Label)>();
+
+        foreach (var refValue in item.Values)
         {
+            var label = item.DefaultProperty != null
+                ? refValue.Value[item.DefaultProperty]
+                : refValue.Name;
+
             if (!_config.CanClassUseEnums(item) && item.EnumKey != null)
             {
                 var code = refValue.Value[item.EnumKey];
-                var label = item.DefaultProperty != null
-                    ? refValue.Value[item.DefaultProperty]
-                    : refValue.Name;
-
-                w.WriteSummary(2, label);
-                w.WriteLine(2, $"public const string {refValue.Name} = \"{code}\";");
-                w.WriteLine();
+                consts.Add((refValue.Name, code, label));
             }
 
             foreach (var uk in item.UniqueKeys.Where(uk =>
@@ -329,15 +329,16 @@ public class CSharpClassGenerator : GeneratorBase
                 if (!_config.CanClassUseEnums(item, prop))
                 {
                     var code = refValue.Value[prop];
-                    var label = item.DefaultProperty != null
-                        ? refValue.Value[item.DefaultProperty]
-                        : refValue.Name;
-
-                    w.WriteSummary(2, label);
-                    w.WriteLine(2, $"public const string {refValue.Name}{prop.Name} = \"{code}\";");
-                    w.WriteLine();
+                    consts.Add(($"{refValue.Name}{prop}", code, label));
                 }
             }
+        }
+
+        foreach (var @const in consts.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            w.WriteSummary(2, @const.Label);
+            w.WriteLine(2, $"public const string {@const.Name} = \"{@const.Code}\";");
+            w.WriteLine();
         }
     }
 

--- a/TopModel.Generator/CSharp/CSharpUtils.cs
+++ b/TopModel.Generator/CSharp/CSharpUtils.cs
@@ -207,10 +207,10 @@ public static class CSharpUtils
                 string _ when cp.DomainKind!.CSharp!.Type.Contains("{composition.name}") => cp.DomainKind.CSharp.Type.ParseTemplate(cp),
                 string _ => $"{cp.DomainKind.CSharp.Type}<{{composition.name}}>".ParseTemplate(cp)
             },
-            AssociationProperty { Association: var assoc } ap when config.CanClassUseEnums(assoc) => $"{assoc}.{assoc.EnumKey!.Name}s{(ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany ? "[]" : "?")}",
-            AliasProperty { Property: AssociationProperty { Association: var assoc } ap, AsList: var asList } when config.CanClassUseEnums(assoc) => $"{assoc}.{assoc.EnumKey!.Name}s{(asList || ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany ? "[]" : "?")}",
-            RegularProperty { PrimaryKey: true } when config.CanClassUseEnums(prop.Class) => $"{prop.Name}s?",
-            AliasProperty { Property: RegularProperty { PrimaryKey: true, Class: var alClass }, AsList: var asList } when config.CanClassUseEnums(alClass) => $"{alClass}.{alClass.EnumKey!.Name}s{(asList ? "[]" : "?")}",
+            AssociationProperty { Association: Class assoc } ap when config.CanClassUseEnums(assoc, ap.Property) => $"{assoc}.{ap.Property}s{(ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany ? "[]" : "?")}",
+            AliasProperty { Property: AssociationProperty { Association: Class assoc } ap, AsList: var asList } when config.CanClassUseEnums(assoc) => $"{assoc}.{ap.Property}s{(asList || ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany ? "[]" : "?")}",
+            RegularProperty { Class: Class classe } rp when config.CanClassUseEnums(classe, rp) => $"{rp}s?",
+            AliasProperty { Property: RegularProperty { Class: Class alClass } rp, AsList: var asList } when config.CanClassUseEnums(alClass, rp) => $"{alClass}.{rp}s{(asList ? "[]" : "?")}",
             IFieldProperty fp => fp.Domain.CSharp?.Type.ParseTemplate(fp) ?? string.Empty,
             _ => string.Empty
         };

--- a/TopModel.Generator/Javascript/TypescriptReferenceGenerator.cs
+++ b/TopModel.Generator/Javascript/TypescriptReferenceGenerator.cs
@@ -94,6 +94,15 @@ public class TypescriptReferenceGenerator : ClassGroupGeneratorBase
                 fw.Write($"{reference.EnumKey.Name} = ");
                 fw.Write(string.Join(" | ", reference.Values.Select(r => $@"""{r.Value[reference.EnumKey]}""").OrderBy(x => x, StringComparer.Ordinal)));
                 fw.WriteLine(";");
+
+                foreach (var uk in reference.UniqueKeys.Where(uk => uk.Count == 1 && uk.Single().Required).Select(uk => uk.Single()))
+                {
+                    fw.Write("export type ");
+                    fw.Write(reference.Name);
+                    fw.Write($"{uk} = ");
+                    fw.Write(string.Join(" | ", reference.Values.Select(r => $@"""{r.Value[uk]}""").OrderBy(x => x, StringComparer.Ordinal)));
+                    fw.WriteLine(";");
+                }
             }
 
             if (reference.FlagProperty != null)


### PR DESCRIPTION
Suite de l'issue #206 et de sa PR #212

Ces évolutions concernent ce qu'on génère pour des values dans le cas où il existe une (ou plusieurs) clé unique simple sur la classe : 
- En C# et en JS, si la classe est une enum et que la propriété est toujours renseignée dans les différentes `values`, alors on génère une "enum" supplémentaire pour cette propriété (enum `{classe}.{prop}s` en C#, et le type d'union `{classe}{prop}` en JS), et le type de la propriété (et de ses dérivés) est mise à jour en conséquence.
- En C#, si on ne peut pas générer d'enum, alors on génère des constantes `{classe}.{valueName}{prop}` pour toutes les valeurs renseignées dans `values`. Elles correspondent à ce qui était généré avant via la contrainte qui forçait à avoir une telle clé unique pour renseigner des values, mais le nom des constantes est désormais suffixé par le nom de la propriété puisqu'on suppose qu'on peut en avoir plusieurs. 