### PR TITLE
Evolutions config JPA + détermination des packages (Java)/namespaces (C#)

### DIFF
--- a/TopModel.Core/IModelWatcher.cs
+++ b/TopModel.Core/IModelWatcher.cs
@@ -13,6 +13,8 @@ public interface IModelWatcher
 
     IEnumerable<string>? GeneratedFiles { get; }
 
+    bool Disabled { get; }
+
     void OnErrors(IDictionary<ModelFile, IEnumerable<ModelError>> errors);
 
     void OnFilesChanged(IEnumerable<ModelFile> files, LoggingScope? storeConfig = null);

--- a/TopModel.Core/Model/Namespace.cs
+++ b/TopModel.Core/Model/Namespace.cs
@@ -6,6 +6,8 @@ public struct Namespace
 {
     public string App { get; set; }
 
+    public string AppPath => App.Replace('.', Path.DirectorySeparatorChar);
+
     public string Module { get; set; }
 
     public string ModuleFlat => Module.Replace(".", string.Empty);

--- a/TopModel.Core/Model/Namespace.cs
+++ b/TopModel.Core/Model/Namespace.cs
@@ -6,8 +6,6 @@ public struct Namespace
 {
     public string App { get; set; }
 
-    public string AppPath => App.Replace('.', Path.DirectorySeparatorChar);
-
     public string Module { get; set; }
 
     public string ModuleFlat => Module.Replace(".", string.Empty);

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -31,7 +31,7 @@ public class ModelStore
         _fsCache = fsCache;
         _logger = logger;
         _modelFileLoader = modelFileLoader;
-        _modelWatchers = modelWatchers;
+        _modelWatchers = modelWatchers.Where(mw => !mw.Disabled);
         _translationStore = translationStore;
 
         var lockFile = new FileInfo(Path.Combine(_config.ModelRoot, _config.LockFileName));

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -306,11 +306,11 @@
           },
           "apiRootPath": {
             "type": "string",
-            "description": "Localisation du l'API générée (client ou serveur), relatif au répertoire de génération. Par défaut : {app}.Web."
+            "description": "Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut : {app}.Web."
           },
           "apiFilePath": {
             "type": "string",
-            "description": "Chemin vers lequel sont créés les fichiers d'endpoints générés, relatif à la racine de l'API. Par défaut : {module}."
+            "description": "Chemin vers lequel sont créés les fichiers d'endpoints générés, relative à la racine de l'API. Par défaut : {module}."
           },
           "apiGeneration": {
             "oneOf": [
@@ -335,7 +335,7 @@
           },
           "dbContextPath": {
             "type": "string",
-            "description": "Localisation du DbContext, relatif au répertoire de génération."
+            "description": "Localisation du DbContext, relative au répertoire de génération."
           },
           "dbContextName": {
             "type": "string",
@@ -514,7 +514,6 @@
         "additionalProperties": false,
         "required": [
           "tags",
-          "modelRootPath",
           "outputDirectory"
         ],
         "properties": {
@@ -553,53 +552,21 @@
             "type": "string",
             "description": "Racine du répertoire de génération."
           },
-          "apiRootPath": {
+          "entitiesPath": {
             "type": "string",
-            "description": "Localisation du l'API générée (client ou serveur), relatif au répertoire de génération."
+            "description": "Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/entities/{module}'."
           },
-          "resourceRootPath": {
+          "daosPath": {
             "type": "string",
-            "description": "Localisation des ressources, relative au répertoire de génération."
+            "description": "Localisation des DAOs, relative au répertoire de génération."
           },
-          "modelRootPath": {
+          "dtosPath": {
             "type": "string",
-            "description": "Localisation du modèle, relative au répertoire de génération."
+            "description": "Localisation des classes non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/dtos/{module}'."
           },
-          "daosPackageName": {
+          "apiPath": {
             "type": "string",
-            "description": "Précise le nom du package dans lequel générer les daos."
-          },
-          "entitiesPackageName": {
-            "type": "string",
-            "description": "Précise le nom du package dans lequel générer les classes persistées du modèle."
-          },
-          "dtosPackageName": {
-            "type": "string",
-            "description": "Précise le nom du package dans lequel générer les classes non persistées du modèle."
-          },
-          "fieldsEnum": {
-            "type": "string",
-            "description": "Option pour générer une enum des champs des classes persistées",
-            "default": "None",
-            "enum": [
-              "None",
-              "Persisted",
-              "Dto",
-              "Persisted_Dto"
-            ]
-          },
-          "enumShortcutMode": {
-            "type": "boolean",
-            "description": "Option pour générer des getters et setters vers l'enum des références plutôt que sur la table",
-            "default": "false"
-          },
-          "fieldsEnumInterface": {
-            "type": "string",
-            "description": "Précise l'interface des fields enum générés."
-          },
-          "apiPackageName": {
-            "type": "string",
-            "description": "Précise le nom du package dans lequel générer les controllers."
+            "description": "Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen/{app}/api/{module}'."
           },
           "apiGeneration": {
             "oneOf": [
@@ -617,6 +584,30 @@
                 "pattern": "^\\{[^\\}]+\\}$"
               }
             ]
+          },
+          "resourcesPath": {
+            "type": "string",
+            "description": "Localisation des ressources, relative au répertoire de génération."
+          },
+          "enumShortcutMode": {
+            "type": "boolean",
+            "description": "Option pour générer des getters et setters vers l'enum des références plutôt que sur la table",
+            "default": "false"
+          },
+          "fieldsEnum": {
+            "type": "string",
+            "description": "Option pour générer une enum des champs des classes persistées",
+            "default": "None",
+            "enum": [
+              "None",
+              "Persisted",
+              "Dto",
+              "Persisted_Dto"
+            ]
+          },
+          "fieldsEnumInterface": {
+            "type": "string",
+            "description": "Précise l'interface des fields enum générés."
           },
           "persistenceMode": {
             "type": "string",

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -100,6 +100,14 @@
               }
             }
           },
+          "disable": {
+            "type": "array",
+            "description": "Désactive les générateurs demandés",
+            "items": {
+              "type": "string",
+              "enum": [ "JTranslationOutGen" ]
+            }
+          },
           "outputDirectory": {
             "type": "string",
             "description": "Racine du répertoire de génération."
@@ -150,6 +158,14 @@
               ".+": {
                 "type": "string"
               }
+            }
+          },
+          "disable": {
+            "type": "array",
+            "description": "Désactive les générateurs demandés",
+            "items": {
+              "type": "string",
+              "enum": [ "SsdtGen", "ProceduralSqlGen" ]
             }
           },
           "outputDirectory": {
@@ -286,6 +302,14 @@
                   }
                 }
               }
+            }
+          },
+          "disable": {
+            "type": "array",
+            "description": "Désactive les générateurs demandés",
+            "items": {
+              "type": "string",
+              "enum": [ "CSharpClassGen", "CSharpMapperGen", "CSharpDbContextGen", "CSharpRefAccessGen", "CSharpApiServerGen", "CSharpApiClientGen" ]
             }
           },
           "outputDirectory": {
@@ -435,6 +459,14 @@
               }
             }
           },
+          "disable": {
+            "type": "array",
+            "description": "Désactive les générateurs demandés",
+            "items": {
+              "type": "string",
+              "enum": [ "JSDefinitionGen", "JSReferenceGen", "JSNGApiClientGen", "JSApiClientGen", "JSResourceGen" ]
+            }
+          },
           "outputDirectory": {
             "type": "string",
             "description": "Racine du répertoire de génération."
@@ -546,6 +578,14 @@
                   }
                 }
               }
+            }
+          },
+          "disable": {
+            "type": "array",
+            "description": "Désactive les générateurs demandés",
+            "items": {
+              "type": "string",
+              "enum": [ "JpaModelGen", "JpaInterfaceGen", "JpaMapperGenerator", "JpaDaoGen", "JpaResourceGen", "SpringApiServerGen", "SpringApiClientGen" ]
             }
           },
           "outputDirectory": {

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -554,7 +554,7 @@
           },
           "entitiesPath": {
             "type": "string",
-            "description": "Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/entities/{module}'."
+            "description": "Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen:{app}/entities/{module}'."
           },
           "daosPath": {
             "type": "string",
@@ -562,11 +562,11 @@
           },
           "dtosPath": {
             "type": "string",
-            "description": "Localisation des classes non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/dtos/{module}'."
+            "description": "Localisation des classes non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen:{app}/dtos/{module}'."
           },
           "apiPath": {
             "type": "string",
-            "description": "Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen/{app}/api/{module}'."
+            "description": "Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen:{app}/api/{module}'."
           },
           "apiGeneration": {
             "oneOf": [

--- a/TopModel.Generator.Core/GeneratorBase.cs
+++ b/TopModel.Generator.Core/GeneratorBase.cs
@@ -25,6 +25,8 @@ public abstract class GeneratorBase<T> : IModelWatcher
 
     public virtual IEnumerable<string> GeneratedFiles => new List<string>();
 
+    public bool Disabled => Config.Disable?.Contains(Name) ?? false;
+
     protected Dictionary<string, ModelFile> Files { get; } = new();
 
     protected IEnumerable<Class> Classes => Files.SelectMany(f => f.Value.Classes).Distinct();

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -19,6 +19,11 @@ public abstract class GeneratorConfigBase
 #nullable enable
 
     /// <summary>
+    /// Générateurs désactivés.
+    /// </summary>
+    public IList<string>? Disable { get; set; }
+
+    /// <summary>
     /// Variables globales du générateur.
     /// </summary>
     public Dictionary<string, string> Variables { get; set; } = new();

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -33,11 +33,6 @@ public abstract class GeneratorConfigBase
     public IEnumerable<string> GlobalVariableNames => Variables.Select(v => v.Key).Except(TagVariableNames).Distinct();
 
     /// <summary>
-    /// Propriétés qui supportent la variable "app".
-    /// </summary>
-    public virtual string[] PropertiesWithAppVariableSupport => Array.Empty<string>();
-
-    /// <summary>
     /// Propriétés qui supportent la variable "module".
     /// </summary>
     public virtual string[] PropertiesWithModuleVariableSupport => Array.Empty<string>();
@@ -57,28 +52,16 @@ public abstract class GeneratorConfigBase
     /// </summary>
     /// <param name="value">Valeur.</param>
     /// <param name="tag">Tag.</param>
-    /// <param name="app">App.</param>
     /// <param name="module">Module.</param>
     /// <param name="lang">Lang.</param>
-    /// <param name="trimBeforeApp">Supprime tout ce qui précède le premier {app}.</param>
     /// <returns>La valeur avec les variables résolues.</returns>
-    public virtual string ResolveVariables(string value, string? tag = null, string? app = null, string? module = null, string? lang = null, bool trimBeforeApp = false)
+    public virtual string ResolveVariables(string value, string? tag = null, string? module = null, string? lang = null)
     {
         var result = value;
 
         if (tag != null)
         {
             result = ResolveTagVariables(result, tag);
-        }
-
-        if (app != null)
-        {
-            if (trimBeforeApp)
-            {
-                result = result[Math.Max(0, result.IndexOf("{app}"))..];
-            }
-
-            result = ReplaceVariable(result, "app", app);
         }
 
         if (module != null)
@@ -97,9 +80,15 @@ public abstract class GeneratorConfigBase
     /// <summary>
     /// Initialise les variables globales, et par tag manquantes.
     /// </summary>
+    /// <param name="app">Valeur de la variable 'app'.</param>
     /// <param name="number">Numéro du générateur.</param>
-    public void InitVariables(int number)
+    public void InitVariables(string app, int number)
     {
+        if (!Variables.ContainsKey("app"))
+        {
+            Variables["app"] = app;
+        }
+
         // Si on a défini au moins une variable par tag, alors on s'assure qu'elle est définie pour tous les tags (et on y met "" si ce n'est pas une variable globale).
         if (TagVariableNames.Any())
         {
@@ -141,11 +130,10 @@ public abstract class GeneratorConfigBase
                 foreach (var match in Regex.Matches(value, @"\{([$a-zA-Z0-9_-]+)(:\w+)?\}").Cast<Match>())
                 {
                     var varName = match.Groups[1].Value;
-                    if (varName == "app" || varName == "module" || varName == "lang")
+                    if (varName == "module" || varName == "lang")
                     {
                         var supportedProperties = varName switch
                         {
-                            "app" => PropertiesWithAppVariableSupport,
                             "module" => PropertiesWithModuleVariableSupport,
                             "lang" => PropertiesWithLangVariableSupport,
                             _ => null!

--- a/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
@@ -31,7 +31,7 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
 
     protected override string GetFileName(ModelFile file, string tag)
     {
-        return $"{Config.GetApiPath(file, tag)}/generated/{file.Options.Endpoints.FileName.ToPascalCase()}Client.cs";
+        return Path.Combine(Config.GetApiPath(file, tag), "generated", $"{file.Options.Endpoints.FileName.ToPascalCase()}Client.cs");
     }
 
     protected override void HandleFile(string filePath, string fileName, string tag, IList<Endpoint> endpoints)

--- a/TopModel.Generator.Csharp/CSharpApiServerGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpApiServerGenerator.cs
@@ -35,7 +35,7 @@ public class CSharpApiServerGenerator : EndpointsGeneratorBase<CsharpConfig>
 
     protected override string GetFileName(ModelFile file, string tag)
     {
-        return $"{Config.GetApiPath(file, tag, withControllers: true)}/{file.Options.Endpoints.FileName.ToPascalCase()}Controller.cs";
+        return Path.Combine(Config.GetApiPath(file, tag, withControllers: true), $"{file.Options.Endpoints.FileName.ToPascalCase()}Controller.cs");
     }
 
     protected override void HandleFile(string filePath, string fileName, string tag, IList<Endpoint> endpoints)

--- a/TopModel.Generator.Csharp/CSharpUtils.cs
+++ b/TopModel.Generator.Csharp/CSharpUtils.cs
@@ -123,21 +123,19 @@ public static class CSharpUtils
             (classe.Abstract ? "I" : string.Empty) + classe.NamePascal + ".cs");
     }
 
-    public static string GetDbContextFilePath(this CsharpConfig config, Namespace ns, string tag)
+    public static string GetDbContextFilePath(this CsharpConfig config, string tag)
     {
         return Path.Combine(
             config.OutputDirectory,
-            config.ResolveVariables(config.DbContextPath!, tag: tag, app: ns.App),
+            config.ResolveVariables(config.DbContextPath!, tag: tag).ToFilePath(),
             "generated",
-            $"{config.GetDbContextName(ns, tag)}.cs");
+            $"{config.GetDbContextName(tag)}.cs");
     }
 
-    public static string GetDbContextNamespace(this CsharpConfig config, Namespace ns, string tag)
+    public static string GetDbContextNamespace(this CsharpConfig config, string tag)
     {
-        return config.ResolveVariables(config.DbContextPath!, tag: tag, app: ns.App, trimBeforeApp: true)
-            .Replace("\\", "/")
-            .Replace("/", ".")
-            .Trim('.');
+        return config.ResolveVariables(config.DbContextPath!, tag: tag)
+            .ToNamespace();
     }
 
     public static string GetMapperFilePath(this CsharpConfig config, Class classe, bool isPersistant, string tag)
@@ -147,8 +145,7 @@ public static class CSharpUtils
             config.ResolveVariables(
                 isPersistant ? config.PersistantModelPath : config.NonPersistantModelPath,
                 tag: tag,
-                app: classe.Namespace.App,
-                module: classe.Namespace.ModulePath),
+                module: classe.Namespace.ModulePath).ToFilePath(),
             "generated",
             $"{classe.GetMapperName(isPersistant)}.cs");
     }
@@ -163,7 +160,6 @@ public static class CSharpUtils
         return config.ResolveVariables(
             config.ReferenceAccessorsName,
             tag: tag,
-            app: ns.App,
             module: ns.ModuleFlat);
     }
 
@@ -174,8 +170,7 @@ public static class CSharpUtils
             config.ResolveVariables(
                 config.ReferenceAccessorsInterfacePath,
                 tag: tag,
-                app: ns.App,
-                module: ns.ModulePath),
+                module: ns.ModulePath).ToFilePath(),
             "generated",
             $"I{config.GetReferenceAccessorName(ns, tag)}.cs");
     }
@@ -187,8 +182,7 @@ public static class CSharpUtils
             config.ResolveVariables(
                 config.ReferenceAccessorsImplementationPath,
                 tag: tag,
-                app: ns.App,
-                module: ns.ModulePath),
+                module: ns.ModulePath).ToFilePath(),
             "generated",
             $"{config.GetReferenceAccessorName(ns, tag)}.cs");
     }
@@ -198,12 +192,7 @@ public static class CSharpUtils
         return config.ResolveVariables(
             config.ReferenceAccessorsInterfacePath,
             tag: tag,
-            app: ns.App,
-            module: ns.Module,
-            trimBeforeApp: true)
-        .Replace("\\", "/")
-        .Replace("/", ".")
-        .Replace("..", ".");
+            module: ns.Module).ToNamespace();
     }
 
     public static string GetReferenceImplementationNamespace(this CsharpConfig config, Namespace ns, string tag)
@@ -211,12 +200,7 @@ public static class CSharpUtils
         return config.ResolveVariables(
             config.ReferenceAccessorsImplementationPath,
             tag: tag,
-            app: ns.App,
-            module: ns.Module,
-            trimBeforeApp: true)
-        .Replace("\\", "/")
-        .Replace("/", ".")
-        .Replace("..", ".");
+            module: ns.Module).ToNamespace();
     }
 
     public static string GetPropertyTypeName(this CsharpConfig config, IProperty prop, bool nonNullable = false, bool useIEnumerable = true)
@@ -274,6 +258,16 @@ public static class CSharpUtils
         }
 
         return regType!.ContainsKey(name);
+    }
+
+    public static string ToFilePath(this string path)
+    {
+        return path.TrimEnd('.').Replace(':', Path.DirectorySeparatorChar);
+    }
+
+    public static string ToNamespace(this string path)
+    {
+        return path.Split(':').Last().Replace('/', '.').Replace('\\', '.').Replace("..", ".").Trim('.');
     }
 
     /// <summary>

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -28,12 +28,12 @@ public class CsharpConfig : GeneratorConfigBase
     public string NonPersistantModelPath { get; set; } = "{app}.{module}.Models/Dto";
 
     /// <summary>
-    /// Localisation du l'API générée (client ou serveur), relatif au répertoire de génération. Par défaut : "{app}.Web".
+    /// Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut : "{app}.Web".
     /// </summary>
     public string ApiRootPath { get; set; } = "{app}.Web";
 
     /// <summary>
-    /// Chemin vers lequel sont créés les fichiers d'endpoints générés, relatif à la racine de l'API. Par défaut : "{module}".
+    /// Chemin vers lequel sont créés les fichiers d'endpoints générés, relative à la racine de l'API. Par défaut : "{module}".
     /// </summary>
     public string ApiFilePath { get; set; } = "{module}";
 
@@ -48,7 +48,7 @@ public class CsharpConfig : GeneratorConfigBase
     public bool NoAsyncControllers { get; set; }
 
     /// <summary>
-    /// Localisation du DbContext, relatif au répertoire de génération.
+    /// Localisation du DbContext, relative au répertoire de génération.
     /// </summary>
     public string? DbContextPath { get; set; }
 

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -120,19 +120,6 @@ public class CsharpConfig : GeneratorConfigBase
     /// </summary>
     public bool UseEFComments { get; set; }
 
-    public override string[] PropertiesWithAppVariableSupport => new[]
-    {
-        nameof(PersistantModelPath),
-        nameof(PersistantReferencesModelPath),
-        nameof(NonPersistantModelPath),
-        nameof(ApiRootPath),
-        nameof(DbContextName),
-        nameof(DbContextPath),
-        nameof(ReferenceAccessorsName),
-        nameof(ReferenceAccessorsInterfacePath),
-        nameof(ReferenceAccessorsImplementationPath)
-    };
-
     public override string[] PropertiesWithModuleVariableSupport => new[]
     {
         nameof(PersistantModelPath),
@@ -228,12 +215,11 @@ public class CsharpConfig : GeneratorConfigBase
     /// <summary>
     /// Récupère le nom du DbContext.
     /// </summary>
-    /// <param name="ns">Nom de l'application.</param>
     /// <param name="tag">tag</param>
     /// <returns>Nom.</returns>
-    public string GetDbContextName(Namespace ns, string tag)
+    public string GetDbContextName(string tag)
     {
-        return ResolveVariables(DbContextName, tag: tag, app: ns.App.Replace(".", string.Empty));
+        return ResolveVariables(DbContextName, tag: tag).Replace(".", string.Empty);
     }
 
     /// <summary>
@@ -251,18 +237,16 @@ public class CsharpConfig : GeneratorConfigBase
                     : PersistantModelPath
                 : NonPersistantModelPath,
             tag: tag,
-            app: classe.Namespace.App,
-            module: classe.Namespace.ModulePath);
+            module: classe.Namespace.ModulePath).ToFilePath();
     }
 
     public string GetApiPath(ModelFile file, string tag, bool withControllers = false)
     {
         return Path.Combine(
             OutputDirectory,
-            ResolveVariables(ApiRootPath, tag: tag, app: file.Namespace.App),
+            ResolveVariables(ApiRootPath, tag: tag).ToFilePath(),
             withControllers ? "Controllers" : string.Empty,
-            ResolveVariables(ApiFilePath, tag: tag, module: file.Namespace.ModulePath))
-       .Replace("\\", "/");
+            ResolveVariables(ApiFilePath, tag: tag, module: file.Namespace.ModulePath));
     }
 
     /// <summary>
@@ -285,10 +269,8 @@ public class CsharpConfig : GeneratorConfigBase
                         : PersistantModelPath
                     : NonPersistantModelPath,
             tag: tag,
-            app: classe.Namespace.App,
-            module: classe.Namespace.Module,
-            trimBeforeApp: true)
-        .Replace("/", ".")
+            module: classe.Namespace.Module)
+        .ToNamespace()
         .Replace(".Dto", string.Empty);
     }
 
@@ -303,10 +285,7 @@ public class CsharpConfig : GeneratorConfigBase
         return ResolveVariables(
              Path.Combine(ApiRootPath, ApiFilePath),
              tag: tag,
-             app: endpoint.Namespace.App,
-             module: endpoint.Namespace.Module,
-             trimBeforeApp: true)
-        .Replace("\\", "/")
-        .Replace("/", ".");
+             module: endpoint.Namespace.Module)
+        .ToNamespace();
     }
 }

--- a/TopModel.Generator.Csharp/DbContextGenerator.cs
+++ b/TopModel.Generator.Csharp/DbContextGenerator.cs
@@ -20,20 +20,20 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
     {
         if (classe.IsPersistent && !classe.Abstract)
         {
-            yield return ("main", Config.GetDbContextFilePath(classe.Namespace, tag));
+            yield return ("main", Config.GetDbContextFilePath(tag));
 
             if (Config.UseEFComments)
             {
-                yield return ("comments", Config.GetDbContextFilePath(classe.Namespace, tag).Replace(".cs", ".comments.cs"));
+                yield return ("comments", Config.GetDbContextFilePath(tag).Replace(".cs", ".comments.cs"));
             }
         }
     }
 
     protected override void HandleFile(string fileType, string fileName, string tag, IEnumerable<Class> classes)
     {
-        var dbContextName = Config.GetDbContextName(classes.First().Namespace, tag);
+        var dbContextName = Config.GetDbContextName(tag);
         var usings = new List<string> { "Microsoft.EntityFrameworkCore" };
-        var contextNs = Config.GetDbContextNamespace(classes.First().Namespace, tag);
+        var contextNs = Config.GetDbContextNamespace(tag);
 
         foreach (var ns in classes
             .Concat(GetAssociationProperties(classes).Select(ap => ap.AssociationProperty.Association))

--- a/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
+++ b/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
@@ -93,7 +93,7 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
                 usings.Add("System.Linq");
             }
 
-            var contextNs = Config.GetDbContextNamespace(ns, tag);
+            var contextNs = Config.GetDbContextNamespace(tag);
             if (!implementationNamespace.Contains(contextNs))
             {
                 usings.Add(contextNs);
@@ -112,7 +112,7 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
 
         if (Config.DbContextPath != null)
         {
-            var dbContextName = Config.GetDbContextName(ns, tag);
+            var dbContextName = Config.GetDbContextName(tag);
 
             w.WriteLine(2, $"private readonly {dbContextName} _dbContext;");
             w.WriteLine();

--- a/TopModel.Generator.Jpa/Config/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/Config/JpaConfig.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using TopModel.Core;
+﻿using TopModel.Core;
 using TopModel.Generator.Core;
 
 namespace TopModel.Generator.Jpa;
@@ -8,61 +6,24 @@ namespace TopModel.Generator.Jpa;
 public class JpaConfig : GeneratorConfigBase
 {
     /// <summary>
-    /// Localisation du modèle, relative au répertoire de génération.
+    /// Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/entities/{module}'.
     /// </summary>
-    public string ModelRootPath { get; set; }
+    public string EntitiesPath { get; set; } = "javagen/{app}/entities/{module}";
 
     /// <summary>
-    /// Localisation des ressources, relative au répertoire de génération.
+    /// Localisation des DAOs, relative au répertoire de génération.
     /// </summary>
-    public string ResourceRootPath { get; set; }
+    public string? DaosPath { get; set; }
 
     /// <summary>
-    /// Localisation du l'API générée (client ou serveur), relatif au répertoire de génération.
+    /// Localisation des classses non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/dtos/{module}'.
     /// </summary>
-    public string ApiRootPath { get; set; }
+    public string DtosPath { get; set; } = "javagen/{app}/dtos/{module}";
 
     /// <summary>
-    /// Précise le nom du package dans lequel générer les classes persistées du modèle.
+    /// Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen/{app}/api/{module}'.
     /// </summary>
-    public string EntitiesPackageName { get; set; }
-
-    /// <summary>
-    /// Précise le nom du package dans lequel générer les classes non persistées du modèle.
-    /// </summary>
-    public string DtosPackageName { get; set; }
-
-    /// <summary>
-    /// Précise le nom du package dans lequel générer les classes non persistées du modèle.
-    /// </summary>
-    public string DaosPackageName { get; set; }
-
-    /// <summary>
-    /// Option pour générer une enum des champs des classes persistées
-    /// </summary>
-    public Target FieldsEnum { get; set; } = Target.None;
-
-    /// <summary>
-    /// Option pour générer des getters et setters vers l'enum des références plutôt que sur la table
-    /// </summary>
-    public bool EnumShortcutMode { get; set; }
-
-    /// <summary>
-    /// Précise l'interface des fields enum générés.
-    /// </summary>
-    public string FieldsEnumInterface { get; set; }
-
-    /// <summary>
-    /// Précise le nom du package dans lequel générer les controllers.
-    /// </summary>
-    public string ApiPackageName { get; set; }
-
-    /// <summary>
-    /// Précise le nom du package dans lequel générer les controllers.
-    /// </summary>
-    public PersistenceMode PersistenceMode { get; set; } = PersistenceMode.Javax;
-
-#nullable enable
+    public string ApiPath { get; set; } = "javagen/{app}/api/{module}";
 
     /// <summary>
     /// Mode de génération de l'API ("Client" ou "Server").
@@ -70,27 +31,63 @@ public class JpaConfig : GeneratorConfigBase
     public string? ApiGeneration { get; set; }
 
     /// <summary>
+    /// Localisation des ressources, relative au répertoire de génération.
+    /// </summary>
+    public string? ResourcesPath { get; set; }
+
+    /// <summary>
+    /// Option pour générer des getters et setters vers l'enum des références plutôt que sur la table
+    /// </summary>
+    public bool EnumShortcutMode { get; set; }
+
+    /// <summary>
+    /// Option pour générer une enum des champs des classes persistées
+    /// </summary>
+    public Target FieldsEnum { get; set; } = Target.None;
+
+    /// <summary>
+    /// Précise l'interface des fields enum générés.
+    /// </summary>
+    public string? FieldsEnumInterface { get; set; }
+
+    /// <summary>
+    /// Précise le nom du package dans lequel générer les controllers.
+    /// </summary>
+    public PersistenceMode PersistenceMode { get; set; } = PersistenceMode.Javax;
+
+    /// <summary>
     /// Mode de génération des séquences.
     /// </summary>
-    public IdentityConfig Identity { get; set; } = new IdentityConfig()
-    {
-        Mode = IdentityMode.IDENTITY
-    };
+    public IdentityConfig Identity { get; set; } = new() { Mode = IdentityMode.IDENTITY };
 
     public override string[] PropertiesWithLangVariableSupport => new[]
     {
-        nameof(ResourceRootPath)
+        nameof(ResourcesPath)
     };
 
     public override string[] PropertiesWithTagVariableSupport => new[]
     {
-        nameof(ModelRootPath),
-        nameof(EntitiesPackageName),
-        nameof(DaosPackageName),
-        nameof(DtosPackageName),
-        nameof(ResourceRootPath),
+        nameof(EntitiesPath),
+        nameof(DaosPath),
+        nameof(DtosPath),
+        nameof(ApiPath),
         nameof(ApiGeneration),
-        nameof(ApiRootPath),
-        nameof(ApiPackageName)
+        nameof(ResourcesPath)
+    };
+
+    public override string[] PropertiesWithAppVariableSupport => new[]
+    {
+        nameof(EntitiesPath),
+        nameof(DaosPath),
+        nameof(DtosPath),
+        nameof(ApiPath)
+    };
+
+    public override string[] PropertiesWithModuleVariableSupport => new[]
+    {
+        nameof(EntitiesPath),
+        nameof(DaosPath),
+        nameof(DtosPath),
+        nameof(ApiPath)
     };
 }

--- a/TopModel.Generator.Jpa/Config/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/Config/JpaConfig.cs
@@ -8,7 +8,7 @@ public class JpaConfig : GeneratorConfigBase
     /// <summary>
     /// Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/entities/{module}'.
     /// </summary>
-    public string EntitiesPath { get; set; } = "javagen/{app}/entities/{module}";
+    public string EntitiesPath { get; set; } = "javagen:{app}/entities/{module}";
 
     /// <summary>
     /// Localisation des DAOs, relative au répertoire de génération.
@@ -18,12 +18,12 @@ public class JpaConfig : GeneratorConfigBase
     /// <summary>
     /// Localisation des classses non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen/{app}/dtos/{module}'.
     /// </summary>
-    public string DtosPath { get; set; } = "javagen/{app}/dtos/{module}";
+    public string DtosPath { get; set; } = "javagen:{app}/dtos/{module}";
 
     /// <summary>
     /// Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen/{app}/api/{module}'.
     /// </summary>
-    public string ApiPath { get; set; } = "javagen/{app}/api/{module}";
+    public string ApiPath { get; set; } = "javagen:{app}/api/{module}";
 
     /// <summary>
     /// Mode de génération de l'API ("Client" ou "Server").
@@ -73,14 +73,6 @@ public class JpaConfig : GeneratorConfigBase
         nameof(ApiPath),
         nameof(ApiGeneration),
         nameof(ResourcesPath)
-    };
-
-    public override string[] PropertiesWithAppVariableSupport => new[]
-    {
-        nameof(EntitiesPath),
-        nameof(DaosPath),
-        nameof(DtosPath),
-        nameof(ApiPath)
     };
 
     public override string[] PropertiesWithModuleVariableSupport => new[]

--- a/TopModel.Generator.Jpa/GeneratorRegistration.cs
+++ b/TopModel.Generator.Jpa/GeneratorRegistration.cs
@@ -9,27 +9,27 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
 {
     public void Register(IServiceCollection services, JpaConfig config, int number)
     {
-        TrimSlashes(config, c => c.ApiRootPath);
-        TrimSlashes(config, c => c.ModelRootPath);
-        TrimSlashes(config, c => c.ResourceRootPath);
+        TrimSlashes(config, c => c.EntitiesPath);
+        TrimSlashes(config, c => c.DaosPath);
+        TrimSlashes(config, c => c.DtosPath);
+        TrimSlashes(config, c => c.ApiPath);
+        TrimSlashes(config, c => c.ResourcesPath);
 
-        if (config.EntitiesPackageName != null || config.DtosPackageName != null)
-        {
-            services.AddGenerator<JpaModelGenerator, JpaConfig>(config, number);
-            services.AddGenerator<JpaModelInterfaceGenerator, JpaConfig>(config, number);
-        }
+        services.AddGenerator<JpaModelGenerator, JpaConfig>(config, number);
+        services.AddGenerator<JpaModelInterfaceGenerator, JpaConfig>(config, number);
+        services.AddGenerator<JpaMapperGenerator, JpaConfig>(config, number);
 
-        if (config.DaosPackageName != null)
+        if (config.DaosPath != null)
         {
             services.AddGenerator<JpaDaoGenerator, JpaConfig>(config, number);
         }
 
-        if (config.ResourceRootPath != null)
+        if (config.ResourcesPath != null)
         {
             services.AddGenerator<JpaResourceGenerator, JpaConfig>(config, number);
         }
 
-        if (config.ApiRootPath != null && config.ApiGeneration != null)
+        if (config.ApiGeneration != null)
         {
             if (config.ApiGeneration != ApiGeneration.Client)
             {
@@ -41,7 +41,5 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
                 services.AddGenerator<SpringClientApiGenerator, JpaConfig>(config, number);
             }
         }
-
-        services.AddGenerator<JpaMapperGenerator, JpaConfig>(config, number);
     }
 }

--- a/TopModel.Generator.Jpa/JpaDaoGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaDaoGenerator.cs
@@ -28,9 +28,11 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
     {
         return Path.Combine(
             Config.OutputDirectory,
-            Config.ResolveVariables(Config.ModelRootPath, tag),
-            Path.Combine(Config.ResolveVariables(Config.DaosPackageName, tag).Split(".")),
-            classe.Namespace.ModulePath.ToLower(),
+            Config.ResolveVariables(
+                Config.DaosPath!,
+                tag,
+                app: classe.Namespace.AppPath,
+                module: classe.Namespace.ModulePath).ToLower(),
             $"{classe.NamePascal}DAO.java");
     }
 
@@ -42,7 +44,12 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
             return;
         }
 
-        var packageName = $"{Config.ResolveVariables(Config.DaosPackageName, tag)}.{classe.Namespace.Module.ToLower()}";
+        var packageName = Config.ResolveVariables(
+            Config.DaosPath!,
+            tag,
+            app: classe.Namespace.App,
+            module: classe.Namespace.Module,
+            trimBeforeApp: true).ToPackageName();
 
         using var fw = new JavaWriter(fileName, _logger, packageName, null);
         fw.WriteLine();

--- a/TopModel.Generator.Jpa/JpaDaoGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaDaoGenerator.cs
@@ -28,11 +28,7 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
     {
         return Path.Combine(
             Config.OutputDirectory,
-            Config.ResolveVariables(
-                Config.DaosPath!,
-                tag,
-                app: classe.Namespace.AppPath,
-                module: classe.Namespace.ModulePath).ToLower(),
+            Config.ResolveVariables(Config.DaosPath!, tag, module: classe.Namespace.Module).ToFilePath(),
             $"{classe.NamePascal}DAO.java");
     }
 
@@ -47,9 +43,7 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
         var packageName = Config.ResolveVariables(
             Config.DaosPath!,
             tag,
-            app: classe.Namespace.App,
-            module: classe.Namespace.Module,
-            trimBeforeApp: true).ToPackageName();
+            module: classe.Namespace.Module).ToPackageName();
 
         using var fw = new JavaWriter(fileName, _logger, packageName, null);
         fw.WriteLine();

--- a/TopModel.Generator.Jpa/JpaResourceGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaResourceGenerator.cs
@@ -30,7 +30,7 @@ public class JpaResourceGenerator : TranslationGeneratorBase<JpaConfig>
         {
             return Path.Combine(
                 Config.OutputDirectory,
-                Config.ResolveVariables(Config.ResourceRootPath, tag: tag, lang: lang).ToLower(),
+                Config.ResolveVariables(Config.ResourcesPath!, tag: tag, lang: lang).ToLower(),
                 $"{p.Parent.Namespace.RootModule.ToKebabCase()}{(string.IsNullOrEmpty(lang) ? string.Empty : $"_{lang}")}.properties");
         }
 

--- a/TopModel.Generator.Jpa/JpaUtils.cs
+++ b/TopModel.Generator.Jpa/JpaUtils.cs
@@ -192,11 +192,7 @@ public static class JpaUtils
     {
         return Path.Combine(
             config.OutputDirectory,
-            config.ResolveVariables(
-                classe.IsPersistent ? config.EntitiesPath : config.DtosPath,
-                tag,
-                app: classe.Namespace.AppPath,
-                module: classe.Namespace.ModulePath).ToLower(),
+            config.ResolveVariables(classe.IsPersistent ? config.EntitiesPath : config.DtosPath, tag, module: classe.Namespace.Module).ToFilePath(),
             $"{classe.NamePascal}.java");
     }
 
@@ -204,11 +200,7 @@ public static class JpaUtils
     {
         return Path.Combine(
             config.OutputDirectory,
-            config.ResolveVariables(
-                config.ApiPath!,
-                tag,
-                app: file.Namespace.AppPath,
-                module: file.Namespace.ModulePath).ToLower());
+            config.ResolveVariables(config.ApiPath!, tag, module: file.Namespace.Module).ToFilePath());
     }
 
     public static string GetPackageName(this JpaConfig config, Class classe, string tag, bool? isPersistant = null)
@@ -222,19 +214,12 @@ public static class JpaUtils
                     ? config.EntitiesPath
                     : config.DtosPath,
             tag,
-            app: classe.Namespace.App,
-            module: classe.Namespace.Module,
-            trimBeforeApp: true).ToPackageName();
+            module: classe.Namespace.Module).ToPackageName();
     }
 
     public static string GetPackageName(this JpaConfig config, Endpoint endpoint, string tag)
     {
-        return config.ResolveVariables(
-            config.ApiPath,
-            tag,
-            app: endpoint.Namespace.App,
-            module: endpoint.Namespace.Module,
-            trimBeforeApp: true).ToPackageName();
+        return config.ResolveVariables(config.ApiPath, tag, module: endpoint.Namespace.Module).ToPackageName();
     }
 
     public static string GetMapperFilePath(this JpaConfig config, Class classe, bool isPersistant, string tag)
@@ -244,8 +229,7 @@ public static class JpaUtils
             config.ResolveVariables(
                 isPersistant ? config.EntitiesPath : config.DtosPath,
                 tag: tag,
-                app: classe.Namespace.AppPath,
-                module: classe.Namespace.ModulePath).ToLower(),
+                module: classe.Namespace.Module).ToFilePath(),
             $"{GetMapperClassName(classe, isPersistant)}.java");
     }
 
@@ -279,9 +263,14 @@ public static class JpaUtils
         return GetPackageName(config, classe, tag, isPersistant);
     }
 
+    public static string ToFilePath(this string path)
+    {
+        return path.ToLower().Replace(':', '.').Replace('.', Path.DirectorySeparatorChar);
+    }
+
     public static string ToPackageName(this string path)
     {
-        return path.ToLower().Replace('/', '.').Replace('\\', '.');
+        return path.Split(':').Last().ToLower().Replace('/', '.').Replace('\\', '.');
     }
 
     private static string GetMapperImport(JpaConfig config, Class classe, bool isPersistant, string tag)

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -175,7 +175,7 @@ for (var i = 0; i < configs.Count; i++)
 
                 var genConfig = (GeneratorConfigBase)fileChecker.GetGenConfig(configType, genConfigMap);
 
-                genConfig.InitVariables(number);
+                genConfig.InitVariables(config.App, number);
 
                 ModelUtils.CombinePath(dn, genConfig, c => c.OutputDirectory);
 

--- a/TopModel.LanguageServer/ModelWatcher.cs
+++ b/TopModel.LanguageServer/ModelWatcher.cs
@@ -22,6 +22,8 @@ public class ModelWatcher : IModelWatcher
 
     public IEnumerable<string>? GeneratedFiles => null;
 
+    public bool Disabled => false;
+
     public void OnErrors(IDictionary<ModelFile, IEnumerable<ModelError>> errors)
     {
         foreach (var fileErrors in errors)

--- a/TopModel.UI/ModelFileProvider.cs
+++ b/TopModel.UI/ModelFileProvider.cs
@@ -31,6 +31,8 @@ public class ModelFileProvider : IModelWatcher
 
     public IEnumerable<string>? GeneratedFiles => null;
 
+    public bool Disabled => false;
+
     public void OnFilesChanged(IEnumerable<ModelFile> files, LoggingScope? storeConfig = null)
     {
         foreach (var file in files)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,11 +56,11 @@ Il existe **3 types de variables** :
 
 Les variables globales sont utilisables dans tous les paramètres (string) de toutes les générateurs, sans restriction. Elles seront remplacées à l'initialisation du générateur par la valeur qui a été définie dans la section `variables` de la configuration.
 
+La variable globale `{app}` est définie par défaut avec la valeur de la propriété `app` de la configuration est peut donc être utilisée partout. Elle peut bien sûr être surchargée si besoin.
+
 ### Variables contextuelles
 
-Il existe 3 variables "contextuelles", dont la valeur est automatiquement renseignée selon l'objet qui est généré, et qui sont utilisables dans certaines propriétés spécifiques des générateurs (selon leur implémentation). Ce sont :
-
-- `{app}`, qui aura toujours pour valeur la valeur de la propriété `app` de la configuration du modèle. Outre son utilisation dans certaines valeurs par défaut de paramètres, certains d'entre-eux implémentent également une règle qui retire tout ce qui précède `{app}` pour générer une valeur. Par exemple, le générateur C# construira le namespace des classes générés de cette façon : si la classe est configurée pour être générée dans `./Sources/Models/{app}.Models`, son namespace sera `{app}.Models`.
+Il existe 2 variables "contextuelles", dont la valeur est automatiquement renseignée selon l'objet qui est généré, et qui sont utilisables dans certaines propriétés spécifiques des générateurs (selon leur implémentation). Ce sont :
 
 - `{module}`, qui sera renseigné avec la valeur du module du fichier courant lors de la génération d'une classe ou d'un endpoint.
 

--- a/docs/generator/csharp.md
+++ b/docs/generator/csharp.md
@@ -66,9 +66,9 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Localisation du modèle persisté, relative au répertoire de génération.
 
-  Le namespace des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: `"{app}.{module}.Models"`
 
@@ -78,9 +78,9 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Localisation des classes de références persistées, relative au répertoire de génération.
 
-  Le namespace des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: Valeur de `persistantModelPath`
 
@@ -90,9 +90,9 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Localisation du modèle non persisté, relative au répertoire de génération.
 
-  Le namespace des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: `"{app}.{module}.Models/Dto"`
 
@@ -102,9 +102,7 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Localisation du l'API générée (client ou serveur), relative au répertoire de génération.
 
-  Le namespace des classes d'API générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
-
-  _Templating_: `{app}`
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
   _Valeur par défaut_: `"{app}.Web"`
 
@@ -136,15 +134,11 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   C'est ce paramètre qui décide si le DbContext est généré ou non.
 
-  _Templating_: `{app}`
-
   _Variables par tag_: **oui** (plusieurs contextes pourraient être générés si un fichier à plusieurs tags)
 
 - `dbContextName`
 
   Nom du DbContext.
-
-  _Templating_: `{app}`
 
   _Valeur par défaut_: `"{app}DbContext"`
 
@@ -154,9 +148,11 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Chemin vers lequel générer les interfaces d'accesseurs de référence.
 
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
+
   Les accesseurs de référence ne seront générés que si `kinetix: true`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: `"{DbContextPath}/Reference"`
 
@@ -166,9 +162,11 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Chemin vers lequel générer les implémentation d'accesseurs de référence.
 
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
+
   Les accesseurs de référence ne seront générés que si `kinetix: true`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: `"{DbContextPath}/Reference"`
 
@@ -180,7 +178,7 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Les accesseurs de référence ne seront générés que si `kinetix: true`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Valeur par défaut_: `"{module}ReferenceAccessors"`
 

--- a/docs/generator/csharp.md
+++ b/docs/generator/csharp.md
@@ -100,7 +100,7 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
 - `apiRootPath`
 
-  Localisation du l'API générée (client ou serveur), relatif au répertoire de génération.
+  Localisation du l'API générée (client ou serveur), relative au répertoire de génération.
 
   Le namespace des classes d'API générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
 
@@ -112,7 +112,7 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
 - `apiFilePath`
 
-  Chemin vers lequel sont créés les fichiers d'endpoints générés, relatif à la racine de l'API.
+  Chemin vers lequel sont créés les fichiers d'endpoints générés, relative à la racine de l'API.
 
   _Templating_: `{module}`
 
@@ -132,7 +132,7 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
 - `dbContextPath`
 
-  Localisation du DbContext, relatif au répertoire de génération.
+  Localisation du DbContext, relative au répertoire de génération.
 
   C'est ce paramètre qui décide si le DbContext est généré ou non.
 

--- a/docs/generator/jpa.md
+++ b/docs/generator/jpa.md
@@ -90,7 +90,7 @@ Pour des raisons de performances, les associations oneToOne réciproques ne sont
 
 #### Enum
 
-Lorsque sont ajoutées des valeurs (`values`), le générateur créé les `enum` correspondantes. Le domaine de clé primaire de la classe est ignoré, et le champs prend le type de l'enum. L'enum est générée à l'intérieur de la classe de référence, et s'appelle  `[Nom de la classe].Values`. Les différents champs renseignés dans les valeurs sont également ajoutés en tant que propriétés de l'enum.
+Lorsque sont ajoutées des valeurs (`values`), le générateur créé les `enum` correspondantes. Le domaine de clé primaire de la classe est ignoré, et le champs prend le type de l'enum. L'enum est générée à l'intérieur de la classe de référence, et s'appelle `[Nom de la classe].Values`. Les différents champs renseignés dans les valeurs sont également ajoutés en tant que propriétés de l'enum.
 
 Par ailleurs, si la classe possède une association avec une classe qui contient une liste de référence, alors il le type du champ dans l'enum sera le type de l'enum de la clé primaire de la classe associée.
 
@@ -346,10 +346,10 @@ Le mode `sequence` dans la configuration jpa et dans la configuration postgresql
 
 ```yaml
 ## Configuration jpa et proceduralSql
-    identity:
-      increment: 50
-      start: 1000
-      mode: sequence
+identity:
+  increment: 50
+  start: 1000
+  mode: sequence
 ```
 
 ## FieldsEnum
@@ -382,13 +382,13 @@ Génèrera, dans la classe `Departement`, l'enum suivante :
 
 Le générateur de resources s'appuie sur les `Label` des propriétés, ainsi que sur les traductions récupérées dans le cadre de la configuration du [multilinguisme](/model/i18n.md).
 
-Il suffit d'ajouter la configguration `resourceRootPath` au générateur comme suit :
+Il suffit d'ajouter la configuration `resourcesPath` au générateur comme suit :
 
 ```yaml
 jpa:
   - tags:
       - dto
-    resourceRootPath: resources/i18n/model/{module} # Chemin des fichiers de ressource générés. Ici {module} sera remplacé par le nom du module
+    resourcesPath: resources/i18n/model # Chemin des fichiers de ressource générés.
 ```
 
 Pour que, pour chaque module, soit généré les fichiers de resources dans les différentes langues configurées globalement.
@@ -401,41 +401,67 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   Racine du répertoire de génération
 
-- `apiRootPath`
+- `entitiesPath`
 
-  Localisation du l'API générée (client ou serveur), relatif au répertoire de génération.
+  Localisation des classses persistées du modèle, relatif au répertoire de génération.
 
-  _Variables par tag_: **oui**
+  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
 
-- `resourceRootPath`
+  _Templating_: `{app}`, `{module}`
+
+  _Valeur par défaut_: `"javagen/{app}/entities/{module}"`
+
+  _Variables par tag_: **oui** (plusieurs définition de classes pourraient être générées si un fichier à plusieurs tags)
+
+- `daosPath`
+
+  Localisation des DAOs, relative au répertoire de génération.
+
+  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+
+  _Templating_: `{app}`, `{module}`
+
+  _Variables par tag_: **oui** (plusieurs DAOs pourraient être générés si un fichier à plusieurs tags)
+
+- `dtosPath`
+
+  Localisation des classes non persistées du modèle, relative au répertoire de génération.
+
+  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+
+  _Templating_: `{app}`, `{module}`
+
+  _Valeur par défaut_: `"javagen/{app}/dtos/{module}"`
+
+  _Variables par tag_: **oui** (plusieurs définition de classes pourraient être générées si un fichier à plusieurs tags)
+
+- `apiPath`
+
+  Localisation du l'API générée (client ou serveur), relative au répertoire de génération.
+
+  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+
+  _Templating_: `{app}`, `{module}`
+
+  _Valeur par défaut_: `"javagen/{app}/api/{module}"`
+
+  _Variables par tag_: **oui** (plusieurs clients/serveurs pourraient être générés si un fichier à plusieurs tags)
+
+- `apiGeneration`
+
+  Mode de génération de l'API (`"client"` ou `"server"`).
+
+  _Variables par tag_: **oui** (la valeur de la variable doit être `"client"` ou `"server"`. le client et le serveur pourraient être générés si un fichier à plusieurs tags)
+
+- `resourcesPath`
 
   Localisation des ressources, relative au répertoire de génération.
 
   _Variables par tag_: **oui**
 
-- `modelRootPath`
+- `enumShortcutMode`
 
-  Localisation du modèle, relative au répertoire de génération.
-
-  _Variables par tag_: **oui**
-
-- `daosPackageName`
-
-  Précise le nom du package dans lequel générer les daos
-
-  _Variables par tag_: **oui**
-
-- `entitiesPackageName`
-
-  Précise le nom du package dans lequel générer les classes persistées du modèle.
-
-  _Variables par tag_: **oui**
-
-- `dtosPackageName`
-
-  Précise le nom du package dans lequel générer les classes non persistées du modèle.
-
-  _Variables par tag_: **oui**
+  Option pour générer des getters et setters vers l'enum des références plutôt que sur la table
 
 - `fieldsEnum`
 
@@ -452,43 +478,27 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   _Templating_: `<>` (remplace par `<NomDeLaClasse>`)
 
-- `enumShortcutMode`
-
-  Option pour générer des getters et setters vers l'enum des références plutôt que sur la table
-
-- `apiPackageName`
-
-  Précise le nom du package dans lequel générer les controllers
-
-  _Variables par tag_: **oui**
-
-- `apiGeneration`
-
-  Mode de génération de l'API (`"client"` ou `"server"`).
-
-  _Variables par tag_: **oui** (la valeur de la variable doit être `"client"` ou `"server"`. le client et le serveur pourraient être générés si un fichier à plusieurs tags)
-
 - `persistenceMode`
 
   Mode de génération de la persistence (`"javax"` ou `"jakarta"`).
 
   _Variables par tag_: **oui** (la valeur de la variable doit être `"javax"` ou `"jakarta"`)
 
-- `Identity`
+- `identity`
 
   Options de génération de la séquence
 
-  - `Mode`
+  - `mode`
 
     Mode de génération de la persistence (`"none"` ou `"sequence"` ou `"identity"`).
 
     _Valeur par défaut_: `identity`
 
-  - `Increment`
+  - `increment`
 
     Incrément de la séquence générée.
 
-  - `Start`
+  - `start`
 
     Début de la séquence générée.
 
@@ -501,12 +511,11 @@ jpa:
   - tags:
       - dto
       - entity
-    modelOutputDirectory: ./jpa/src/main/javagen # Dossier cible de la génération
-    daosPackageName: topmodel.exemple.name.daos # Package des DAO
-    dtosPackageName: topmodel.exemple.name.dtos # Package des objets non persistés
-    entitiesPackageName: topmodel.exemple.name.entities # Package des objets non persistés
-    apiOutputDirectory: ./jpa/src/main/javagen # Dossier cible des API
-    apiPackageName: topmodel.exemple.name.api # Package des l'API
+    outputDirectory: ./jpa/src/main/javagen # Dossier cible de la génération
+    entitiesPath: topmodel/exemple/name/entities # Dossier cible des objets non persistés
+    daosPath: topmodel/exemple/name/daos # Dossier cible des DAO
+    dtosPath: topmodel/exemple/name/dtos # Dossier cible des objets non persistés
+    apiPath: topmodel/exemple/name/api # Dossier cible des API
     apiGeneration: Server # Mode de génération de l'API (serveur ou client)
     fieldsEnum: Persisted # Classes  dans lesquelles le générateur doit ajouter une enum des champs : jamais (None), dans les classes persistées (Persisted), dans les classes non persistées (Dto), ou les deux (Persisted_Dto)
     fieldsEnumInterface: topmodel.exemple.utils.IFieldEnum<> # Classe dont doivent hériter ces enum

--- a/docs/generator/jpa.md
+++ b/docs/generator/jpa.md
@@ -405,11 +405,11 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   Localisation des classses persistées du modèle, relatif au répertoire de génération.
 
-  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `.` et le `:` par des `/` dans cette valeur, tandis que le nom du package des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
-  _Valeur par défaut_: `"javagen/{app}/entities/{module}"`
+  _Valeur par défaut_: `"javagen:{app}/entities/{module}"`
 
   _Variables par tag_: **oui** (plusieurs définition de classes pourraient être générées si un fichier à plusieurs tags)
 
@@ -417,9 +417,9 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   Localisation des DAOs, relative au répertoire de génération.
 
-  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `.` et le `:` par des `/` dans cette valeur, tandis que le nom du package des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
   _Variables par tag_: **oui** (plusieurs DAOs pourraient être générés si un fichier à plusieurs tags)
 
@@ -427,11 +427,11 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   Localisation des classes non persistées du modèle, relative au répertoire de génération.
 
-  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `.` et le `:` par des `/` dans cette valeur, tandis que le nom du package des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
-  _Valeur par défaut_: `"javagen/{app}/dtos/{module}"`
+  _Valeur par défaut_: `"javagen:{app}/dtos/{module}"`
 
   _Variables par tag_: **oui** (plusieurs définition de classes pourraient être générées si un fichier à plusieurs tags)
 
@@ -439,11 +439,11 @@ Pour que, pour chaque module, soit généré les fichiers de resources dans les 
 
   Localisation du l'API générée (client ou serveur), relative au répertoire de génération.
 
-  Le package des classes générées sera déterminé à partir de cette localisation, en retirant tout ce qui précède `{app}` dans le chemin.
+  Le chemin des fichiers cibles sera calculé en remplaçant les `.` et le `:` par des `/` dans cette valeur, tandis que le nom du package des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
 
-  _Templating_: `{app}`, `{module}`
+  _Templating_: `{module}`
 
-  _Valeur par défaut_: `"javagen/{app}/api/{module}"`
+  _Valeur par défaut_: `"javagen:{app}/api/{module}"`
 
   _Variables par tag_: **oui** (plusieurs clients/serveurs pourraient être générés si un fichier à plusieurs tags)
 

--- a/docs/getting-started/07_generation.md
+++ b/docs/getting-started/07_generation.md
@@ -41,7 +41,7 @@ Lorsque nous ajoutons un générateur, nous lui attribuons également une liste 
 Exemple dans le fichier `topmodel.config` :
 
 ```yaml
-proceduralSql:
+sql:
   - tags:
       - entity
 ```
@@ -54,7 +54,7 @@ Classiquement
 - `dto` est utilisé pour les fichiers contenant les classes non persistées
 - Les fichiers contenant les `endpoints` contiennent les deux tags pour que soient générées les API clientes et server
 
-## Générer du 'SQL' (posgresql)
+## Générer du 'SQL' (postgresql)
 
 Ajoutons tout d'abord un générateur SQL à notre application.
 
@@ -63,25 +63,27 @@ Dans le fichier de configuration `topmodel.config`, nous pouvons ajouter le gén
 ```yaml
 ---
 app: sample # Nom de l'application
-proceduralSql: # Nom du générateur
+sql: # Nom du générateur
   - tags: # Liste des tags des fichiers à filtrer pour ce paramétrage
       - entity # Tag des fichiers contenant des classes persistées
 ```
 
 ### Scripts de créations des tables
 
-Ajoutons au générateur posgres la configuration permettant de générer les fichiers de création de table, des indexes et des clés d'unicités
+Ajoutons au générateur postgres la configuration permettant de générer les fichiers de création de table, des indexes et des clés d'unicités
 
 ```yaml
 ---
 app: sample
-proceduralSql:
+sql:
   - tags:
       - entity
-    crebasFile: ./pg/model/01_crebas.sql
-    indexFKFile: ./pg/model/02_index-fk.sql
-    uniqueKeysFile: ./pg/model/03_uniq.sql
+    outputDirectory: ./pg/model/
     targetDBMS: postgre
+    procedural:
+      crebasFile: 01_crebas.sql
+      indexFKFile: 02_index-fk.sql
+      uniqueKeysFile: 03_uniq.sql
 ```
 
 Dans le répertoire du projet, contenant le fichier `topmodel.config`, lancer la commande `modgen`.
@@ -106,14 +108,18 @@ app: sample
 proceduralSql:
   - tags:
       - entity
-    crebasFile: ./pg/model/01_crebas.sql
-    indexFKFile: ./pg/model/02_index-fk.sql
-    uniqueKeysFile: ./pg/model/03_uniq.sql
+    outputDirectory: ./pg/model/
     targetDBMS: postgre
+    procedural:
+      crebasFile: 01_crebas.sql
+      indexFKFile: 02_index-fk.sql
+      uniqueKeysFile: 03_uniq.sql
   - tags:
       - entity
-    initListFile: ./pg/model/04_references.sql
+    outputDirectory: ./pg/model/
     targetDBMS: postgre
+    procedural:
+      initListFile: 04_references.sql
 ```
 
 Le fichier d'initialisation des listes de référence est créé.

--- a/samples/generators/csharp/topmodel.config
+++ b/samples/generators/csharp/topmodel.config
@@ -7,14 +7,14 @@ csharp:
       - back
       - api-client
     variables:
-      clientsDb: Clients/{app}.Clients.Db
+      clientsDb: Clients:{app}.Clients.Db
     tagVariables:
       back:
         apiGeneration: Server
         apiRootPath: CSharp.Api
       api-client:
         apiGeneration: Client
-        apiRootPath: Clients/{app}.Clients.External
+        apiRootPath: Clients:{app}.Clients.External
     outputDirectory: src
     dbContextPath: "{clientsDb}"
     persistantModelPath: "{clientsDb}/Models/{module}"

--- a/samples/generators/jpa/topmodel.config
+++ b/samples/generators/jpa/topmodel.config
@@ -8,13 +8,13 @@ jpa:
       - api-client
     tagVariables:
       back:
-        apiPath: "javagen/{app}/api/server/{module}"
+        apiPath: "javagen:{app}/api/server/{module}"
         apiGeneration: Server
       api-client:
-        apiPath: "javagen/{app}/api/client/{module}"
+        apiPath: "javagen:{app}/api/client/{module}"
         apiGeneration: Client
     outputDirectory: src/main
-    daosPath: "javagen/{app}/daos/{module}"
+    daosPath: "javagen:{app}/daos/{module}"
     apiPath: "{apiPath}"
     apiGeneration: "{apiGeneration}"
     resourcesPath: resources/i18n/model

--- a/samples/generators/jpa/topmodel.config
+++ b/samples/generators/jpa/topmodel.config
@@ -1,29 +1,23 @@
 ---
-app: Jpa
+app: topmodel.jpa.sample.demo
 modelRoot: ../../model
 lockFileName: jpa.topmodel.lock
 jpa:
   - tags:
       - back
       - api-client
-    variables:
-      rootPackageName: topmodel.jpa.sample.demo
     tagVariables:
       back:
+        apiPath: "javagen/{app}/api/server/{module}"
         apiGeneration: Server
-        apiPackageName: "{rootPackageName}.api.server"
       api-client:
+        apiPath: "javagen/{app}/api/client/{module}"
         apiGeneration: Client
-        apiPackageName: "{rootPackageName}.api.client"
     outputDirectory: src/main
-    modelRootPath: javagen
-    daosPackageName: "{rootPackageName}.daos"
-    dtosPackageName: "{rootPackageName}.dtos"
-    entitiesPackageName: "{rootPackageName}.entities"
-    apiRootPath: javagen
-    resourceRootPath: resources/i18n/model
-    apiPackageName: "{apiPackageName}"
+    daosPath: "javagen/{app}/daos/{module}"
+    apiPath: "{apiPath}"
     apiGeneration: "{apiGeneration}"
+    resourcesPath: resources/i18n/model
     fieldsEnum: Persisted_Dto
     enumShortcutMode: false
     persistenceMode: Jakarta


### PR DESCRIPTION
Fix #215 

J'ai mis à jour la doc et les samples, y a tout dedans je dirais ;)

Mais :
- La config JPA demande maintenant `entitiesPath`, `dtosPath`, `apiPath`, `daosPath` et `resourcesPath` pour déterminer les chemins de génération + le nom du package (au lieu des diverses combinaisons `XXXrootPath` + `XXXpackageName`). Les 3 premiers ont désormais une valeur par défaut.
- `{app}` est désormais une variable globale normale, et on utilise le séparateur `:` dans les chemins à partir desquels on doit déterminer un nom de package/namespace (ceux du dessus en Java par exemple)

J'ai aussi ajouté `disable` dans les différentes config, qui prend une liste de noms de générateurs à désactiver si besoin (puisque les générateurs "obligatoires" comme par exemple les générateurs de classes sont impossibles à configurer pour ne rien générer).