### PR TITLE
[C#] Suppression de la génération des constructeurs + `useRecords`

### DIFF
--- a/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
@@ -31,19 +31,13 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
 
     protected override void HandleFile(string filePath, string fileName, string tag, IList<Endpoint> endpoints)
     {
-        using var fw = new CSharpWriter(filePath, _logger, Config.UseLatestCSharp);
+        using var fw = new CSharpWriter(filePath, _logger);
 
         var hasBody = endpoints.Any(e => e.GetBodyParam() != null);
         var hasReturn = endpoints.Any(e => e.Returns != null);
         var hasJson = hasReturn || hasBody;
 
         var usings = new List<string>();
-
-        if (!Config.UseLatestCSharp)
-        {
-            usings.Add("System.Net.Http");
-            usings.Add("System.Threading.Tasks");
-        }
 
         if (hasBody)
         {
@@ -58,20 +52,11 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
         if (hasJson)
         {
             usings.Add("System.Text.Json");
-
-            if (Config.UseLatestCSharp)
-            {
-                usings.Add("System.Text.Json.Serialization");
-            }
+            usings.Add("System.Text.Json.Serialization");
         }
 
         if (endpoints.Any(e => e.GetQueryParams().Any()))
         {
-            if (!Config.UseLatestCSharp)
-            {
-                usings.AddRange(new[] { "System.Collections.Generic", "System.Linq" });
-            }
-
             if (endpoints.Any(e => e.GetQueryParams().Any(qp =>
             {
                 var typeName = Config.GetType(qp);
@@ -114,46 +99,34 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
 
         fw.WriteNamespace(ns);
 
-        fw.WriteSummary(1, $"Client {fileName}");
+        fw.WriteSummary($"Client {fileName}");
         fw.WriteClassDeclaration(className, null);
 
-        fw.WriteLine(2, "private readonly HttpClient _client;");
+        fw.WriteLine(1, "private readonly HttpClient _client;");
         if (hasJson)
         {
-            if (Config.UseLatestCSharp)
-            {
-                fw.WriteLine(2, "private readonly JsonSerializerOptions _jsOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };");
-            }
-            else
-            {
-                fw.WriteLine(2, "private readonly JsonSerializerOptions _jsOptions = new() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };");
-            }
+            fw.WriteLine(1, "private readonly JsonSerializerOptions _jsOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };");
         }
 
         fw.WriteLine();
-        fw.WriteSummary(2, "Constructeur");
+        fw.WriteSummary(1, "Constructeur");
         fw.WriteParam("client", "HttpClient injecté.");
-        fw.WriteLine(2, $"public {className}(HttpClient client)");
-        fw.WriteLine(2, "{");
-        fw.WriteLine(3, "_client = client;");
-        fw.WriteLine(2, "}");
+        fw.WriteLine(1, $"public {className}(HttpClient client)");
+        fw.WriteLine(1, "{");
+        fw.WriteLine(2, "_client = client;");
+        fw.WriteLine(1, "}");
 
         foreach (var endpoint in endpoints.OrderBy(endpoint => endpoint.NamePascal))
         {
             fw.WriteLine();
-            fw.WriteSummary(2, endpoint.Description);
+            fw.WriteSummary(1, endpoint.Description);
 
             foreach (var param in endpoint.Params)
             {
                 fw.WriteParam(param.GetParamName(), param.Comment);
             }
 
-            fw.WriteReturns(2, endpoint.Returns?.Comment ?? "Task.");
-
-            if (!Config.UseLatestCSharp)
-            {
-                fw.Write("    ");
-            }
+            fw.WriteReturns(1, endpoint.Returns?.Comment ?? "Task.");
 
             fw.Write("    public async Task");
 
@@ -186,16 +159,16 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
             }
 
             fw.WriteLine(")");
-            fw.WriteLine(2, "{");
+            fw.WriteLine(1, "{");
 
             var bodyParam = endpoint.GetBodyParam();
 
-            fw.WriteLine(3, $"await EnsureAuthentication();");
+            fw.WriteLine(2, $"await EnsureAuthentication();");
 
             if (endpoint.GetQueryParams().Any())
             {
-                fw.WriteLine(3, "var query = await new FormUrlEncodedContent(new Dictionary<string, string>");
-                fw.WriteLine(3, "{");
+                fw.WriteLine(2, "var query = await new FormUrlEncodedContent(new Dictionary<string, string>");
+                fw.WriteLine(2, "{");
 
                 foreach (var qp in endpoint.GetQueryParams().Where(qp => !Config.GetType(qp).Contains("[]")))
                 {
@@ -206,22 +179,17 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
                         _ => $"?.ToString(CultureInfo.InvariantCulture)"
                     };
 
-                    fw.WriteLine(4, $@"[""{qp.GetParamName()}""] = {qp.GetParamName().Verbatim()}{toString},");
+                    fw.WriteLine(3, $@"[""{qp.GetParamName()}""] = {qp.GetParamName().Verbatim()}{toString},");
                 }
 
                 var listQPs = endpoint.GetQueryParams().Where(qp => Config.GetType(qp).Contains("[]")).ToList();
 
                 if (listQPs.Count == 0)
                 {
-                    fw.WriteLine(3, "}.Where(kv => kv.Value != null)).ReadAsStringAsync();");
+                    fw.WriteLine(2, "}.Where(kv => kv.Value != null)).ReadAsStringAsync();");
                 }
                 else
                 {
-                    if (!Config.UseLatestCSharp)
-                    {
-                        fw.Write("    ");
-                    }
-
                     fw.Write("        }");
                     foreach (var qp in listQPs)
                     {
@@ -236,64 +204,63 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
                         fw.WriteLine(first ? 0 : 3, $@"{(first ? string.Empty : " ")}.Concat({qp.GetParamName()}?.Select(i => new KeyValuePair<string, string>(""{qp.GetParamName()}"", i{toString})) ?? new Dictionary<string, string>())");
                     }
 
-                    fw.WriteLine(3, " .Where(kv => kv.Value != null)).ReadAsStringAsync();");
+                    fw.WriteLine(2, " .Where(kv => kv.Value != null)).ReadAsStringAsync();");
                 }
             }
 
-            fw.WriteLine(3, $"using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.{endpoint.Method.ToPascalCase(true)}, $\"{endpoint.FullRoute}{(endpoint.GetQueryParams().Any() ? "?{query}" : string.Empty)}\"){(bodyParam != null ? $" {{ Content = GetBody({bodyParam.NameCamel}) }}" : string.Empty)}{(returnType != null ? ", HttpCompletionOption.ResponseHeadersRead" : string.Empty)});");
-            fw.WriteLine(3, $"await EnsureSuccess(res);");
+            fw.WriteLine(2, $"using var res = await _client.SendAsync(new HttpRequestMessage(HttpMethod.{endpoint.Method.ToPascalCase(true)}, $\"{endpoint.FullRoute}{(endpoint.GetQueryParams().Any() ? "?{query}" : string.Empty)}\"){(bodyParam != null ? $" {{ Content = GetBody({bodyParam.NameCamel}) }}" : string.Empty)}{(returnType != null ? ", HttpCompletionOption.ResponseHeadersRead" : string.Empty)});");
+            fw.WriteLine(2, $"await EnsureSuccess(res);");
 
             if (returnType != null)
             {
-                fw.WriteLine(3, $"return await Deserialize<{returnType}>(res);");
+                fw.WriteLine(2, $"return await Deserialize<{returnType}>(res);");
             }
 
-            fw.WriteLine(2, "}");
+            fw.WriteLine(1, "}");
         }
 
         if (hasReturn)
         {
             fw.WriteLine();
-            fw.WriteSummary(2, "Déserialize le contenu d'une réponse HTTP.");
-            fw.WriteTypeParam(2, "T", "Type de destination.");
+            fw.WriteSummary(1, "Déserialize le contenu d'une réponse HTTP.");
+            fw.WriteTypeParam(1, "T", "Type de destination.");
             fw.WriteParam("response", "Réponse HTTP");
-            fw.WriteReturns(2, "Contenu.");
-            fw.WriteLine(2, "private async Task<T> Deserialize<T>(HttpResponseMessage response)");
+            fw.WriteReturns(1, "Contenu.");
+            fw.WriteLine(1, "private async Task<T> Deserialize<T>(HttpResponseMessage response)");
+            fw.WriteLine(1, "{");
+            fw.WriteLine(2, "if (response.StatusCode == HttpStatusCode.NoContent)");
             fw.WriteLine(2, "{");
-            fw.WriteLine(3, "if (response.StatusCode == HttpStatusCode.NoContent)");
-            fw.WriteLine(3, "{");
-            fw.WriteLine(4, "return default;");
-            fw.WriteLine(3, "}");
-            fw.WriteLine();
-            fw.WriteLine(3, "using var res = await response.Content.ReadAsStreamAsync();");
-            fw.WriteLine(3, "return await JsonSerializer.DeserializeAsync<T>(res, _jsOptions);");
+            fw.WriteLine(3, "return default;");
             fw.WriteLine(2, "}");
+            fw.WriteLine();
+            fw.WriteLine(2, "using var res = await response.Content.ReadAsStreamAsync();");
+            fw.WriteLine(2, "return await JsonSerializer.DeserializeAsync<T>(res, _jsOptions);");
+            fw.WriteLine(1, "}");
         }
 
         fw.WriteLine();
-        fw.WriteSummary(2, "Assure que l'authentification est configurée.");
-        fw.WriteLine(2, "private partial Task EnsureAuthentication();");
+        fw.WriteSummary(1, "Assure que l'authentification est configurée.");
+        fw.WriteLine(1, "private partial Task EnsureAuthentication();");
 
         fw.WriteLine();
-        fw.WriteSummary(2, "Gère les erreurs éventuelles retournées par l'API appelée.");
+        fw.WriteSummary(1, "Gère les erreurs éventuelles retournées par l'API appelée.");
         fw.WriteParam("response", "Réponse HTTP");
-        fw.WriteLine(2, "private partial Task EnsureSuccess(HttpResponseMessage response);");
+        fw.WriteLine(1, "private partial Task EnsureSuccess(HttpResponseMessage response);");
 
         if (hasBody)
         {
             fw.WriteLine();
-            fw.WriteSummary(2, "Récupère le body d'une requête pour l'objet donné.");
-            fw.WriteTypeParam(2, "T", "Type source.");
+            fw.WriteSummary(1, "Récupère le body d'une requête pour l'objet donné.");
+            fw.WriteTypeParam(1, "T", "Type source.");
             fw.WriteParam("input", "Entrée");
-            fw.WriteReturns(2, "Contenu.");
-            fw.WriteLine(2, "private StringContent GetBody<T>(T input)");
-            fw.WriteLine(2, "{");
-            fw.WriteLine(3, "return new StringContent(JsonSerializer.Serialize(input, _jsOptions), Encoding.UTF8, \"application/json\");");
-            fw.WriteLine(2, "}");
+            fw.WriteReturns(1, "Contenu.");
+            fw.WriteLine(1, "private StringContent GetBody<T>(T input)");
+            fw.WriteLine(1, "{");
+            fw.WriteLine(2, "return new StringContent(JsonSerializer.Serialize(input, _jsOptions), Encoding.UTF8, \"application/json\");");
+            fw.WriteLine(1, "}");
         }
 
-        fw.WriteLine(1, "}");
-        fw.WriteNamespaceEnd();
+        fw.WriteLine("}");
     }
 
     private string GetNamespace(Class classe, string tag)

--- a/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpApiClientGenerator.cs
@@ -100,7 +100,7 @@ public class CSharpApiClientGenerator : EndpointsGeneratorBase<CsharpConfig>
         fw.WriteNamespace(ns);
 
         fw.WriteSummary($"Client {fileName}");
-        fw.WriteClassDeclaration(className, null);
+        fw.WriteClassDeclaration(className, null, false);
 
         fw.WriteLine(1, "private readonly HttpClient _client;");
         if (hasJson)

--- a/TopModel.Generator.Csharp/CSharpApiServerGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpApiServerGenerator.cs
@@ -40,24 +40,13 @@ public class CSharpApiServerGenerator : EndpointsGeneratorBase<CsharpConfig>
 
         var text = File.Exists(filePath)
             ? File.ReadAllText(filePath)
-            : Config.UseLatestCSharp
-            ? $@"using Microsoft.AspNetCore.Mvc;
+            : $@"using Microsoft.AspNetCore.Mvc;
 
 namespace {ns};
 
 public class {className} : Controller
 {{
 
-}}"
-            : $@"using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-
-namespace {ns}
-{{
-    public class {className} : Controller
-    {{
-
-    }}
 }}";
 
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
@@ -65,7 +54,7 @@ namespace {ns}
 
         var controller = existingController;
 
-        var indent = Config.UseLatestCSharp ? "    " : "        ";
+        var indent = "    ";
 
         foreach (var endpoint in endpoints)
         {

--- a/TopModel.Generator.Csharp/CSharpClassGenerator.cs
+++ b/TopModel.Generator.Csharp/CSharpClassGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using TopModel.Core;
+using TopModel.Core.Model.Implementation;
 using TopModel.Generator.Core;
 using TopModel.Utils;
 
@@ -176,7 +177,8 @@ public class CSharpClassGenerator : ClassGeneratorBase<CsharpConfig>
         }
         else
         {
-            w.WriteClassDeclaration(item.NamePascal, extends, implements.ToArray());
+            var isRecord = (Config.UseRecords & Target.Dto) > 0 && !Config.IsPersistent(item, tag) || (Config.UseRecords & Target.Persisted) > 0 && Config.IsPersistent(item, tag);
+            w.WriteClassDeclaration(item.NamePascal, extends, isRecord, implements.ToArray());
 
             GenerateConstProperties(w, item);
 

--- a/TopModel.Generator.Csharp/CSharpWriter.cs
+++ b/TopModel.Generator.Csharp/CSharpWriter.cs
@@ -9,12 +9,10 @@ namespace TopModel.Generator.Csharp;
 /// </summary>
 public class CSharpWriter : IDisposable
 {
-    private readonly bool _useLatestCSharp;
     private readonly FileWriter _writer;
 
-    public CSharpWriter(string name, ILogger logger, bool useLatestCSharp = false)
+    public CSharpWriter(string name, ILogger logger)
     {
-        _useLatestCSharp = useLatestCSharp;
         _writer = new FileWriter(name, logger);
     }
 
@@ -43,6 +41,16 @@ public class CSharpWriter : IDisposable
         var indentValue = GetIdentValue(indentationLevel);
         value = value.Replace("\r\n", "\r\n" + indentValue);
         _writer.Write(indentValue + value);
+    }
+
+    /// <summary>
+    /// Ecrit un attribut de décoration.
+    /// </summary>
+    /// <param name="attributeName">Nom de l'attribut.</param>
+    /// <param name="attributeParams">Paramètres.</param>
+    public void WriteAttribute(string attributeName, params string[] attributeParams)
+    {
+        WriteAttribute(0, attributeName, attributeParams);
     }
 
     /// <summary>
@@ -116,7 +124,7 @@ public class CSharpWriter : IDisposable
         }
 
         sb.Append("\r\n{");
-        WriteLine(1, sb.ToString());
+        WriteLine(sb.ToString());
     }
 
     /// <summary>
@@ -146,28 +154,8 @@ public class CSharpWriter : IDisposable
     /// <param name="value">Valeur du namespace.</param>
     public void WriteNamespace(string value)
     {
-        Write($"namespace {value}");
-        if (_useLatestCSharp)
-        {
-            WriteLine(";");
-            WriteLine();
-        }
-        else
-        {
-            WriteLine();
-            WriteLine("{");
-        }
-    }
-
-    /// <summary>
-    /// Retourne le code associé à la fin d'un namespace.
-    /// </summary>
-    public void WriteNamespaceEnd()
-    {
-        if (!_useLatestCSharp)
-        {
-            WriteLine("}");
-        }
+        WriteLine($"namespace {value};");
+        WriteLine();
     }
 
     /// <summary>
@@ -179,7 +167,7 @@ public class CSharpWriter : IDisposable
     {
         if (!string.IsNullOrEmpty(paramName) && !string.IsNullOrEmpty(value))
         {
-            WriteLine(2, LoadParam(paramName, value, "param"));
+            WriteLine(1, LoadParam(paramName, value, "param"));
         }
     }
 
@@ -194,6 +182,15 @@ public class CSharpWriter : IDisposable
         {
             WriteLine(indentationLevel, LoadReturns(value));
         }
+    }
+
+    /// <summary>
+    /// Ecrit la valeur du résumé du commentaire..
+    /// </summary>
+    /// <param name="value">Valeur à écrire.</param>
+    public void WriteSummary(string value)
+    {
+        WriteSummary(0, value);
     }
 
     /// <summary>
@@ -328,11 +325,6 @@ public class CSharpWriter : IDisposable
     /// <returns>Identation.</returns>
     private string GetIdentValue(int indentationLevel)
     {
-        if (_useLatestCSharp && indentationLevel > 0)
-        {
-            indentationLevel--;
-        }
-
         var indentValue = string.Empty;
         for (var i = 0; i < indentationLevel; ++i)
         {

--- a/TopModel.Generator.Csharp/CSharpWriter.cs
+++ b/TopModel.Generator.Csharp/CSharpWriter.cs
@@ -75,8 +75,9 @@ public class CSharpWriter : IDisposable
     /// </summary>
     /// <param name="name">Nom de la classe.</param>
     /// <param name="inheritedClass">Classe parente.</param>
+    /// <param name="isRecord">Génère un record au lieu d'une classe.</param>
     /// <param name="ifList">Liste des interfaces implémentées.</param>
-    public void WriteClassDeclaration(string name, string? inheritedClass, params string[] ifList)
+    public void WriteClassDeclaration(string name, string? inheritedClass, bool isRecord, params string[] ifList)
     {
         if (string.IsNullOrEmpty(name))
         {
@@ -90,7 +91,16 @@ public class CSharpWriter : IDisposable
 
         var sb = new StringBuilder();
 
-        sb.Append("public partial class ");
+        sb.Append("public partial ");
+        if (isRecord)
+        {
+            sb.Append("record ");
+        }
+        else
+        {
+            sb.Append("class ");
+        }
+
         sb.Append(name);
         if (!string.IsNullOrEmpty(inheritedClass) || ifList != null && ifList.Length > 0)
         {

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -1,5 +1,6 @@
 ﻿using TopModel.Core;
 using TopModel.Core.FileModel;
+using TopModel.Core.Model.Implementation;
 using TopModel.Generator.Core;
 using TopModel.Utils;
 using YamlDotNet.Serialization;
@@ -126,6 +127,19 @@ public class CsharpConfig : GeneratorConfigBase
     /// Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`).
     /// </summary>
     public bool UseEFComments { get; set; }
+
+    [YamlMember(Alias = "useRecords")]
+    public object? UseRecordsParam { get; set; }
+
+    /// <summary>
+    /// Utilise des records (mutables) au lieu de classes pour la génération de classes.
+    /// </summary>
+    public Target UseRecords => UseRecordsParam switch
+    {
+        true => Target.Persisted_Dto,
+        "dtos-only" => Target.Dto,
+        _ => Target.None
+    };
 
     public override string[] PropertiesWithModuleVariableSupport => new[]
     {

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -92,11 +92,6 @@ public class CsharpConfig : GeneratorConfigBase
     public string? DbSchema { get; set; }
 
     /// <summary>
-    /// Utilise les features C# 10 dans la génération.
-    /// </summary>
-    public bool UseLatestCSharp { get; set; } = true;
-
-    /// <summary>
     /// Si on génère avec Kinetix.
     /// </summary>
     public bool Kinetix { get; set; } = true;

--- a/TopModel.Generator.Csharp/DbContextGenerator.cs
+++ b/TopModel.Generator.Csharp/DbContextGenerator.cs
@@ -73,7 +73,7 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
 
     private void HandleCommentsFile(string fileName, string tag, string dbContextName, string contextNs, IList<string> usings, IList<Class> classes)
     {
-        using var cw = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+        using var cw = new CSharpWriter(fileName, _logger);
 
         var cUsings = new List<string>
         {
@@ -90,20 +90,20 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
         cw.WriteLine();
         cw.WriteNamespace(contextNs);
 
-        cw.WriteSummary(1, "Partial pour ajouter les commentaires EF.");
-        cw.WriteLine(1, $"public partial class {dbContextName} : DbContext");
+        cw.WriteSummary("Partial pour ajouter les commentaires EF.");
+        cw.WriteLine($"public partial class {dbContextName} : DbContext");
+        cw.WriteLine("{");
+        cw.WriteLine(1, "partial void AddComments(ModelBuilder modelBuilder)");
         cw.WriteLine(1, "{");
-        cw.WriteLine(2, "partial void AddComments(ModelBuilder modelBuilder)");
-        cw.WriteLine(2, "{");
 
         foreach (var classe in classes)
         {
-            cw.WriteLine(3, $"var {classe.NameCamel} = modelBuilder.Entity<{classe.NamePascal}>();");
-            cw.WriteLine(3, $"{classe.NameCamel}.ToTable(t => t.HasComment(\"{classe.Comment.Replace("\"", "\\\"")}\"));");
+            cw.WriteLine(2, $"var {classe.NameCamel} = modelBuilder.Entity<{classe.NamePascal}>();");
+            cw.WriteLine(2, $"{classe.NameCamel}.ToTable(t => t.HasComment(\"{classe.Comment.Replace("\"", "\\\"")}\"));");
 
             foreach (var property in classe.Properties.OfType<IFieldProperty>())
             {
-                cw.WriteLine(3, $"{classe.NameCamel}.Property(p => p.{property.NamePascal}).HasComment(\"{property.Comment.Replace("\"", "\\\"")}\");");
+                cw.WriteLine(2, $"{classe.NameCamel}.Property(p => p.{property.NamePascal}).HasComment(\"{property.Comment.Replace("\"", "\\\"")}\");");
             }
 
             if (classes.IndexOf(classe) < classes.Count - 1)
@@ -112,41 +112,41 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             }
         }
 
-        cw.WriteLine(2, "}");
         cw.WriteLine(1, "}");
+        cw.WriteLine("}");
     }
 
     private void HandleMainFile(string fileName, string tag, string dbContextName, string contextNs, IList<string> usings, IList<Class> classes)
     {
-        using var w = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+        using var w = new CSharpWriter(fileName, _logger);
 
         w.WriteUsings(usings.ToArray());
         w.WriteLine();
         w.WriteNamespace(contextNs);
 
-        w.WriteSummary(1, "DbContext généré pour Entity Framework Core.");
-        w.WriteLine(1, $"public partial class {dbContextName} : DbContext");
-        w.WriteLine(1, "{");
+        w.WriteSummary("DbContext généré pour Entity Framework Core.");
+        w.WriteLine($"public partial class {dbContextName} : DbContext");
+        w.WriteLine("{");
 
-        w.WriteSummary(2, "Constructeur par défaut.");
+        w.WriteSummary(1, "Constructeur par défaut.");
         w.WriteParam("options", "Options du DbContext.");
-        w.WriteLine(2, $"public {dbContextName}(DbContextOptions<{dbContextName}> options)");
-        w.WriteLine(3, ": base(options)");
-        w.WriteLine(2, "{");
-        w.WriteLine(2, "}");
+        w.WriteLine(1, $"public {dbContextName}(DbContextOptions<{dbContextName}> options)");
+        w.WriteLine(2, ": base(options)");
+        w.WriteLine(1, "{");
+        w.WriteLine(1, "}");
 
         foreach (var classe in classes)
         {
             w.WriteLine();
-            w.WriteSummary(2, "Accès à l'entité " + classe.NamePascal);
-            w.WriteLine(2, "public DbSet<" + classe.NamePascal + "> " + classe.PluralNamePascal + " { get; set; }");
+            w.WriteSummary(1, "Accès à l'entité " + classe.NamePascal);
+            w.WriteLine(1, "public DbSet<" + classe.NamePascal + "> " + classe.PluralNamePascal + " { get; set; }");
         }
 
         w.WriteLine();
-        w.WriteSummary(2, "Personalisation du modèle.");
+        w.WriteSummary(1, "Personalisation du modèle.");
         w.WriteParam("modelBuilder", "L'objet de construction du modèle.");
-        w.WriteLine(2, "protected override void OnModelCreating(ModelBuilder modelBuilder)");
-        w.WriteLine(2, "{");
+        w.WriteLine(1, "protected override void OnModelCreating(ModelBuilder modelBuilder)");
+        w.WriteLine(1, "{");
 
         var hasPropConfig = false;
         foreach (var fp in classes.Distinct().OrderBy(c => c.NamePascal).SelectMany(c => c.Properties.OfType<IFieldProperty>()))
@@ -160,13 +160,13 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             if (Config.CanClassUseEnums(classe, Classes, targetProp))
             {
                 hasPropConfig = true;
-                w.WriteLine(3, $"modelBuilder.Entity<{fp.Class}>().Property(p => p.{fp.NamePascal}).HasConversion<{Config.GetImplementation(fp.Domain)?.Type ?? string.Empty}>(){(fp.Domain.Length != null ? $".HasMaxLength({fp.Domain.Length})" : string.Empty)};");
+                w.WriteLine(2, $"modelBuilder.Entity<{fp.Class}>().Property(p => p.{fp.NamePascal}).HasConversion<{Config.GetImplementation(fp.Domain)?.Type ?? string.Empty}>(){(fp.Domain.Length != null ? $".HasMaxLength({fp.Domain.Length})" : string.Empty)};");
             }
 
             if (fp.Domain.Length != null && fp.Domain.Scale != null)
             {
                 hasPropConfig = true;
-                w.WriteLine(3, $"modelBuilder.Entity<{fp.Class}>().Property(x => x.{fp.NamePascal}).HasPrecision({fp.Domain.Length}, {fp.Domain.Scale});");
+                w.WriteLine(2, $"modelBuilder.Entity<{fp.Class}>().Property(x => x.{fp.NamePascal}).HasPrecision({fp.Domain.Length}, {fp.Domain.Scale});");
             }
         }
 
@@ -179,7 +179,7 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
         foreach (var classe in classes.Distinct().OrderBy(c => c.NamePascal).Where(c => c.PrimaryKey.Count() > 1))
         {
             hasPk = true;
-            w.WriteLine(3, $"modelBuilder.Entity<{classe}>().HasKey(p => new {{ {string.Join(", ", classe.PrimaryKey.Select(pk => $"p.{pk.NamePascal}"))} }});");
+            w.WriteLine(2, $"modelBuilder.Entity<{classe}>().HasKey(p => new {{ {string.Join(", ", classe.PrimaryKey.Select(pk => $"p.{pk.NamePascal}"))} }});");
         }
 
         if (hasPk)
@@ -193,7 +193,7 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             foreach (var (prop, ap) in GetAssociationProperties(classes))
             {
                 hasFk = true;
-                w.WriteLine(3, $"modelBuilder.Entity<{prop.Class}>().HasOne<{ap.Association}>().With{(ap.Type == AssociationType.ManyToOne ? "Many" : "One")}().HasForeignKey{(ap.Type == AssociationType.ManyToOne ? string.Empty : $"<{prop.Class}>")}(p => p.{prop.NamePascal}).OnDelete(DeleteBehavior.Restrict);");
+                w.WriteLine(2, $"modelBuilder.Entity<{prop.Class}>().HasOne<{ap.Association}>().With{(ap.Type == AssociationType.ManyToOne ? "Many" : "One")}().HasForeignKey{(ap.Type == AssociationType.ManyToOne ? string.Empty : $"<{prop.Class}>")}(p => p.{prop.NamePascal}).OnDelete(DeleteBehavior.Restrict);");
             }
 
             if (hasFk)
@@ -206,7 +206,7 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             {
                 hasUk = true;
                 var expr = uk.Count == 1 ? $"p.{uk.Single().NamePascal}" : $"new {{ {string.Join(", ", uk.Select(p => $"p.{p.NamePascal}"))} }}";
-                w.WriteLine(3, $"modelBuilder.Entity<{uk.First().Class}>().HasIndex(p => {expr}).IsUnique();");
+                w.WriteLine(2, $"modelBuilder.Entity<{uk.First().Class}>().HasIndex(p => {expr}).IsUnique();");
             }
 
             if (hasUk)
@@ -218,14 +218,9 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             foreach (var classe in classes.Distinct().Where(c => c.Values.Any()).OrderBy(c => c.NamePascal))
             {
                 hasData = true;
-                w.WriteLine(3, $"modelBuilder.Entity<{classe.NamePascal}>().HasData(");
+                w.WriteLine(2, $"modelBuilder.Entity<{classe.NamePascal}>().HasData(");
                 foreach (var refValue in classe.Values)
                 {
-                    if (!Config.UseLatestCSharp)
-                    {
-                        w.Write("    ");
-                    }
-
                     w.Write($"            new {classe.NamePascal} {{");
 
                     foreach (var refProp in refValue.Value.ToList())
@@ -274,23 +269,22 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
 
             if (Config.UseEFComments)
             {
-                w.WriteLine(3, "AddComments(modelBuilder);");
+                w.WriteLine(2, "AddComments(modelBuilder);");
             }
         }
 
-        w.WriteLine(3, "OnModelCreatingPartial(modelBuilder);");
-        w.WriteLine(2, "}");
+        w.WriteLine(2, "OnModelCreatingPartial(modelBuilder);");
+        w.WriteLine(1, "}");
 
         if (Config.UseEFMigrations && Config.UseEFComments)
         {
             w.WriteLine();
-            w.WriteLine(2, "partial void AddComments(ModelBuilder modelBuilder);");
+            w.WriteLine(1, "partial void AddComments(ModelBuilder modelBuilder);");
         }
 
         w.WriteLine();
-        w.WriteLine(2, "partial void OnModelCreatingPartial(ModelBuilder modelBuilder);");
+        w.WriteLine(1, "partial void OnModelCreatingPartial(ModelBuilder modelBuilder);");
 
-        w.WriteLine(1, "}");
-        w.WriteNamespaceEnd();
+        w.WriteLine("}");
     }
 }

--- a/TopModel.Generator.Csharp/MapperGenerator.cs
+++ b/TopModel.Generator.Csharp/MapperGenerator.cs
@@ -28,7 +28,7 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
 
     protected override void HandleFile(string fileName, string tag, IList<(Class Classe, FromMapper Mapper)> fromMappers, IList<(Class Classe, ClassMappings Mapper)> toMappers)
     {
-        using var w = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+        using var w = new CSharpWriter(fileName, _logger);
 
         var sampleFromMapper = fromMappers.FirstOrDefault();
         var sampleToMapper = toMappers.FirstOrDefault();
@@ -53,15 +53,15 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
         }
 
         w.WriteNamespace(ns);
-        w.WriteSummary(1, $"Mappers pour le module '{mapperNs.Module}'.");
-        w.WriteLine(1, $"public static class {Config.GetMapperName(mapperNs, modelPath)}");
-        w.WriteLine(1, "{");
+        w.WriteSummary($"Mappers pour le module '{mapperNs.Module}'.");
+        w.WriteLine($"public static class {Config.GetMapperName(mapperNs, modelPath)}");
+        w.WriteLine("{");
 
         foreach (var fromMapper in fromMappers)
         {
             var (classe, mapper) = fromMapper;
 
-            w.WriteSummary(2, $"Crée une nouvelle instance de '{classe.NamePascal}'{(mapper.Comment != null ? $"\n{mapper.Comment}" : string.Empty)}");
+            w.WriteSummary(1, $"Crée une nouvelle instance de '{classe.NamePascal}'{(mapper.Comment != null ? $"\n{mapper.Comment}" : string.Empty)}");
             foreach (var param in mapper.Params)
             {
                 if (param.Comment != null)
@@ -74,43 +74,43 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
                 }
             }
 
-            w.WriteReturns(2, $"Une nouvelle instance de '{classe.NamePascal}'");
+            w.WriteReturns(1, $"Une nouvelle instance de '{classe.NamePascal}'");
 
             if (classe.Abstract)
             {
-                w.Write(2, $"public static T Create{classe.NamePascal}<T>");
+                w.Write(1, $"public static T Create{classe.NamePascal}<T>");
             }
             else
             {
-                w.Write(2, $"public static {classe.NamePascal} Create{classe.NamePascal}");
+                w.Write(1, $"public static {classe.NamePascal} Create{classe.NamePascal}");
             }
 
             w.WriteLine($"({string.Join(", ", mapper.Params.Select(p => $"{(p.Class.Abstract ? "I" : string.Empty)}{p.Class.NamePascal} {p.Name}{(!p.Required ? " = null" : string.Empty)}"))})");
 
             if (classe.Abstract)
             {
-                w.WriteLine(3, $"where T : I{classe.NamePascal}");
+                w.WriteLine(2, $"where T : I{classe.NamePascal}");
             }
 
-            w.WriteLine(2, "{");
+            w.WriteLine(1, "{");
 
             foreach (var param in mapper.Params.Where(p => p.Required))
             {
-                w.WriteLine(3, $"if ({param.Name} is null)");
-                w.WriteLine(3, "{");
-                w.WriteLine(4, $"throw new ArgumentNullException(nameof({param.Name}));");
-                w.WriteLine(3, "}");
+                w.WriteLine(2, $"if ({param.Name} is null)");
+                w.WriteLine(2, "{");
+                w.WriteLine(3, $"throw new ArgumentNullException(nameof({param.Name}));");
+                w.WriteLine(2, "}");
                 w.WriteLine();
             }
 
             if (classe.Abstract)
             {
-                w.WriteLine(3, $"return (T)T.Create(");
+                w.WriteLine(2, $"return (T)T.Create(");
             }
             else
             {
-                w.WriteLine(3, $"return new {classe.NamePascal}");
-                w.WriteLine(3, "{");
+                w.WriteLine(2, $"return new {classe.NamePascal}");
+                w.WriteLine(2, "{");
             }
 
             if (mapper.ParentMapper != null)
@@ -120,7 +120,7 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
                     var mappings = param.Mappings.ToList();
                     foreach (var mapping in mappings)
                     {
-                        w.Write(4, $"{mapping.Key.NamePascal} = ");
+                        w.Write(3, $"{mapping.Key.NamePascal} = ");
 
                         if (mapping.Value == null)
                         {
@@ -164,11 +164,11 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
                 {
                     if (classe.Abstract)
                     {
-                        w.Write(4, $"{mapping.Key.NameCamel}: ");
+                        w.Write(3, $"{mapping.Key.NameCamel}: ");
                     }
                     else
                     {
-                        w.Write(4, $"{mapping.Key.NamePascal} = ");
+                        w.Write(3, $"{mapping.Key.NamePascal} = ");
                     }
 
                     if (mapping.Value == null)
@@ -211,10 +211,10 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
 
             if (!classe.Abstract)
             {
-                w.WriteLine(3, "};");
+                w.WriteLine(2, "};");
             }
 
-            w.WriteLine(2, "}");
+            w.WriteLine(1, "}");
 
             if (toMappers.Any() || fromMappers.IndexOf(fromMapper) < fromMappers.Count - 1)
             {
@@ -226,34 +226,34 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
         {
             var (classe, mapper) = toMapper;
 
-            w.WriteSummary(2, $"Mappe '{classe.NamePascal}' vers '{mapper.Class.NamePascal}'{(mapper.Comment != null ? $"\n{mapper.Comment}" : string.Empty)}");
+            w.WriteSummary(1, $"Mappe '{classe.NamePascal}' vers '{mapper.Class.NamePascal}'{(mapper.Comment != null ? $"\n{mapper.Comment}" : string.Empty)}");
             w.WriteParam("source", $"Instance de '{classe.NamePascal}'");
             if (!mapper.Class.Abstract)
             {
                 w.WriteParam("dest", $"Instance pré-existante de '{mapper.Class.NamePascal}'. Une nouvelle instance sera créée si non spécifié.");
             }
 
-            w.WriteReturns(2, $"Une instance de '{mapper.Class.NamePascal}'");
+            w.WriteReturns(1, $"Une instance de '{mapper.Class.NamePascal}'");
 
             if (mapper.Class.Abstract)
             {
-                w.WriteLine(2, $"public static T {mapper.Name}<T>(this {classe.NamePascal} source)");
-                w.WriteLine(3, $"where T : I{mapper.Class.NamePascal}");
+                w.WriteLine(1, $"public static T {mapper.Name}<T>(this {classe.NamePascal} source)");
+                w.WriteLine(2, $"where T : I{mapper.Class.NamePascal}");
             }
             else
             {
-                w.WriteLine(2, $"public static {mapper.Class.NamePascal} {mapper.Name}(this {(classe.Abstract ? "I" : string.Empty)}{classe.NamePascal} source, {mapper.Class.NamePascal} dest = null)");
+                w.WriteLine(1, $"public static {mapper.Class.NamePascal} {mapper.Name}(this {(classe.Abstract ? "I" : string.Empty)}{classe.NamePascal} source, {mapper.Class.NamePascal} dest = null)");
             }
 
-            w.WriteLine(2, "{");
+            w.WriteLine(1, "{");
 
             if (mapper.Class.Abstract)
             {
-                w.WriteLine(3, $"return (T)T.Create(");
+                w.WriteLine(2, $"return (T)T.Create(");
             }
             else
             {
-                w.WriteLine(3, $"dest ??= new {mapper.Class.NamePascal}();");
+                w.WriteLine(2, $"dest ??= new {mapper.Class.NamePascal}();");
             }
 
             static string GetSourceMapping(IProperty property)
@@ -275,7 +275,7 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
 
                 if (mapper.Class.Abstract)
                 {
-                    w.Write(4, $"{mapping.Value?.NameCamel}: {value}");
+                    w.Write(3, $"{mapping.Value?.NameCamel}: {value}");
 
                     if (mappings.IndexOf(mapping) < mappings.Count - 1)
                     {
@@ -288,16 +288,16 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
                 }
                 else
                 {
-                    w.WriteLine(3, $"dest.{mapping.Value?.NamePascal} = {value};");
+                    w.WriteLine(2, $"dest.{mapping.Value?.NamePascal} = {value};");
                 }
             }
 
             if (!mapper.Class.Abstract)
             {
-                w.WriteLine(3, "return dest;");
+                w.WriteLine(2, "return dest;");
             }
 
-            w.WriteLine(2, "}");
+            w.WriteLine(1, "}");
 
             if (toMappers.IndexOf(toMapper) < toMappers.Count - 1)
             {
@@ -305,8 +305,7 @@ public class MapperGenerator : MapperGeneratorBase<CsharpConfig>
             }
         }
 
-        w.WriteLine(1, "}");
-        w.WriteNamespaceEnd();
+        w.WriteLine("}");
     }
 
     protected override bool IsPersistent(Class classe)

--- a/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
+++ b/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
@@ -58,14 +58,9 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         var interfaceName = $"I{implementationName}";
         var interfaceNamespace = Config.GetReferenceInterfaceNamespace(ns, tag);
 
-        using var w = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+        using var w = new CSharpWriter(fileName, _logger);
 
         var usings = new HashSet<string>();
-
-        if (!Config.UseLatestCSharp)
-        {
-            usings.Add("System.Collections.Generic");
-        }
 
         if (!implementationNamespace.StartsWith(interfaceNamespace))
         {
@@ -94,11 +89,6 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         }
         else
         {
-            if (!Config.UseLatestCSharp)
-            {
-                usings.Add("System.Linq");
-            }
-
             var contextNs = Config.GetDbContextNamespace(tag);
             if (!implementationNamespace.Contains(contextNs))
             {
@@ -111,8 +101,8 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         w.WriteLine();
         w.WriteNamespace(implementationNamespace);
 
-        w.WriteSummary(1, "This interface was automatically generated. It contains all the operations to load the reference lists declared in module " + ns.Module + ".");
-        w.WriteLine(1, "[RegisterImpl]");
+        w.WriteSummary("This interface was automatically generated. It contains all the operations to load the reference lists declared in module " + ns.Module + ".");
+        w.WriteLine("[RegisterImpl]");
 
         w.WriteClassDeclaration(implementationName, null, interfaceName);
 
@@ -120,36 +110,36 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         {
             var dbContextName = Config.GetDbContextName(tag);
 
-            w.WriteLine(2, $"private readonly {dbContextName} _dbContext;");
+            w.WriteLine(1, $"private readonly {dbContextName} _dbContext;");
             w.WriteLine();
-            w.WriteSummary(2, "Constructeur");
+            w.WriteSummary(1, "Constructeur");
             w.WriteParam("dbContext", "DbContext");
-            w.WriteLine(2, $"public {implementationName}({dbContextName} dbContext)");
-            w.WriteLine(2, "{");
-            w.WriteLine(3, "_dbContext = dbContext;");
-            w.WriteLine(2, "}");
+            w.WriteLine(1, $"public {implementationName}({dbContextName} dbContext)");
+            w.WriteLine(1, "{");
+            w.WriteLine(2, "_dbContext = dbContext;");
+            w.WriteLine(1, "}");
             w.WriteLine();
         }
         else
         {
-            w.WriteLine(2, $"private readonly BrokerManager _brokerManager;");
+            w.WriteLine(1, $"private readonly BrokerManager _brokerManager;");
             w.WriteLine();
-            w.WriteSummary(2, "Constructeur");
+            w.WriteSummary(1, "Constructeur");
             w.WriteParam("brokerManager", "BrokerManager");
-            w.WriteLine(2, $"public {implementationName}(BrokerManager brokerManager)");
-            w.WriteLine(2, "{");
-            w.WriteLine(3, "_brokerManager = brokerManager;");
-            w.WriteLine(2, "}");
+            w.WriteLine(1, $"public {implementationName}(BrokerManager brokerManager)");
+            w.WriteLine(1, "{");
+            w.WriteLine(2, "_brokerManager = brokerManager;");
+            w.WriteLine(1, "}");
             w.WriteLine();
         }
 
         foreach (var classe in classList.Where(c => !Config.NoPersistence(tag) && (c.IsPersistent || c.Values.Any())))
         {
             var serviceName = "Load" + (Config.DbContextPath == null ? $"{classe.NamePascal}List" : classe.PluralNamePascal);
-            w.WriteLine(2, "/// <inheritdoc cref=\"" + interfaceName + "." + serviceName + "\" />");
-            w.WriteLine(2, "public ICollection<" + classe.NamePascal + "> " + serviceName + "()\r\n{");
-            w.WriteLine(3, LoadReferenceAccessorBody(classe));
-            w.WriteLine(2, "}");
+            w.WriteLine(1, "/// <inheritdoc cref=\"" + interfaceName + "." + serviceName + "\" />");
+            w.WriteLine(1, "public ICollection<" + classe.NamePascal + "> " + serviceName + "()\r\n{");
+            w.WriteLine(2, LoadReferenceAccessorBody(classe));
+            w.WriteLine(1, "}");
 
             if (classList.IndexOf(classe) != classList.Count - 1)
             {
@@ -157,8 +147,7 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
             }
         }
 
-        w.WriteLine(1, "}");
-        w.WriteNamespaceEnd();
+        w.WriteLine("}");
     }
 
     /// <summary>
@@ -172,14 +161,9 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         var interfaceNamespace = Config.GetReferenceInterfaceNamespace(ns, tag);
         var interfaceName = $"I{Config.GetReferenceAccessorName(ns, tag)}";
 
-        using var w = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+        using var w = new CSharpWriter(fileName, _logger);
 
         var usings = new HashSet<string>();
-
-        if (!Config.UseLatestCSharp)
-        {
-            usings.Add("System.Collections.Generic");
-        }
 
         foreach (var classe in classList)
         {
@@ -196,18 +180,18 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
 
         w.WriteLine();
         w.WriteNamespace(interfaceNamespace);
-        w.WriteSummary(1, "This interface was automatically generated. It contains all the operations to load the reference lists declared in module " + ns.Module + ".");
-        w.WriteLine(1, "[RegisterContract]");
-        w.WriteLine(1, "public partial interface " + interfaceName + "\r\n{");
+        w.WriteSummary("This interface was automatically generated. It contains all the operations to load the reference lists declared in module " + ns.Module + ".");
+        w.WriteLine("[RegisterContract]");
+        w.WriteLine("public partial interface " + interfaceName + "\r\n{");
 
         var count = 0;
         foreach (var classe in classList)
         {
             count++;
-            w.WriteSummary(2, "Reference accessor for type " + classe.NamePascal);
-            w.WriteReturns(2, "List of " + classe.NamePascal);
-            w.WriteLine(2, "[ReferenceAccessor]");
-            w.WriteLine(2, "ICollection<" + classe.NamePascal + "> Load" + (Config.DbContextPath == null ? $"{classe.NamePascal}List" : classe.PluralNamePascal) + "();");
+            w.WriteSummary(1, "Reference accessor for type " + classe.NamePascal);
+            w.WriteReturns(1, "List of " + classe.NamePascal);
+            w.WriteLine(1, "[ReferenceAccessor]");
+            w.WriteLine(1, "ICollection<" + classe.NamePascal + "> Load" + (Config.DbContextPath == null ? $"{classe.NamePascal}List" : classe.PluralNamePascal) + "();");
 
             if (count != classList.Count())
             {
@@ -215,8 +199,7 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
             }
         }
 
-        w.WriteLine(1, "}");
-        w.WriteNamespaceEnd();
+        w.WriteLine("}");
     }
 
     /// <summary>

--- a/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
+++ b/TopModel.Generator.Csharp/ReferenceAccessorGenerator.cs
@@ -104,7 +104,7 @@ public class ReferenceAccessorGenerator : ClassGroupGeneratorBase<CsharpConfig>
         w.WriteSummary("This interface was automatically generated. It contains all the operations to load the reference lists declared in module " + ns.Module + ".");
         w.WriteLine("[RegisterImpl]");
 
-        w.WriteClassDeclaration(implementationName, null, interfaceName);
+        w.WriteClassDeclaration(implementationName, null, false, interfaceName);
 
         if (Config.DbContextPath != null)
         {

--- a/TopModel.Generator.Csharp/csharp.config.json
+++ b/TopModel.Generator.Csharp/csharp.config.json
@@ -148,10 +148,6 @@
       "type": "string",
       "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
     },
-    "useLatestCSharp": {
-      "type": "boolean",
-      "description": "Utilise les features C# 10 dans la génération."
-    },
     "kinetix": {
       "type": "boolean",
       "description": "Si on génère avec Kinetix."

--- a/TopModel.Generator.Csharp/csharp.config.json
+++ b/TopModel.Generator.Csharp/csharp.config.json
@@ -187,6 +187,15 @@
     "useEFComments": {
       "type": "boolean",
       "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+    },
+    "useRecords": {
+      "type": [ "string", "boolean" ],
+      "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+      "enum": [
+        true,
+        false,
+        "dtos-only"
+      ]      
     }
   }
 }

--- a/docs/generator/csharp.md
+++ b/docs/generator/csharp.md
@@ -239,6 +239,10 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   Utilise des enums C# à la place du type original pour les listes de références statiques (= clé primaire non-autogénérée).
 
+- `useRecords`
+
+  Utilise des records (mutables) au lieu de classes pour la génération de classes. Valeurs possibles : `true`, `false` et `dtos-only`.
+
 - `useEFComments`
 
   Génère les commentaires en SQL pour les migrations EF Core (à partir des commentaires du modèle).

--- a/docs/generator/csharp.md
+++ b/docs/generator/csharp.md
@@ -204,12 +204,6 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
 
   _Variables par tag_: **oui** (à faire correspondre avec les valeurs de différents `modelPath`)
 
-- `useLatestCSharp`
-
-  Utilise les features C# 10 dans la génération. (namespaces de fichiers, usings implicites...)
-
-  _Valeur par défaut_: `true`
-
 - `kinetix`
 
   Active les fonctionnalités Kinetix dans la génération.

--- a/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Securite/generated/Profil.cs
+++ b/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Securite/generated/Profil.cs
@@ -17,33 +17,6 @@ namespace CSharp.Clients.Db.Models.Securite;
 public partial class Profil
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public Profil()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public Profil(Profil bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-        TypeProfilCode = bean.TypeProfilCode;
-        Droits = bean.Droits;
-        Secteurs = bean.Secteurs;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("pro_id")]
@@ -75,15 +48,4 @@ public partial class Profil
     [Domain(Domains.IdList)]
     [NotMapped]
     public int[] Secteurs { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(Profil bean);
 }

--- a/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Securite/generated/Secteur.cs
+++ b/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Securite/generated/Secteur.cs
@@ -16,45 +16,10 @@ namespace CSharp.Clients.Db.Models.Securite;
 public partial class Secteur
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public Secteur()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public Secteur(Secteur bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("sec_id")]
     [Domain(Domains.Id)]
     [Key]
     public int? Id { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(Secteur bean);
 }

--- a/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Utilisateur/generated/Utilisateur.cs
+++ b/samples/generators/csharp/src/Clients/CSharp.Clients.Db/Models/Utilisateur/generated/Utilisateur.cs
@@ -17,40 +17,6 @@ namespace CSharp.Clients.Db.Models.Utilisateur;
 public partial class Utilisateur
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public Utilisateur()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public Utilisateur(Utilisateur bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-        Age = bean.Age;
-        ProfilId = bean.ProfilId;
-        Email = bean.Email;
-        Nom = bean.Nom;
-        Actif = bean.Actif;
-        TypeUtilisateurCode = bean.TypeUtilisateurCode;
-        UtilisateurIdParent = bean.UtilisateurIdParent;
-        UtilisateursEnfant = bean.UtilisateursEnfant;
-        DateCreation = bean.DateCreation;
-        DateModification = bean.DateModification;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("uti_id")]
@@ -131,15 +97,4 @@ public partial class Utilisateur
     [Column("uti_date_modification")]
     [Domain(Domains.DateModification)]
     public DateOnly? DateModification { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(Utilisateur bean);
 }

--- a/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/Droit.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/Droit.cs
@@ -19,32 +19,6 @@ namespace Models.CSharp.Securite.Models;
 public partial class Droit
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public Droit()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public Droit(Droit bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Code = bean.Code;
-        Libelle = bean.Libelle;
-        TypeProfilCode = bean.TypeProfilCode;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Valeurs possibles de la liste de référence Droit.
     /// </summary>
     public enum Codes
@@ -89,15 +63,4 @@ public partial class Droit
     [ReferencedType(typeof(TypeProfil))]
     [Domain(Domains.Code)]
     public TypeProfil.Codes? TypeProfilCode { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(Droit bean);
 }

--- a/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/ProfilDto.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/ProfilDto.cs
@@ -16,37 +16,6 @@ namespace Models.CSharp.Securite.Models;
 public partial class ProfilDto
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public ProfilDto()
-    {
-        Utilisateurs = new List<UtilisateurDto>();
-        Secteurs = new List<SecteurDto>();
-
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public ProfilDto(ProfilDto bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-        TypeProfilCode = bean.TypeProfilCode;
-        Droits = bean.Droits;
-        Utilisateurs = new List<UtilisateurDto>(bean.Utilisateurs);
-        Secteurs = new List<SecteurDto>(bean.Secteurs);
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("pro_id")]
@@ -74,22 +43,11 @@ public partial class ProfilDto
     /// Liste paginée des utilisateurs de ce profil.
     /// </summary>
     [NotMapped]
-    public ICollection<UtilisateurDto> Utilisateurs { get; set; }
+    public ICollection<UtilisateurDto> Utilisateurs { get; set; } = new List<UtilisateurDto>();
 
     /// <summary>
     /// Liste des secteurs du profil.
     /// </summary>
     [NotMapped]
-    public ICollection<SecteurDto> Secteurs { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(ProfilDto bean);
+    public ICollection<SecteurDto> Secteurs { get; set; } = new List<SecteurDto>();
 }

--- a/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/SecteurDto.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/SecteurDto.cs
@@ -15,45 +15,10 @@ namespace Models.CSharp.Securite.Models;
 public partial class SecteurDto
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public SecteurDto()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public SecteurDto(SecteurDto bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("sec_id")]
     [Required]
     [Domain(Domains.Id)]
     public int? Id { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(SecteurDto bean);
 }

--- a/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/TypeProfil.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Securite.Models/generated/TypeProfil.cs
@@ -19,31 +19,6 @@ namespace Models.CSharp.Securite.Models;
 public partial class TypeProfil
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public TypeProfil()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public TypeProfil(TypeProfil bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Code = bean.Code;
-        Libelle = bean.Libelle;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Valeurs possibles de la liste de référence TypeProfil.
     /// </summary>
     public enum Codes
@@ -75,15 +50,4 @@ public partial class TypeProfil
     [Domain(Domains.Libelle)]
     [StringLength(3)]
     public string Libelle { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(TypeProfil bean);
 }

--- a/samples/generators/csharp/src/Models/CSharp.Utilisateur.Models/generated/TypeUtilisateur.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Utilisateur.Models/generated/TypeUtilisateur.cs
@@ -19,31 +19,6 @@ namespace Models.CSharp.Utilisateur.Models;
 public partial class TypeUtilisateur
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public TypeUtilisateur()
-    {
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public TypeUtilisateur(TypeUtilisateur bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Code = bean.Code;
-        Libelle = bean.Libelle;
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Valeurs possibles de la liste de référence TypeUtilisateur.
     /// </summary>
     public enum Codes
@@ -80,15 +55,4 @@ public partial class TypeUtilisateur
     [Domain(Domains.Libelle)]
     [StringLength(3)]
     public string Libelle { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(TypeUtilisateur bean);
 }

--- a/samples/generators/csharp/src/Models/CSharp.Utilisateur.Models/generated/UtilisateurDto.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Utilisateur.Models/generated/UtilisateurDto.cs
@@ -15,42 +15,6 @@ namespace Models.CSharp.Utilisateur.Models;
 public partial class UtilisateurDto
 {
     /// <summary>
-    /// Constructeur.
-    /// </summary>
-    public UtilisateurDto()
-    {
-        UtilisateurParent = new UtilisateurDto();
-
-        OnCreated();
-    }
-
-    /// <summary>
-    /// Constructeur par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    public UtilisateurDto(UtilisateurDto bean)
-    {
-        if (bean == null)
-        {
-            throw new ArgumentNullException(nameof(bean));
-        }
-
-        Id = bean.Id;
-        Age = bean.Age;
-        ProfilId = bean.ProfilId;
-        Email = bean.Email;
-        Nom = bean.Nom;
-        Actif = bean.Actif;
-        TypeUtilisateurCode = bean.TypeUtilisateurCode;
-        UtilisateursEnfant = bean.UtilisateursEnfant;
-        DateCreation = bean.DateCreation;
-        DateModification = bean.DateModification;
-        UtilisateurParent = new UtilisateurDto(bean.UtilisateurParent);
-
-        OnCreated(bean);
-    }
-
-    /// <summary>
     /// Id technique.
     /// </summary>
     [Column("uti_id")]
@@ -128,16 +92,5 @@ public partial class UtilisateurDto
     /// UtilisateurParent.
     /// </summary>
     [NotMapped]
-    public UtilisateurDto UtilisateurParent { get; set; }
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs.
-    /// </summary>
-    partial void OnCreated();
-
-    /// <summary>
-    /// Methode d'extensibilité possible pour les constructeurs par recopie.
-    /// </summary>
-    /// <param name="bean">Source.</param>
-    partial void OnCreated(UtilisateurDto bean);
+    public UtilisateurDto UtilisateurParent { get; set; } = new UtilisateurDto();
 }


### PR DESCRIPTION
fix #259 

Le générateur C# ne génère plus aucun constructeur. Il est toujours possible de définir des constructeurs personnalisés dans un partial si besoin.

Les classes peuvent désormais générés comme des records (via `useRecords`), ce qui permet au compiler C# de générer un constructeur de copie (qui s'utilise avec `with`) et un shallow equals. Les records générés ne sont pas positionnels ni immutables, on remplace juste `class` par `record`.

Si vous utilisiez le constructeur de copie, vous pouvez soit passer la génération en mode record, soit définir un mapper `from` la classe en question.

Le paramètre `useLatestCSharp` à également été retiré, on ne génère plus que du C# 10 quoi qu'il arrive (.NET 6 et plus). C'était déjà la valeur par défaut.