### PR TITLE
[JS] Séparer le API mode de l'Entity Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ entityMode: untyped
 apiMode: angular
 ```
 
+Les `StoreNode` ne sont plus générés. En effet, ils sont spécifiques à l'implémentation Focus et ne sont pas utiles dans le cas général. Il est possible de remplacer par `StoreNode<XXXEntityType>` comme ce qui est déjà fait pour `FormNode`.
+
 ## 1.31.8
 
 - [`3a8fb5effa`](https://github.com/klee-contrib/topmodel/commit/3a8fb5effaf09d7cd41782f1bca5287cb6a4aef6) - [JPA] Fix import mapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # TopModel.Generator (`modgen`)
 
+## 1.32.0
+
+- [#276](https://github.com/klee-contrib/topmodel/pull/276) - [JS] Séparer le API mode de l'Entity Mode
+
+Breaking change !
+La configuration du mode `angular` pour la génération de l'API client JS évolue. Il faut maintenant distinguer le mode de génération de l'API, et le mode de génération des types des entités. Un configuration équivalente au `targetFramework: angular` est donc :
+
+```yaml
+targetFramework: angular
+```
+
+devient :
+
+```yaml
+entityMode: untyped
+apiMode: angular
+```
+
 ## 1.31.8
 
 - [`3a8fb5effa`](https://github.com/klee-contrib/topmodel/commit/3a8fb5effaf09d7cd41782f1bca5287cb6a4aef6) - [JPA] Fix import mapper

--- a/TopModel.Generator.Javascript/EntityMode.cs
+++ b/TopModel.Generator.Javascript/EntityMode.cs
@@ -1,14 +1,14 @@
 ﻿namespace TopModel.Generator.Javascript;
 
-public enum TargetFramework
+public enum EntityMode
 {
     /// <summary>
-    /// Angular.
+    /// Ne pas typer les entités.
     /// </summary>
-    ANGULAR,
+    UNTYPED,
 
     /// <summary>
-    /// Vanilla.
+    /// Typer les entités.
     /// </summary>
-    VANILLA
+    TYPED
 }

--- a/TopModel.Generator.Javascript/GeneratorRegistration.cs
+++ b/TopModel.Generator.Javascript/GeneratorRegistration.cs
@@ -26,7 +26,7 @@ public class GeneratorRegistration : IGeneratorRegistration<JavascriptConfig>
 
             if (config.ApiClientRootPath != null)
             {
-                if (config.TargetFramework == TargetFramework.ANGULAR)
+                if (config.ApiMode == TargetFramework.ANGULAR)
                 {
                     services.AddGenerator<AngularApiClientGenerator, JavascriptConfig>(config, number);
                 }

--- a/TopModel.Generator.Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator.Javascript/JavascriptConfig.cs
@@ -43,7 +43,17 @@ public class JavascriptConfig : GeneratorConfigBase
     /// <summary>
     /// Framework cible pour la génération.
     /// </summary>
-    public TargetFramework TargetFramework { get; set; } = TargetFramework.FOCUS;
+    public TargetFramework ApiMode { get; set; } = TargetFramework.VANILLA;
+
+    /// <summary>
+    /// Typage des entités générées
+    /// </summary>
+    public EntityMode EntityMode { get; set; } = EntityMode.TYPED;
+
+    /// <summary>
+    /// Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.
+    /// </summary>
+    public string EntityTypesPath { get; set; } = "@focus4/stores";
 
     /// <summary>
     /// Mode de génération (JS, JSON ou JSON Schema).

--- a/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
+++ b/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
@@ -75,15 +75,7 @@ public class TypescriptDefinitionGenerator : ClassGeneratorBase<JavascriptConfig
 
         if (Config.EntityMode == EntityMode.TYPED)
         {
-            fw.Write("export type ");
-            fw.Write(classe.NamePascal);
-            fw.Write(" = EntityToType<");
-            fw.Write(classe.NamePascal);
-            fw.Write("EntityType>;\r\nexport type ");
-            fw.Write(classe.NamePascal);
-            fw.Write("Node = StoreNode<");
-            fw.Write(classe.NamePascal);
-            fw.Write("EntityType>;\r\n");
+            fw.WriteLine($"export type {classe.NamePascal} = EntityToType<{classe.NamePascal}EntityType>");
 
             fw.Write($"export interface {classe.NamePascal}EntityType ");
 
@@ -283,6 +275,5 @@ public class TypescriptDefinitionGenerator : ClassGeneratorBase<JavascriptConfig
         }
 
         yield return "EntityToType";
-        yield return "StoreNode";
     }
 }

--- a/TopModel.Generator.Javascript/javascript.config.json
+++ b/TopModel.Generator.Javascript/javascript.config.json
@@ -86,15 +86,28 @@
       "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
       "default": "../domains"
     },
-    "targetFramework": {
+    "apiMode": {
       "type": "string",
       "description": "Framework cible pour la génération.",
       "default": "focus",
       "enum": [
-        "focus",
         "angular",
         "vanilla"
       ]
+    },
+    "entityMode": {
+      "type": "string",
+      "description": "Framework cible pour la génération.",
+      "default": "typed",
+      "enum": [
+        "untyped",
+        "typed"
+      ]
+    },
+    "entityTypesPath": {
+      "type": "string",
+      "description": "Chemin d'import des type d'entités",
+      "default": "@focus4/stores"
     },
     "resourceMode": {
       "type": "string",

--- a/docs/generator/js.md
+++ b/docs/generator/js.md
@@ -2,6 +2,90 @@
 
 ## Configuration
 
+### Modes de génération de l'API client
+
+Il est possible de générer l'API cliente selon deux modes (`apiMode`) : `vanilla` ou `angular`.
+
+#### Angular
+
+Le mode `angular` permet de générer un service injectable au sens `Angular`, contenant les méthodes d'appels à l'API.
+
+#### Vanilla
+
+Le mode `vanilla` permet de générer un fichier ts, contenant les méthodes d'appels à l'API exportées sous forme de fonctions. Ce mode nécessite la définission d'une méthode `fetch`. Par défaut, cette méthode est importée de `focus4/core`, mais il est possible de la surcharger avec le paramètre `fetchPath`.
+
+exemple :
+
+```yaml
+  fetchPath: "@api-services"
+```
+
+### Modes de génération des entités
+
+Il est possible de générer les entités selon deux modes (`entityMode`) : `typed` ou `untyped`. Dans les deux cas, la génération utilise le chemin défini dans la propriété `domainPath`, pour importer les objets de définition de domaine. Par défaut `domainPath` vaut `../domains`
+
+#### Typed
+
+Le mode `typed` permet de générer la description des entités métier contenant des types. Ces types sont importés par défaut de `@focus4/stores`, mais ce chemin peut être surchargé avec la propriété `entityTypesPath`.
+
+#### Untyped
+
+Le mode `untyped` permet de générer la description des entités métier en tant que **`const`** non typés.
+
+Exemple :
+
+```ts
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_CODE_LIST, DO_ID} from "@domains";
+
+import {UtilisateurDtoEntity, UtilisateurDto} from "../utilisateur/utilisateur-dto";
+import {DroitCode, TypeProfilCode} from "./references";
+import {SecteurDtoEntity, SecteurDto} from "./secteur-dto";
+
+export interface ProfilDto {
+    id?: number,
+    typeProfilCode?: TypeProfilCode,
+    droits?: DroitCode[],
+    utilisateurs?: UtilisateurDto[],
+    secteurs?: SecteurDto[]
+}
+
+export const ProfilDtoEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: false,
+        label: "securite.profil.id"
+    },
+    typeProfilCode: {
+        type: "field",
+        name: "typeProfilCode",
+        domain: DO_CODE,
+        isRequired: false,
+        label: "securite.profil.typeProfilCode"
+    },
+    droits: {
+        type: "field",
+        name: "droits",
+        domain: DO_CODE_LIST,
+        isRequired: false,
+        label: "securite.profil.droits"
+    },
+    utilisateurs: {
+        type: "list",
+        entity: UtilisateurDtoEntity
+    },
+    secteurs: {
+        type: "list",
+        entity: SecteurDtoEntity
+    }
+} as const
+```
+
 ### Modes de génération des fichiers de ressource
 
 #### JS

--- a/samples/generators/angular/topmodel.config
+++ b/samples/generators/angular/topmodel.config
@@ -9,8 +9,8 @@ javascript:
     apiClientRootPath: api
     modelRootPath: model
     domainPath: "@domains"
-    fetchPath: "@api-services"
     resourceRootPath: resources
-    targetFramework: angular
+    entityMode: untyped
+    apiMode: angular
     referenceMode: values
     resourceMode: json

--- a/samples/generators/focus/src/model/securite/profil-dto.ts
+++ b/samples/generators/focus/src/model/securite/profil-dto.ts
@@ -2,15 +2,14 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {EntityToType, FieldEntry2, ListEntry, StoreNode} from "@focus4/stores";
+import {EntityToType, FieldEntry2, ListEntry} from "@focus4/stores";
 import {DO_CODE, DO_CODE_LIST, DO_ID} from "../../domains";
 
 import {UtilisateurDtoEntity, UtilisateurDtoEntityType} from "../utilisateur/utilisateur-dto";
 import {DroitCode, TypeProfilCode} from "./references";
 import {SecteurDtoEntity, SecteurDtoEntityType} from "./secteur-dto";
 
-export type ProfilDto = EntityToType<ProfilDtoEntityType>;
-export type ProfilDtoNode = StoreNode<ProfilDtoEntityType>;
+export type ProfilDto = EntityToType<ProfilDtoEntityType>
 export interface ProfilDtoEntityType {
     id: FieldEntry2<typeof DO_ID, number>,
     typeProfilCode: FieldEntry2<typeof DO_CODE, TypeProfilCode>,

--- a/samples/generators/focus/src/model/securite/secteur-dto.ts
+++ b/samples/generators/focus/src/model/securite/secteur-dto.ts
@@ -2,11 +2,10 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {EntityToType, FieldEntry2, StoreNode} from "@focus4/stores";
+import {EntityToType, FieldEntry2} from "@focus4/stores";
 import {DO_ID} from "../../domains";
 
-export type SecteurDto = EntityToType<SecteurDtoEntityType>;
-export type SecteurDtoNode = StoreNode<SecteurDtoEntityType>;
+export type SecteurDto = EntityToType<SecteurDtoEntityType>
 export interface SecteurDtoEntityType {
     id: FieldEntry2<typeof DO_ID, number>
 }

--- a/samples/generators/focus/src/model/utilisateur/utilisateur-dto.ts
+++ b/samples/generators/focus/src/model/utilisateur/utilisateur-dto.ts
@@ -2,13 +2,12 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {EntityToType, FieldEntry2, ObjectEntry, StoreNode} from "@focus4/stores";
+import {EntityToType, FieldEntry2, ObjectEntry} from "@focus4/stores";
 import {DO_BOOLEAN, DO_CODE, DO_DATE_CREATION, DO_DATE_MODIFICATION, DO_EMAIL, DO_ID, DO_ID_LIST, DO_LIBELLE, DO_NUMBER} from "../../domains";
 
 import {TypeUtilisateurCode} from "./references";
 
-export type UtilisateurDto = EntityToType<UtilisateurDtoEntityType>;
-export type UtilisateurDtoNode = StoreNode<UtilisateurDtoEntityType>;
+export type UtilisateurDto = EntityToType<UtilisateurDtoEntityType>
 export interface UtilisateurDtoEntityType {
     id: FieldEntry2<typeof DO_ID, number>,
     age: FieldEntry2<typeof DO_NUMBER, number>,

--- a/samples/generators/focus/src/model/utilisateur/utilisateur-search.ts
+++ b/samples/generators/focus/src/model/utilisateur/utilisateur-search.ts
@@ -2,13 +2,12 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {EntityToType, FieldEntry2, StoreNode} from "@focus4/stores";
+import {EntityToType, FieldEntry2} from "@focus4/stores";
 import {DO_BOOLEAN, DO_CODE, DO_DATE_CREATION, DO_DATE_MODIFICATION, DO_EMAIL, DO_ID, DO_ID_LIST, DO_LIBELLE, DO_NUMBER} from "../../domains";
 
 import {TypeUtilisateurCode} from "./references";
 
-export type UtilisateurSearch = EntityToType<UtilisateurSearchEntityType>;
-export type UtilisateurSearchNode = StoreNode<UtilisateurSearchEntityType>;
+export type UtilisateurSearch = EntityToType<UtilisateurSearchEntityType>
 export interface UtilisateurSearchEntityType {
     id: FieldEntry2<typeof DO_ID, number>,
     age: FieldEntry2<typeof DO_NUMBER, number>,


### PR DESCRIPTION
La configuration du mode `angular` pour la génération de l'API client JS évolue. Il faut maintenant distinguer le mode de génération de l'API, et le mode de génération des types des entités. Un configuration équivalente au `targetFramework: angular` est donc :
```yaml
    targetFramework: angular
```

devient :

```yaml
    entityMode: untyped
    apiMode: angular
```
Fixes #275