### PR TITLE
useLegacyAssociationCompositionMappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TopModel.Generator (`modgen`)
 
+## 1.31.7
+
+- [278](https://github.com/klee-contrib/topmodel/pull/278) [JPA] Ajout d'un mode `useLegacyAssociationCompositionMappers` pour rétro compatibilité avec les projets qui utilisaient beaucoup les mappers entre compositions et associations multiples. Cette propriété s'ajoute à la configuration générale, afin qu'elle ne créé pas d'erreur
+
 ## 1.31.6
 
 - [#273](https://github.com/klee-contrib/topmodel/pull/273) - [Core] Gestion des associations vers PK composite (avec `property` explicite).

--- a/TopModel.Core/Loaders/FileChecker.cs
+++ b/TopModel.Core/Loaders/FileChecker.cs
@@ -102,6 +102,9 @@ public class FileChecker
                 case "useLegacyRoleNames":
                     config.UseLegacyRoleNames = value!.Value == "true";
                     break;
+                case "useLegacyAssociationCompositionMappers":
+                    config.UseLegacyAssociationCompositionMappers = value!.Value == "true";
+                    break;  
                 case "i18n":
                     config.I18n = _deserializer.Deserialize<I18nConfig>(parser);
                     break;

--- a/TopModel.Core/ModelConfig.cs
+++ b/TopModel.Core/ModelConfig.cs
@@ -16,6 +16,8 @@ public class ModelConfig
 
     public bool UseLegacyRoleNames { get; set; }
 
+    public bool UseLegacyAssociationCompositionMappers { get; set; }
+
     public I18nConfig I18n { get; set; } = new();
 
     public Dictionary<string, IEnumerable<IDictionary<string, object>>> Generators { get; } = new();

--- a/TopModel.Core/schema.config.json
+++ b/TopModel.Core/schema.config.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",

--- a/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
+++ b/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
@@ -67,7 +67,7 @@ public static class ImportsJpaExtensions
     private static List<string> GetTypeImports(this AliasProperty ap, JpaConfig config, string tag, bool noAnnotations = false)
     {
         var imports = new List<string>();
-        if (ap.Class != null && ap.Class.IsPersistent && ap.Property is AssociationProperty asp)
+        if (ap.Class != null && ap.Property is AssociationProperty asp)
         {
             if (config.CanClassUseEnums(asp.Association))
             {


### PR DESCRIPTION
Ajout d'un mode `useLegacyAssociationCompositionMappers` pour rétro compatibilité avec les projets qui utilisaient beaucoup les mappers entre compositions et associations multiples. Cette propriété s'ajoute à la configuration générale, afin qu'elle ne créé pas d'erreur

Fix: #277