### PR TITLE
Rétro-ingénierie d'une base Oracle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Modgen",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/TopModel.Generator/bin/Debug/TopModel.Generator.dll",
+            "args": ["--file", "${workspaceFolder}\\samples\\generators\\php\\topmodel.config"],
+            "cwd": "${workspaceFolder}/TopModel.Generator",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        
+        {
+            "name": "Tmdgen",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-tmd",
+            "program": "${workspaceFolder}/TopModel.ModelGenerator/bin/Debug/TopModel.ModelGenerator.dll",
+            "args": ["--file", "${workspaceFolder}\\samples\\generators\\database\\tmdgen.config"],
+            "cwd": "${workspaceFolder}/TopModel.ModelGenerator",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/TopModel.Generator/TopModel.Generator.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-tmd",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/TopModel.Generator/TopModel.Generator.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/TopModel.Generator/TopModel.Generator.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/TopModel.Core/schema.tmdgen.config.json
+++ b/TopModel.Core/schema.tmdgen.config.json
@@ -174,6 +174,15 @@
                 "type": "string",
                 "description": "Mot de passe de connexion à la base de données",
                 "default": "postgres"
+              },
+              "dbType": {
+                "type": "string",
+                "description": "Type de la base de données : postgresql ou oracle",
+                "enum": [
+                  "oracle",
+                  "postgresql"
+                ],
+                "default": "postgresql"
               }
             }
           }

--- a/TopModel.Core/schema.tmdgen.config.json
+++ b/TopModel.Core/schema.tmdgen.config.json
@@ -81,6 +81,7 @@
         "type": "object",
         "description": "Configuration de la génération de fichiers Topmodel à partir d'une base de données",
         "additionalProperties": false,
+        "required": ["source"],
         "properties": {
           "tags": {
             "type": "array",
@@ -144,6 +145,7 @@
             "type": "object",
             "description": "Informations de connexion à la base de données",
             "additionalProperties": false,
+            "required": ["dbType"],
             "properties": {
               "host": {
                 "type": "string",
@@ -181,8 +183,7 @@
                 "enum": [
                   "oracle",
                   "postgresql"
-                ],
-                "default": "postgresql"
+                ]
               }
             }
           }

--- a/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
@@ -21,12 +21,12 @@ public class DatabaseOraTmdGenerator : DatabaseTmdGenerator
     {
         return @$"
             select                 
-                table_name                        AS TableName,
-                column_name                       AS ColumnName,
-                data_type                         AS DataType,
-                nullable                          AS Nullable,    
-                data_precision                    AS ""Precision"",
-                coalesce(char_length, data_scale) AS Scale
+                table_name                                  AS TableName,
+                column_name                                 AS ColumnName,
+                data_type                                   AS DataType,
+                case when nullable = 'Y' then 1 else 0 end  AS Nullable,   
+                data_precision                              AS ""Precision"",
+                coalesce(char_length, data_scale)           AS Scale
             from all_tab_columns
             where owner = '{_config.Source.Schema}'
             order by table_name, column_id

--- a/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Data.Common;
+using Microsoft.Extensions.Logging;
 using Oracle.ManagedDataAccess.Client;
 
 namespace TopModel.ModelGenerator.Database;
@@ -9,12 +10,12 @@ public class DatabaseOraTmdGenerator : DatabaseTmdGenerator
 
 #pragma warning disable CS8618
     public DatabaseOraTmdGenerator(ILogger<DatabaseOraTmdGenerator> logger, DatabaseConfig config)
-        : base(logger, config, new OracleConnection(config.ConnectionString))
+        : base(logger, config)
     {
         _config = config;
     }
-#pragma warning restore CS8618
 
+#pragma warning restore CS8618
     public override string Name => "DatabaseOraGen";
 
     protected override string GetColumnsQuery()
@@ -31,6 +32,11 @@ public class DatabaseOraTmdGenerator : DatabaseTmdGenerator
             where owner = '{_config.Source.Schema}'
             order by table_name, column_id
             ";
+    }
+
+    protected override DbConnection GetConnection()
+    {
+        return new OracleConnection(_config.ConnectionString);
     }
 
     protected override string GetForeignKeysQuery()

--- a/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseOraTmdGenerator.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using Oracle.ManagedDataAccess.Client;
+
+namespace TopModel.ModelGenerator.Database;
+
+public class DatabaseOraTmdGenerator : DatabaseTmdGenerator
+{
+    private readonly DatabaseConfig _config;
+
+#pragma warning disable CS8618
+    public DatabaseOraTmdGenerator(ILogger<DatabaseOraTmdGenerator> logger, DatabaseConfig config)
+        : base(logger, config, new OracleConnection(config.ConnectionString))
+    {
+        _config = config;
+    }
+#pragma warning restore CS8618
+
+    public override string Name => "DatabaseOraGen";
+
+    protected override string GetColumnsQuery()
+    {
+        return @$"
+            select                 
+                table_name                        AS TableName,
+                column_name                       AS ColumnName,
+                data_type                         AS DataType,
+                nullable                          AS Nullable,    
+                data_precision                    AS ""Precision"",
+                coalesce(char_length, data_scale) AS Scale
+            from all_tab_columns
+            where owner = '{_config.Source.Schema}'
+            order by table_name, column_id
+            ";
+    }
+
+    protected override string GetForeignKeysQuery()
+    {
+        return @$"
+                Select 
+                    uc.constraint_name      AS ""Name"",
+                    uc.table_name           AS TableName,
+                    cols.column_name        AS ColumnName,
+                    uc_pk.table_name        AS ForeignTableName,
+                    cols_pk.column_name     AS ForeignColumnName
+                From 
+                    user_constraints uc
+                    JOIN user_cons_columns cols ON uc.constraint_name = cols.constraint_name
+                    JOIN user_constraints uc_pk ON uc.r_constraint_name = uc_pk.constraint_name
+                    JOIN user_cons_columns cols_pk ON uc_pk.constraint_name = cols_pk.constraint_name
+                Where 
+                    uc.owner = '{_config.Source.Schema}'
+                    and uc.constraint_type = 'R'
+                Order by
+                    uc.table_name,
+                    cols.position
+            ";
+    }
+
+    protected override string GetPrimaryKeysQuery()
+    {
+        return GetConstraintKeyQuery("P");
+    }
+
+    protected override string GetUniqueKeysQuery()
+    {
+        return GetConstraintKeyQuery("U");
+    }
+
+    private string GetConstraintKeyQuery(string name)
+    {
+        return @$"
+                select 
+                    uc.constraint_name AS ""Name"",
+                    uc.table_name      AS TableName,
+                    cols.column_name   AS ColumnName
+                from 
+                    user_constraints uc
+                    join user_cons_columns cols ON uc.constraint_name = cols.constraint_name
+                where
+                    uc.owner = '{_config.Source.Schema}'
+                    and uc.constraint_type = '{name}'
+                order by
+                    uc.table_name, 
+                    cols.position
+            ";
+    }
+}

--- a/TopModel.ModelGenerator/Database/DatabasePgTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabasePgTmdGenerator.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace TopModel.ModelGenerator.Database;
+
+public class DatabasePgTmdGenerator : DatabaseTmdGenerator, IDisposable
+{
+    private readonly DatabaseConfig _config;
+
+#pragma warning disable CS8618
+    public DatabasePgTmdGenerator(ILogger<DatabasePgTmdGenerator> logger, DatabaseConfig config)
+        : base(logger, config, new NpgsqlConnection(config.ConnectionString))
+    {
+        _config = config;
+    }
+#pragma warning restore CS8618
+
+    public override string Name => "DatabasePgGen";
+
+    protected override string GetColumnsQuery()
+    {
+        // Récupération des colonnes
+        return @$"
+                select  table_name                                                              as TableName, 
+                        column_name                                                             as ColumnName, 
+                        data_type                                                               as DataType,
+                        is_nullable = 'YES'                                                     as Nullable,
+                        coalesce(numeric_precision, datetime_precision, interval_precision)     as Precision,
+                        coalesce(character_maximum_length, numeric_scale, interval_precision)   as Scale
+                from information_schema.columns 
+                where table_schema  = '{_config.Source.Schema}'
+                order by ordinal_position 
+            ";
+    }
+
+    protected override string GetForeignKeysQuery()
+    {
+        // Récupération des contraintes de clés étrangères
+        return GetConstraintKeyQuery("FOREIGN KEY");
+    }
+
+    protected override string GetPrimaryKeysQuery()
+    {
+        // Récupération des contraintes de clés primaires
+        return GetConstraintKeyQuery("PRIMARY KEY");
+    }
+
+    protected override string GetUniqueKeysQuery()
+    {
+        // Récupération des contraintes d'unicité
+        return $@"
+                SELECT
+                    tc.constraint_name  AS Name,
+                    tc.table_name       AS TableName,
+                    kcu.column_name     AS ColumnName
+                FROM 
+                    information_schema.table_constraints        AS tc 
+                    JOIN information_schema.key_column_usage    AS kcu
+                        ON  tc.constraint_name      = kcu.constraint_name
+                        AND tc.table_schema         = kcu.table_schema
+                WHERE       tc.constraint_type      = 'UNIQUE'
+                    AND     tc.table_schema         = '{_config.Source.Schema}'
+            ";
+    }
+
+    private string GetConstraintKeyQuery(string name)
+    {
+        return @$"
+                SELECT
+                    tc.table_name   AS TableName, 
+                    kcu.column_name AS ColumnName, 
+                    ccu.table_name  AS ForeignTableName,
+                    ccu.column_name AS ForeignColumnName 
+                FROM 
+                            information_schema.table_constraints   AS tc 
+                    JOIN    information_schema.key_column_usage    AS kcu
+                        ON  tc.constraint_name   = kcu.constraint_name
+                        AND tc.table_schema      = kcu.table_schema
+                    JOIN information_schema.constraint_column_usage AS ccu
+                        ON  ccu.constraint_name  = tc.constraint_name
+                        AND ccu.table_schema     = tc.table_schema
+                WHERE       tc.constraint_type   = '{name}'
+                    AND     tc.table_schema      = '{_config.Source.Schema}'
+                    AND     ccu.table_schema     = '{_config.Source.Schema}'
+            ";
+    }
+}

--- a/TopModel.ModelGenerator/Database/DatabasePgTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabasePgTmdGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Data.Common;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace TopModel.ModelGenerator.Database;
@@ -9,7 +10,7 @@ public class DatabasePgTmdGenerator : DatabaseTmdGenerator, IDisposable
 
 #pragma warning disable CS8618
     public DatabasePgTmdGenerator(ILogger<DatabasePgTmdGenerator> logger, DatabaseConfig config)
-        : base(logger, config, new NpgsqlConnection(config.ConnectionString))
+        : base(logger, config)
     {
         _config = config;
     }
@@ -31,6 +32,11 @@ public class DatabasePgTmdGenerator : DatabaseTmdGenerator, IDisposable
                 where table_schema  = '{_config.Source.Schema}'
                 order by ordinal_position 
             ";
+    }
+
+    protected override DbConnection GetConnection()
+    {
+        return new NpgsqlConnection(_config.ConnectionString);
     }
 
     protected override string GetForeignKeysQuery()

--- a/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Data.Common;
+using System.Text.RegularExpressions;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -6,31 +7,30 @@ using TopModel.Utils;
 
 namespace TopModel.ModelGenerator.Database;
 
-public class DatabaseTmdGenerator : ModelGenerator, IDisposable
+public abstract class DatabaseTmdGenerator : ModelGenerator, IDisposable
 {
     private readonly Dictionary<string, TmdClass> _classes = new();
     private readonly DatabaseConfig _config;
-    private readonly NpgsqlConnection _connection;
+
+    private readonly DbConnection _connection;
     private readonly ILogger<DatabaseTmdGenerator> _logger;
 
     private int _fileIndice = 10;
     private int _moduleIndice = 0;
 
 #pragma warning disable CS8618
-    public DatabaseTmdGenerator(ILogger<DatabaseTmdGenerator> logger, DatabaseConfig config)
+    public DatabaseTmdGenerator(ILogger<DatabaseTmdGenerator> logger, DatabaseConfig config, DbConnection connection)
         : base(logger)
     {
         _config = config;
+        _connection = connection;
         _logger = logger;
-
-        // Connexion à la base de données {_config.Source.DbName}
-        _connection = new NpgsqlConnection(config.ConnectionString);
     }
+
+    public Dictionary<string, string> Passwords { get; init; }
 #pragma warning restore CS8618
 
     public override string Name => "DatabaseGen";
-
-    public Dictionary<string, string> Passwords { get; init; }
 
     private IEnumerable<TmdFile> Files => _classes.Select(c => c.Value.File!).Distinct().OrderBy(c => c.Name);
 
@@ -43,44 +43,14 @@ public class DatabaseTmdGenerator : ModelGenerator, IDisposable
         }
     }
 
-    /// <inheritdoc cref="IDisposable.Dispose" />
-    void IDisposable.Dispose()
+    public void Dispose()
     {
         _connection.Dispose();
     }
 
     protected override async IAsyncEnumerable<string> GenerateCore()
     {
-        if (Passwords.TryGetValue(_config.Source.DbName, out var password))
-        {
-            _config.Source.Password = password;
-        }
-        else
-        {
-            try
-            {
-                using var connection = new NpgsqlConnection(_config.ConnectionString);
-                connection.Open();
-            }
-            catch (NpgsqlException)
-            {
-                _logger.LogInformation($"Mot de passe pour l'utilisateur {_config.Source.User}:  ");
-                while (true)
-                {
-                    var key = Console.ReadKey(true);
-                    if (key.Key == ConsoleKey.Enter)
-                    {
-                        break;
-                    }
-
-                    password += key.KeyChar;
-                }
-
-                Passwords.Add(_config.Source.DbName, password ?? string.Empty);
-                _config.Source.Password = password;
-            }
-        }
-
+        InitConnection();
         var columns = await GetColumns();
         var classGroups = columns.GroupBy(c => c.TableName);
 
@@ -109,6 +79,14 @@ public class DatabaseTmdGenerator : ModelGenerator, IDisposable
             yield return file;
         }
     }
+
+    protected abstract string GetColumnsQuery();
+
+    protected abstract string GetForeignKeysQuery();
+
+    protected abstract string GetPrimaryKeysQuery();
+
+    protected abstract string GetUniqueKeysQuery();
 
     private static void AddUniqConstraints(TmdClass classe, IEnumerable<IGrouping<string, ConstraintKey>> groupings)
     {
@@ -344,76 +322,32 @@ public class DatabaseTmdGenerator : ModelGenerator, IDisposable
     {
         // Récupération des colonnes
         var columns = await _connection
-            .QueryAsync<DbColumn>(@$"
-                select  table_name                                                              as TableName, 
-                        column_name                                                             as ColumnName, 
-                        data_type                                                               as DataType,
-                        is_nullable = 'YES'                                                     as Nullable,
-                        coalesce(numeric_precision, datetime_precision, interval_precision)     as Precision,
-                        coalesce(character_maximum_length, numeric_scale, interval_precision)   as Scale
-                from information_schema.columns 
-                where table_schema  = '{_config.Source.Schema}'
-                order by ordinal_position 
-            ");
+            .QueryAsync<DbColumn>(GetColumnsQuery());
         return columns.Where(c => !_config.Exclude.Contains(c.TableName));
     }
 
-    private async Task<IEnumerable<ConstraintKey>> GetConstraintKey(string name)
+    private async Task<IEnumerable<ConstraintKey>> GetConstraintKeys(string query)
     {
-        var constraint = await _connection
-            .QueryAsync<ConstraintKey>(@$"
-                SELECT
-                    tc.table_name   AS TableName, 
-                    kcu.column_name AS ColumnName, 
-                    ccu.table_name  AS ForeignTableName,
-                    ccu.column_name AS ForeignColumnName 
-                FROM 
-                            information_schema.table_constraints   AS tc 
-                    JOIN    information_schema.key_column_usage    AS kcu
-                        ON  tc.constraint_name   = kcu.constraint_name
-                        AND tc.table_schema      = kcu.table_schema
-                    JOIN information_schema.constraint_column_usage AS ccu
-                        ON  ccu.constraint_name  = tc.constraint_name
-                        AND ccu.table_schema     = tc.table_schema
-                WHERE       tc.constraint_type   = '{name}'
-                    AND     tc.table_schema      = '{_config.Source.Schema}'
-                    AND     ccu.table_schema     = '{_config.Source.Schema}'
-            ");
+        // Récupération des contraintes
+        var keys = await _connection
+            .QueryAsync<ConstraintKey>(query);
 
-        return constraint.Where(c => !_config.Exclude.Contains(c.TableName));
+        return keys.Where(c => !_config.Exclude.Contains(c.TableName));
     }
 
     private Task<IEnumerable<ConstraintKey>> GetForeignKeys()
     {
-        // Récupération des contraintes de clés étrangères
-        return GetConstraintKey("FOREIGN KEY");
+        return GetConstraintKeys(GetForeignKeysQuery());
     }
 
     private Task<IEnumerable<ConstraintKey>> GetPrimaryKeys()
     {
-        // Récupération des contraintes de clés primaires
-        return GetConstraintKey("PRIMARY KEY");
+        return GetConstraintKeys(GetPrimaryKeysQuery());
     }
 
-    private async Task<IEnumerable<ConstraintKey>> GetUniqueKeys()
+    private Task<IEnumerable<ConstraintKey>> GetUniqueKeys()
     {
-        // Récupération des contraintes d'unicité
-        var keys = await _connection
-            .QueryAsync<ConstraintKey>(@$"
-                SELECT
-                    tc.constraint_name  AS Name,
-                    tc.table_name       AS TableName,
-                    kcu.column_name     AS ColumnName
-                FROM 
-                    information_schema.table_constraints        AS tc 
-                    JOIN information_schema.key_column_usage    AS kcu
-                        ON  tc.constraint_name      = kcu.constraint_name
-                        AND tc.table_schema         = kcu.table_schema
-                WHERE       tc.constraint_type      = 'UNIQUE'
-                    AND     tc.table_schema         = '{_config.Source.Schema}'
-            ");
-
-        return keys.Where(c => !_config.Exclude.Contains(c.TableName));
+        return GetConstraintKeys(GetUniqueKeysQuery());
     }
 
     private void GroupFiles()
@@ -454,6 +388,41 @@ public class DatabaseTmdGenerator : ModelGenerator, IDisposable
         foreach (var group in classGroups)
         {
             _classes.Add(group.Key, new TmdClass() { Name = group.Key.ToPascalCase() });
+        }
+    }
+
+    private void InitConnection()
+    {
+        {
+            if (Passwords.TryGetValue(_config.Source.DbName, out var password))
+            {
+                _config.Source.Password = password;
+            }
+            else
+            {
+                try
+                {
+                    using var connection = new NpgsqlConnection(_config.ConnectionString);
+                    connection.Open();
+                }
+                catch (NpgsqlException)
+                {
+                    _logger.LogInformation($"Mot de passe pour l'utilisateur {_config.Source.User}:  ");
+                    while (true)
+                    {
+                        var key = Console.ReadKey(true);
+                        if (key.Key == ConsoleKey.Enter)
+                        {
+                            break;
+                        }
+
+                        password += key.KeyChar;
+                    }
+
+                    Passwords.Add(_config.Source.DbName, password ?? string.Empty);
+                    _config.Source.Password = password;
+                }
+            }
         }
     }
 

--- a/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
@@ -2,7 +2,6 @@
 using System.Text.RegularExpressions;
 using Dapper;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 using TopModel.Utils;
 
 namespace TopModel.ModelGenerator.Database;
@@ -402,10 +401,9 @@ public abstract class DatabaseTmdGenerator : ModelGenerator, IDisposable
             {
                 try
                 {
-                    using var connection = new NpgsqlConnection(_config.ConnectionString);
-                    connection.Open();
+                    _connection.Open();
                 }
-                catch (NpgsqlException)
+                catch (Exception e)
                 {
                     _logger.LogInformation($"Mot de passe pour l'utilisateur {_config.Source.User}:  ");
                     while (true)

--- a/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
+++ b/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
@@ -2,6 +2,7 @@
 
 public class DatabaseConfig
 {
+
     public string OutputDirectory { get; set; } = "./";
 
     public IList<DomainMapping> Domains { get; set; } = new List<DomainMapping>();
@@ -16,5 +17,9 @@ public class DatabaseConfig
 
     public List<ModuleConfig> Modules { get; set; } = new();
 
-    public string ConnectionString => @$"Host={Source.Host};Port={Source.Port};Database={Source.DbName};Username={Source.User}{(Source.Password != null ? $";Password={Source.Password}" : string.Empty)}";
+    public string ConnectionString => Source.DbType == DbType.POSTGRESQL ? PgConnectionString : OracleConnectionString;
+
+    private string OracleConnectionString => $@"Data Source=(DESCRIPTION =(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST = {Source.Host})(PORT = {Source.Port})))(CONNECT_DATA =(SERVICE_NAME = {Source.DbName})));;User ID={Source.User};{(Source.Password != null ? $";Password={Source.Password}" : string.Empty)};Unicode=True";
+
+    private string PgConnectionString => @$"Host={Source.Host};Port={Source.Port};Database={Source.DbName};Username={Source.User}{(Source.Password != null ? $";Password={Source.Password}" : string.Empty)}";
 }

--- a/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
+++ b/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
@@ -19,7 +19,7 @@ public class DatabaseConfig
 
     public string ConnectionString => Source.DbType == DbType.POSTGRESQL ? PgConnectionString : OracleConnectionString;
 
-    private string OracleConnectionString => $@"Data Source=(DESCRIPTION =(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST = {Source.Host})(PORT = {Source.Port})))(CONNECT_DATA =(SERVICE_NAME = {Source.DbName})));;User ID={Source.User};{(Source.Password != null ? $";Password={Source.Password}" : string.Empty)};Unicode=True";
+    private string OracleConnectionString => $@"DATA SOURCE={Source.Host}:{Source.Port}/{Source.DbName};USER ID={Source.User};password={Source.Password}";
 
     private string PgConnectionString => @$"Host={Source.Host};Port={Source.Port};Database={Source.DbName};Username={Source.User}{(Source.Password != null ? $";Password={Source.Password}" : string.Empty)}";
 }

--- a/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
+++ b/TopModel.ModelGenerator/Database/config/DatabaseConfig.cs
@@ -2,7 +2,6 @@
 
 public class DatabaseConfig
 {
-
     public string OutputDirectory { get; set; } = "./";
 
     public IList<DomainMapping> Domains { get; set; } = new List<DomainMapping>();

--- a/TopModel.ModelGenerator/Database/config/DatabaseSource.cs
+++ b/TopModel.ModelGenerator/Database/config/DatabaseSource.cs
@@ -2,6 +2,8 @@
 
 public class DatabaseSource
 {
+    public DbType DbType { get; set; } = DbType.POSTGRESQL;
+
     public string Host { get; set; } = "localhost";
 
     public string Port { get; set; } = "5432";

--- a/TopModel.ModelGenerator/Database/config/DbType.cs
+++ b/TopModel.ModelGenerator/Database/config/DbType.cs
@@ -1,4 +1,4 @@
-public enum DbType
+﻿public enum DbType
 {
     /// <summary>
     ///  Base de données Posgresql

--- a/TopModel.ModelGenerator/Database/config/DbType.cs
+++ b/TopModel.ModelGenerator/Database/config/DbType.cs
@@ -1,0 +1,12 @@
+public enum DbType
+{
+    /// <summary>
+    ///  Base de données Posgresql
+    /// </summary>
+    POSTGRESQL,
+
+    /// <summary>
+    ///  Base de données Oracle
+    /// </summary>
+    ORACLE
+}

--- a/TopModel.ModelGenerator/Program.cs
+++ b/TopModel.ModelGenerator/Program.cs
@@ -168,13 +168,26 @@ async Task StartGeneration(string filePath, string directoryName, int i)
     foreach (var conf in config.Database)
     {
         ModelUtils.TrimSlashes(conf, c => c.OutputDirectory);
-        services.AddSingleton<ModelGenerator>(p => new DatabaseTmdGenerator(p.GetRequiredService<ILogger<DatabaseTmdGenerator>>(), conf)
+        if (conf.Source.DbType == DbType.ORACLE)
         {
-            DirectoryName = directoryName,
-            ModelRoot = config.ModelRoot,
-            Number = config.Database.IndexOf(conf) + 1,
-            Passwords = passwords
-        });
+            services.AddSingleton<ModelGenerator>(p => new DatabaseOraTmdGenerator(p.GetRequiredService<ILogger<DatabaseOraTmdGenerator>>(), conf)
+            {
+                DirectoryName = directoryName,
+                ModelRoot = config.ModelRoot,
+                Number = config.Database.IndexOf(conf) + 1,
+                Passwords = passwords
+            });
+        }
+        else if (conf.Source.DbType == DbType.POSTGRESQL)
+        {
+            services.AddSingleton<ModelGenerator>(p => new DatabasePgTmdGenerator(p.GetRequiredService<ILogger<DatabasePgTmdGenerator>>(), conf)
+            {
+                DirectoryName = directoryName,
+                ModelRoot = config.ModelRoot,
+                Number = config.Database.IndexOf(conf) + 1,
+                Passwords = passwords
+            });
+        }
     }
 
     using var provider = services.BuildServiceProvider();

--- a/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
+++ b/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TopModel.VSCode/.vscode/settings.json
+++ b/TopModel.VSCode/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 4,
+}

--- a/docs/tmdgen/database.md
+++ b/docs/tmdgen/database.md
@@ -18,11 +18,12 @@ La configuration du générateur `database` permet de définir :
 
 - `outputDirectory` : répertoire de génération des fichiers, relatif au `modelRoot`
 - `source` :
+  - `dbType`: type de base de base de données source (`postgresql` ou `oracle`)
   - `host`: hôte de la base de données
   - `port`: port d'écoute de la base de données
   - `dbName`: nom de la base de données
   - `user`: nom de l'utilisateur de connexion à la base de données
-  - `schema`: schéma dont on souhaite extraire la structure
+  - `schema`: schéma dont on souhaite extraire la structure, `db owner` pour les bases Oracle
   - `password`: (factultatif) mot de passe de connexion à la base de données
 - `domains` : Correspondance entre les types dans la spécification `openApi` et les domaines du modèle cible. Quelques spécificités
   - Définition d'un `name` ou d'un `type`, pour matcher soit sur le nom de la propriété soit sur son type
@@ -103,7 +104,7 @@ database:
 
 ## Connexion à la base de données
 
-Actuellement, seules les bases de données `postgresql` sont supportées par le générateur `database`. Pour s'y connecter, remplir les informations de la propriété `source` de la configuration. Vous pouvez remarquer que le `password` n'est pas obligatoire. En effet, vous pouvez utiliser la variable d'environnement `PGPASSWORD`.
+Actuellement, seules les bases de données `postgresql` et `oracle` sont supportées par le générateur `database`. Pour s'y connecter, remplir les informations de la propriété `source` de la configuration. Vous pouvez remarquer que le `password` n'est pas obligatoire. En effet, vous pouvez utiliser la variable d'environnement `PGPASSWORD` pour `postgresql` par exemple.
 
 Si la connexion à la base de données échoue, le mot de passe vous sera demandé dans la console.
 


### PR DESCRIPTION
Générer les fichiers de modélisation TopModel à partir d'une base Oracle vivante.

Il faut maintenant préciser le type de base de données dans la configuration (postgresql/oracle)


Fix: #248 