### PR TITLE
Flux de données et MVP générateur C#

### DIFF
--- a/TopModel.Core/FileModel/DataFlowReference.cs
+++ b/TopModel.Core/FileModel/DataFlowReference.cs
@@ -1,0 +1,11 @@
+﻿using YamlDotNet.Core.Events;
+
+namespace TopModel.Core.FileModel;
+
+public class DataFlowReference : Reference
+{
+    internal DataFlowReference(Scalar scalar)
+        : base(scalar)
+    {
+    }
+}

--- a/TopModel.Core/Loaders/DataFlowLoader.cs
+++ b/TopModel.Core/Loaders/DataFlowLoader.cs
@@ -1,0 +1,92 @@
+﻿using TopModel.Core.FileModel;
+using TopModel.Utils;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace TopModel.Core.Loaders;
+
+public class DataFlowLoader : ILoader<DataFlow>
+{
+    /// <inheritdoc cref="ILoader{T}.Load" />
+    public DataFlow Load(Parser parser)
+    {
+        var dataFlow = new DataFlow();
+
+        parser.ConsumeMapping(() =>
+        {
+            var prop = parser.Consume<Scalar>();
+            _ = parser.TryConsume<Scalar>(out var value);
+
+            switch (prop.Value)
+            {
+                case "name":
+                    dataFlow.Name = new LocatedString(value);
+                    break;
+                case "target":
+                    dataFlow.Target = value!.Value;
+                    break;
+                case "class":
+                    dataFlow.ClassReference = new ClassReference(value!);
+                    break;
+                case "type":
+                    dataFlow.Type = Enum.Parse<DataFlowType>(value!.Value.ToPascalCase());
+                    break;
+                case "dependsOn":
+                    parser.ConsumeSequence(() =>
+                    {
+                        dataFlow.DependsOnReference.Add(new DataFlowReference(parser.Consume<Scalar>()));
+                    });
+                    break;
+                case "postQuery":
+                    dataFlow.PostQuery = value!.Value == "true";
+                    break;
+                case "preQuery":
+                    dataFlow.PreQuery = value!.Value == "true";
+                    break;
+                case "activeProperty":
+                    dataFlow.ActivePropertyReference = new Reference(value!);
+                    break;
+                case "sources":
+                    parser.ConsumeSequence(() =>
+                    {
+                        var source = new DataFlowSource();
+                        parser.ConsumeMapping(() =>
+                        {
+                            var prop = parser.Consume<Scalar>();
+                            _ = parser.TryConsume<Scalar>(out var value);
+
+                            switch (prop.Value)
+                            {
+                                case "source":
+                                    source.Source = value!.Value;
+                                    break;
+                                case "class":
+                                    source.ClassReference = new ClassReference(value!);
+                                    break;
+                                case "mode":
+                                    source.Mode = Enum.Parse<DataFlowSourceMode>(value!.Value.ToPascalCase());
+                                    break;
+                                case "joinProperties":
+                                    parser.ConsumeSequence(() =>
+                                    {
+                                        source.JoinPropertyReferences.Add(new Reference(parser.Consume<Scalar>()));
+                                    });
+                                    break;
+                                case "innerJoin":
+                                    source.InnerJoin = value!.Value == "true";
+                                    break;
+                                default:
+                                    throw new ModelException(dataFlow, $"Propriété ${prop} inconnue pour une source de flux de données");
+                            }
+                        });
+                        dataFlow.Sources.Add(source);
+                    });
+                    break;
+                default:
+                    throw new ModelException(dataFlow, $"Propriété ${prop} inconnue pour un flux de données");
+            }
+        });
+
+        return dataFlow;
+    }
+}

--- a/TopModel.Core/Loaders/DataFlowLoader.cs
+++ b/TopModel.Core/Loaders/DataFlowLoader.cs
@@ -49,7 +49,7 @@ public class DataFlowLoader : ILoader<DataFlow>
                 case "sources":
                     parser.ConsumeSequence(() =>
                     {
-                        var source = new DataFlowSource();
+                        var source = new DataFlowSource { DataFlow = dataFlow };
                         parser.ConsumeMapping(() =>
                         {
                             var prop = parser.Consume<Scalar>();

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -10,16 +10,18 @@ public class ModelFileLoader
     private readonly ClassLoader _classLoader;
     private readonly ModelConfig _config;
     private readonly ConverterLoader _converterLoader;
+    private readonly DataFlowLoader _dataFlowLoader;
     private readonly DecoratorLoader _decoratorLoader;
     private readonly DomainLoader _domainLoader;
     private readonly EndpointLoader _endpointLoader;
     private readonly FileChecker _fileChecker;
 
-    public ModelFileLoader(ModelConfig config, ClassLoader classLoader, FileChecker fileChecker, DecoratorLoader decoratorLoader, ConverterLoader converterLoader, EndpointLoader endpointLoader, DomainLoader domainLoader)
+    public ModelFileLoader(ModelConfig config, ClassLoader classLoader, DataFlowLoader dataFlowLoader, FileChecker fileChecker, DecoratorLoader decoratorLoader, ConverterLoader converterLoader, EndpointLoader endpointLoader, DomainLoader domainLoader)
     {
         _classLoader = classLoader;
         _config = config;
         _converterLoader = converterLoader;
+        _dataFlowLoader = dataFlowLoader;
         _decoratorLoader = decoratorLoader;
         _domainLoader = domainLoader;
         _endpointLoader = endpointLoader;
@@ -167,6 +169,13 @@ public class ModelFileLoader
                 alias.ModelFile = file;
                 alias.Location = new Reference(scalar);
                 file.Aliases.Add(alias);
+            }
+            else if (scalar.Value == "dataFlow")
+            {
+                var dataFlow = _dataFlowLoader.Load(parser);
+                dataFlow.ModelFile = file;
+                dataFlow.Location = new Reference(scalar);
+                file.DataFlows.Add(dataFlow);
             }
             else
             {

--- a/TopModel.Core/Model/DataFlow.cs
+++ b/TopModel.Core/Model/DataFlow.cs
@@ -5,6 +5,10 @@ namespace TopModel.Core;
 public class DataFlow
 {
 #nullable disable
+    public ModelFile ModelFile { get; set; }
+
+    public Reference Location { get; set; }
+
     public LocatedString Name { get; set; }
 
     public string Target { get; set; }
@@ -18,7 +22,7 @@ public class DataFlow
 
     public List<DataFlow> DependsOn { get; set; } = new();
 
-    public List<Reference> DependsOnReference { get; set; } = new();
+    public List<DataFlowReference> DependsOnReference { get; set; } = new();
 
     public bool PostQuery { get; set; }
 
@@ -29,4 +33,9 @@ public class DataFlow
     public Reference? ActivePropertyReference { get; set; }
 
     public List<DataFlowSource> Sources { get; set; } = new();
+
+    public override string ToString()
+    {
+        return Name;
+    }
 }

--- a/TopModel.Core/Model/DataFlow.cs
+++ b/TopModel.Core/Model/DataFlow.cs
@@ -1,0 +1,32 @@
+﻿using TopModel.Core.FileModel;
+
+namespace TopModel.Core;
+
+public class DataFlow
+{
+#nullable disable
+    public LocatedString Name { get; set; }
+
+    public string Target { get; set; }
+
+    public Class Class { get; set; }
+
+    public ClassReference ClassReference { get; set; }
+
+    public DataFlowType Type { get; set; }
+#nullable enable
+
+    public List<DataFlow> DependsOn { get; set; } = new();
+
+    public List<Reference> DependsOnReference { get; set; } = new();
+
+    public bool PostQuery { get; set; }
+
+    public bool PreQuery { get; set; }
+
+    public IFieldProperty? ActiveProperty { get; set; }
+
+    public Reference? ActivePropertyReference { get; set; }
+
+    public List<DataFlowSource> Sources { get; set; } = new();
+}

--- a/TopModel.Core/Model/DataFlowSource.cs
+++ b/TopModel.Core/Model/DataFlowSource.cs
@@ -1,0 +1,22 @@
+﻿using TopModel.Core.FileModel;
+
+namespace TopModel.Core;
+
+#nullable disable
+
+public class DataFlowSource
+{
+    public string Source { get; set; }
+
+    public Class Class { get; set; }
+
+    public ClassReference ClassReference { get; set; }
+
+    public DataFlowSourceMode Mode { get; set; }
+
+    public List<IFieldProperty> JoinProperties { get; set; } = new();
+
+    public List<Reference> JoinPropertyReferences { get; set; } = new();
+
+    public bool InnerJoin { get; set; }
+}

--- a/TopModel.Core/Model/DataFlowSource.cs
+++ b/TopModel.Core/Model/DataFlowSource.cs
@@ -2,10 +2,11 @@
 
 namespace TopModel.Core;
 
-#nullable disable
+
 
 public class DataFlowSource
 {
+#nullable disable
     public string Source { get; set; }
 
     public Class Class { get; set; }
@@ -19,4 +20,26 @@ public class DataFlowSource
     public List<Reference> JoinPropertyReferences { get; set; } = new();
 
     public bool InnerJoin { get; set; }
+
+    public DataFlow DataFlow { get; set; }
+
+#nullable enable
+    public FromMapper? TargetFromMapper
+    {
+        get => DataFlow.Class.FromMappers.FirstOrDefault(fm => fm.Params.Count == 1 && fm.Params.First().Class == Class);
+    }
+
+    public ClassMappings? FirstSourceToMapper
+    {
+        get
+        {
+            var joinedSources = DataFlow.Sources.Where(s => s.JoinProperties.Any()).ToList();
+            if (joinedSources.Count <= 1 || joinedSources.First() == this)
+            {
+                return null;
+            }
+
+            return Class.ToMappers.FirstOrDefault(mapper => mapper.Class == joinedSources.First().Class);
+        }
+    }
 }

--- a/TopModel.Core/Model/DataFlowSource.cs
+++ b/TopModel.Core/Model/DataFlowSource.cs
@@ -2,8 +2,6 @@
 
 namespace TopModel.Core;
 
-
-
 public class DataFlowSource
 {
 #nullable disable

--- a/TopModel.Core/Model/DataFlowSourceMode.cs
+++ b/TopModel.Core/Model/DataFlowSourceMode.cs
@@ -1,0 +1,14 @@
+﻿namespace TopModel.Core;
+
+public enum DataFlowSourceMode
+{
+    /// <summary>
+    /// Implémentation manuelle.
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// Implémentation automatique qui sélectionne tous les éléments.
+    /// </summary>
+    QueryAll
+}

--- a/TopModel.Core/Model/DataFlowType.cs
+++ b/TopModel.Core/Model/DataFlowType.cs
@@ -1,0 +1,24 @@
+﻿namespace TopModel.Core;
+
+public enum DataFlowType
+{
+    /// <summary>
+    /// Insertion simple (bulk insert).
+    /// </summary>
+    Insert,
+
+    /// <summary>
+    /// Remplacement des données (truncate puis bulk insert).
+    /// </summary>
+    Replace,
+
+    /// <summary>
+    /// Fusion des données (bulk merge).
+    /// </summary>
+    Merge,
+
+    /// <summary>
+    /// Fusion des données et désactivation des données non matchées (bulk merge + bulk update)
+    /// </summary>
+    MergeDisable
+}

--- a/TopModel.Core/Model/LocatedString.cs
+++ b/TopModel.Core/Model/LocatedString.cs
@@ -89,6 +89,11 @@ public class LocatedString : IComparable
         return Value.ToKebabCase();
     }
 
+    public string ToPascalCase()
+    {
+        return Value.ToPascalCase();
+    }
+
     public string ToLower()
     {
         return Value.ToLower();

--- a/TopModel.Core/ModelErrorType.cs
+++ b/TopModel.Core/ModelErrorType.cs
@@ -43,6 +43,11 @@ public enum ModelErrorType
     TMD0007,
 
     /// <summary>
+    /// Le flux de données '{dataFlow}' est défini plusieurs fois dans le fichier ou une de ses dépendences.
+    /// </summary>
+    TMD0008,
+
+    /// <summary>
     /// La classe '{0}' doit avoir une (et une seule) clé primaire pour être référencée dans une association.
     /// </summary>
     TMD1001,
@@ -176,6 +181,11 @@ public enum ModelErrorType
     /// Cette association ne peut pas avoir le type {ap.Type} car le domain {ap.Class.PrimaryKey.Single().Domain} ne contient pas de définition de AsDomain
     /// </summary>
     TMD1028,
+
+    /// <summary>
+    /// Le flux de données est introuvable dans le fichier ou l'une de ses références.
+    /// </summary>
+    TMD2000,
 
     /// <summary>
     /// L'import {} n'est pas utilisé.

--- a/TopModel.Core/ServiceExtensions.cs
+++ b/TopModel.Core/ServiceExtensions.cs
@@ -13,6 +13,7 @@ public static class ServiceExtensions
             .AddSingleton(fileChecker)
             .AddSingleton<ClassLoader>()
             .AddSingleton<ConverterLoader>()
+            .AddSingleton<DataFlowLoader>()
             .AddSingleton<DecoratorLoader>()
             .AddSingleton<DomainLoader>()
             .AddSingleton<EndpointLoader>()

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -955,6 +955,111 @@
           }
         }
       }
+    },
+    {
+      "type": "object",
+      "description": "Description d'un flux de données",
+      "required": [
+        "dataFlow"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "dataFlow": {
+          "type": "object",
+          "description": "Description d'un flux de données",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "target",
+            "class",
+            "type"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Nom du flux de données."
+            },
+            "target": {
+              "type": "string",
+              "description": "Nom de la connection cible du flux de données."
+            },
+            "class": {
+              "type": "string",
+              "description": "Type de classe cible du flux de données"
+            },
+            "type": {
+              "type": "string",
+              "description": "Type de flux de données.",
+              "enum": [
+                "insert",
+                "replace",
+                "merge",
+                "mergeDisable"
+              ]
+            },
+            "dependsOn": {
+              "type": "array",
+              "description": "Flux de données à exécuter avant celui-ci.",
+              "items": {
+                "type": "string",
+                "description": "Flux de données à exécuter avant celui-ci."
+              }
+            },
+            "postQuery": {
+              "type": "boolean",
+              "description": "Si le flux de données doit définir une requête à jouer après son exécution."
+            },
+            "preQuery": {
+              "type": "boolean",
+              "description": "Si le flux de données doit définir une requête à jouer avant son exécution."
+            },
+            "activeProperty": {
+              "type": "string",
+              "description": "Pour un flux de type 'mergeDisable', nom de la propriété à utiliser pour déterminer le caractère actif de la ligne."
+            },
+            "sources": {
+              "type": "array",
+              "description": "Sources de données pour le flux.",
+              "items": {
+                "type": "object",
+                "description": "Description d'une source de données.",
+                "required": [
+                  "source",
+                  "class",
+                  "mode"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "description": "Nom de la connection source."
+                  },
+                  "class": {
+                    "type": "string",
+                    "description": "Type de classe source.\n\nS'il est différent du type de classe cible et n'est pas la classe cible d'une jointure, alors il doit exister un mapper 'from' de cette classe sur la classe cible.\n\nS'il est utilisé dans une jointure et que ce n'est pas la première classe concernée (qui sera la cible), alors il doit exister un mapper 'to' sur cette classe vers la classe cible de la jointure (première source du flux de données qui définit des 'joinProperties')."
+                  },
+                  "mode": {
+                    "type": "string",
+                    "description": "Mode de génération de la source.",
+                    "enum": [
+                      "partial",
+                      "queryAll"
+                    ]
+                  },
+                  "joinProperties": {
+                    "type": "array",
+                    "description": "A utiliser si une jointure doit être réalisée entre plusieurs sources. Doit lister les propriétés de la classe sur lesquelles il faut joindre, dans le même ordre sur chaque source.\n\nUne seule jointure peut être définie par source. Les sources sans 'joinProperties' seront concatanées entre-elles et avec le résultat de la jointure."
+                  },
+                  "innerJoin": {
+                    "type": "boolean",
+                    "description": "Indique dans une jointure s'il faut filtrer ou non les lignes sans correspondance."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/TopModel.Generator.Core/GeneratorBase.cs
+++ b/TopModel.Generator.Core/GeneratorBase.cs
@@ -69,6 +69,11 @@ public abstract class GeneratorBase<T> : IModelWatcher
         HandleFiles(handledFiles);
     }
 
+    protected string GetBestClassTag(Class classe, string tag)
+    {
+        return GetClassTags(classe).Contains(tag) ? tag : GetClassTags(classe).Intersect(Config.Tags).FirstOrDefault() ?? tag;
+    }
+
     protected IEnumerable<string> GetClassTags(Class classe)
     {
         return Files.Values.Where(f => f.Classes.Contains(classe)).SelectMany(f => f.Tags).Distinct();

--- a/TopModel.Generator.Csharp/CSharpWriter.cs
+++ b/TopModel.Generator.Csharp/CSharpWriter.cs
@@ -16,6 +16,18 @@ public class CSharpWriter : IDisposable
         _writer = new FileWriter(name, logger);
     }
 
+    public bool EnableHeader
+    {
+        get => _writer.EnableHeader;
+        set => _writer.EnableHeader = value;
+    }
+
+    public string HeaderMessage
+    {
+        get => _writer.HeaderMessage;
+        set => _writer.HeaderMessage = value;
+    }
+
     /// <inheritdoc cref="IDisposable.Dispose" />
     public void Dispose()
     {

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -209,6 +209,15 @@ public class CsharpConfig : GeneratorConfigBase
             $"{df.Name.ToPascalCase()}Flow.cs");
     }
 
+    public string GetDataFlowRegistrationFilePath(DataFlow df, string tag)
+    {
+        return Path.Combine(
+            OutputDirectory,
+            ResolveVariables(DataFlowsPath!, tag: tag, module: df.ModelFile.Namespace.ModulePath).ToFilePath(),
+            "generated",
+            $"ServiceExtensions.cs");
+    }
+
     public string GetDbContextFilePath(string tag)
     {
         return Path.Combine(

--- a/TopModel.Generator.Csharp/CsharpConfig.cs
+++ b/TopModel.Generator.Csharp/CsharpConfig.cs
@@ -59,6 +59,11 @@ public class CsharpConfig : GeneratorConfigBase
     /// </summary>
     public string DbContextName { get; set; } = "{app}DbContext";
 
+    /// <summary>
+    /// Location des flux de données générés.
+    /// </summary>
+    public string? DataFlowsPath { get; set; }
+
 #nullable disable
 
     /// <summary>
@@ -150,7 +155,8 @@ public class CsharpConfig : GeneratorConfigBase
         nameof(DbSchema),
         nameof(ReferenceAccessorsName),
         nameof(ReferenceAccessorsInterfacePath),
-        nameof(ReferenceAccessorsImplementationPath)
+        nameof(ReferenceAccessorsImplementationPath),
+        nameof(DataFlowsPath)
     };
 
     public override string[] PropertiesWithTagVariableSupport => new[]
@@ -167,7 +173,8 @@ public class CsharpConfig : GeneratorConfigBase
         nameof(ReferenceAccessorsImplementationPath),
         nameof(ApiGeneration),
         nameof(ApiRootPath),
-        nameof(ApiFilePath)
+        nameof(ApiFilePath),
+        nameof(DataFlowsPath)
     };
 
     public override bool CanClassUseEnums(Class classe, IEnumerable<Class>? availableClasses, IFieldProperty? prop = null)
@@ -191,6 +198,15 @@ public class CsharpConfig : GeneratorConfigBase
             GetModelPath(classe, tag),
             "generated",
             (classe.Abstract ? "I" : string.Empty) + classe.NamePascal + ".cs");
+    }
+
+    public string GetDataFlowFilePath(DataFlow df, string tag)
+    {
+        return Path.Combine(
+            OutputDirectory,
+            ResolveVariables(DataFlowsPath!, tag: tag, module: df.ModelFile.Namespace.ModulePath).ToFilePath(),
+            "generated",
+            $"{df.Name.ToPascalCase()}Flow.cs");
     }
 
     public string GetDbContextFilePath(string tag)
@@ -305,6 +321,17 @@ public class CsharpConfig : GeneratorConfigBase
     public string GetNamespace(Endpoint endpoint, string tag)
     {
         return GetNamespace(endpoint.Namespace, Path.Combine(ApiRootPath, ApiFilePath), tag);
+    }
+
+    /// <summary>
+    /// Récupère le namespace d'un flux de données.
+    /// </summary>
+    /// <param name="dataFlow">Le flux de données.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Namespace.</returns>
+    public string GetNamespace(DataFlow dataFlow, string tag)
+    {
+        return GetNamespace(dataFlow.ModelFile.Namespace, DataFlowsPath!, tag);
     }
 
     /// <summary>

--- a/TopModel.Generator.Csharp/DataFlowGenerator.cs
+++ b/TopModel.Generator.Csharp/DataFlowGenerator.cs
@@ -1,0 +1,250 @@
+﻿using System.Data;
+using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Core.FileModel;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+
+namespace TopModel.Generator.Csharp;
+
+public class DataFlowGenerator : GeneratorBase<CsharpConfig>
+{
+    private readonly ILogger<DataFlowGenerator> _logger;
+
+    public DataFlowGenerator(ILogger<DataFlowGenerator> logger)
+        : base(logger)
+    {
+        _logger = logger;
+    }
+
+    public override IEnumerable<string> GeneratedFiles => Files.Values.SelectMany(f => f.DataFlows)
+        .SelectMany(df => Config.Tags.Intersect(df.ModelFile.Tags).Select(tag => Config.GetDataFlowFilePath(df, tag)))
+        .Distinct();
+
+    public override string Name => "CSharpDataFlowGen";
+
+    protected void HandleDataFlow(string fileName, DataFlow dataFlow, string tag)
+    {
+        int GetSourceNumber(DataFlowSource source)
+        {
+            return dataFlow.Sources.OrderBy(s => s.Source).Where(s => s.Source == source.Source).ToList().IndexOf(source) + 1;
+        }
+
+        string GetConnectionName(DataFlowSource source)
+        {
+            return $"_{source.Source.ToCamelCase()}Connection{GetSourceNumber(source)}";
+        }
+
+        using var w = new CSharpWriter(fileName, _logger, Config.UseLatestCSharp);
+
+        var usings = new List<string>()
+        {
+            "Kinetix.Etl",
+            "Microsoft.Extensions.Logging",
+            Config.GetNamespace(dataFlow.Class, tag)
+        };
+
+        foreach (var source in dataFlow.Sources)
+        {
+            usings.Add(Config.GetNamespace(source.Class, GetBestClassTag(source.Class, tag)));
+        }
+
+        w.WriteUsings(usings.ToArray());
+        w.WriteLine();
+        w.WriteNamespace(Config.GetNamespace(dataFlow, tag));
+
+        var name = $"{dataFlow.Name.ToPascalCase()}Flow";
+
+        w.WriteClassDeclaration(name, $"DataFlow<{dataFlow.Class.NamePascal}>");
+
+        foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
+        {
+            w.WriteLine(2, $"private IConnection {GetConnectionName(source)};");
+        }
+
+        w.WriteLine();
+
+        w.WriteLine(2, $"public {name}(ILogger<{name}> logger, ConnectionPool connectionPool, EtlMonitor monitor)");
+        w.WriteLine(3, ": base(logger, connectionPool, monitor)");
+        w.WriteLine(2, "{");
+        w.WriteLine(2, "}");
+
+        w.WriteLine();
+        w.WriteLine(2, $"public override string Name => \"{dataFlow.Name.ToPascalCase()}\";");
+        w.WriteLine();
+        w.WriteLine(2, $"protected override TargetMode TargetMode => TargetMode.{dataFlow.Type};");
+
+        if (dataFlow.ActiveProperty != null)
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"protected override string ActiveProperty => nameof({dataFlow.Class.NamePascal}.{dataFlow.ActiveProperty.NamePascal});");
+        }
+
+        w.WriteLine();
+        w.WriteLine(2, $"protected override string TargetName => \"{dataFlow.Target.ToCamelCase()}\";");
+
+        if (dataFlow.DependsOn.Any())
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"public override string[] DependsOn => new[] {{ {string.Join(", ", dataFlow.DependsOn.Select(d => $"\"{d.Name.ToPascalCase()}\""))} }};");
+        }
+
+        if (dataFlow.PostQuery)
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"protected override bool PostQuery => true;");
+        }
+
+        if (dataFlow.PreQuery)
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"protected override bool PreQuery => true;");
+        }
+
+        w.WriteLine();
+        w.WriteLine(2, "public override void Dispose()");
+        w.WriteLine(2, "{");
+        w.WriteLine(3, "base.Dispose();");
+
+        foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
+        {
+            w.WriteLine(3, $"{GetConnectionName(source)}?.Dispose();");
+        }
+
+        w.WriteLine(2, "}");
+
+        w.WriteLine();
+        w.WriteLine(2, $"protected override async Task<IEnumerable<{dataFlow.Class.NamePascal}>> GetData()");
+        w.WriteLine(2, "{");
+
+        foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
+        {
+            w.WriteLine(3, $"{GetConnectionName(source)} = ConnectionPool.GetConnection(\"{source.Source.ToCamelCase()}\");");
+        }
+
+        if (dataFlow.Sources.Count == 1)
+        {
+            var source = dataFlow.Sources.First();
+            w.WriteLine();
+            w.Write(3, $"return ");
+
+            if (source.Class != dataFlow.Class)
+            {
+                w.Write("(");
+            }
+
+            w.Write($"await Get{source.Source.ToPascalCase()}Source{GetSourceNumber(source)}({GetConnectionName(source)})");
+            w.WriteLine(source.Class != dataFlow.Class ? ")" : ";");
+
+            if (source.Class != dataFlow.Class && source.TargetFromMapper != null)
+            {
+                var (ns, modelPath) = Config.GetMapperLocation((dataFlow.Class, source.TargetFromMapper), GetBestClassTag(dataFlow.Class, tag));
+                w.WriteLine(4, $".Select({Config.GetMapperName(ns, modelPath)}.Create{dataFlow.Class.NamePascal});");
+            }
+        }
+        else if (dataFlow.Sources.Count > 1)
+        {
+            if (dataFlow.Sources.All(source => !source.JoinProperties.Any()))
+            {
+                w.WriteLine();
+                w.WriteLine(3, "return (await Task.WhenAll(");
+                foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
+                {
+                    w.Write(4, $"Get{source.Source.ToPascalCase()}Source{GetSourceNumber(source)}({GetConnectionName(source)})");
+                    if (dataFlow.Sources.OrderBy(s => s.Source).ToList().IndexOf(source) < dataFlow.Sources.Count - 1)
+                    {
+                        w.WriteLine(",");
+                    }
+                    else
+                    {
+                        w.WriteLine("))");
+                    }
+                }
+
+                w.WriteLine(3, ".SelectMany(s => s);");
+            }
+            else if (dataFlow.Sources.All(source => source.JoinProperties.Any()))
+            {
+                string GetVarName(DataFlowSource source)
+                {
+                    return $"{source.Source.ToCamelCase()}{GetSourceNumber(source)}";
+                }
+
+                string GetJoin(DataFlowSource source)
+                {
+                    if (source.JoinProperties.Count == 1)
+                    {
+                        return $"{GetVarName(source)}.{source.JoinProperties.Single().NamePascal}";
+                    }
+
+                    return $"({string.Join(", ", source.JoinProperties.Select(jp => $"{GetVarName(source)}.{jp.NamePascal}"))})";
+                }
+
+                foreach (var source in dataFlow.Sources.Skip(1))
+                {
+                    var varName = GetVarName(source);
+                    w.WriteLine();
+                    w.WriteLine(3, $"var {source.Source.ToCamelCase()}Source{GetSourceNumber(source)} = (await Get{source.Source.ToPascalCase()}Source{GetSourceNumber(source)}({GetConnectionName(source)}))");
+                    w.WriteLine(4, $".ToDictionary({varName} => {GetJoin(source)}, {varName} => {varName});");
+                }
+
+                w.WriteLine();
+
+                var mainSource = dataFlow.Sources.First();
+                w.WriteLine(3, $"return (await Get{mainSource.Source.ToPascalCase()}Source{GetSourceNumber(mainSource)}({GetConnectionName(mainSource)}))");
+
+                foreach (var source in dataFlow.Sources.Skip(1))
+                {
+                    w.WriteLine(4, $".Select({GetVarName(mainSource)} => {source.Source.ToCamelCase()}Source{GetSourceNumber(source)}.TryGetValue({GetJoin(mainSource)}, out var {GetVarName(source)})");
+                    w.WriteLine(5, $"? {GetVarName(source)}.{source.FirstSourceToMapper?.Name.ToPascalCase()}({GetVarName(mainSource)})");
+                    w.WriteLine(5, $": {GetVarName(mainSource)}){(dataFlow.Sources.Skip(1).ToList().IndexOf(source) == dataFlow.Sources.Count - 2 ? ";" : string.Empty)}");
+                }
+            }
+        }
+
+        w.WriteLine(2, "}");
+
+        if (dataFlow.PostQuery)
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"protected override partial Task<int> ExecutePostQuery(IConnection connection);");
+        }
+
+        if (dataFlow.PreQuery)
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"protected override partial Task<int> ExecutePreQuery(IConnection connection);");
+        }
+
+        foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
+        {
+            w.WriteLine();
+            w.WriteLine(2, $"private static {(source.Mode == DataFlowSourceMode.Partial ? "partial" : "async")} Task<IEnumerable<{source.Class.NamePascal}>> Get{source.Source.ToPascalCase()}Source{GetSourceNumber(source)}(IConnection connection){(source.Mode == DataFlowSourceMode.Partial ? ";" : string.Empty)}");
+            if (source.Mode == DataFlowSourceMode.QueryAll)
+            {
+                w.WriteLine(2, "{");
+                w.WriteLine(3, $"return await connection.QueryAllAsync<{source.Class.NamePascal}>();");
+                w.WriteLine(2, "}");
+            }
+        }
+
+        w.WriteLine(1, "}");
+        w.WriteNamespaceEnd();
+    }
+
+    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    {
+        foreach (var file in files)
+        {
+            foreach (var classe in file.DataFlows)
+            {
+                foreach (var (tag, fileName) in Config.Tags.Intersect(file.Tags)
+                     .Select(tag => (tag, fileName: Config.GetDataFlowFilePath(classe, tag)))
+                     .DistinctBy(t => t.fileName))
+                {
+                    HandleDataFlow(fileName, classe, tag);
+                }
+            }
+        }
+    }
+}

--- a/TopModel.Generator.Csharp/GeneratorRegistration.cs
+++ b/TopModel.Generator.Csharp/GeneratorRegistration.cs
@@ -49,5 +49,10 @@ public class GeneratorRegistration : IGeneratorRegistration<CsharpConfig>
                 services.AddGenerator<CSharpApiClientGenerator, CsharpConfig>(config, number);
             }
         }
+
+        if (config.DataFlowsPath != null)
+        {
+            services.AddGenerator<DataFlowGenerator, CsharpConfig>(config, number);
+        }
     }
 }

--- a/TopModel.Generator.Csharp/csharp.config.json
+++ b/TopModel.Generator.Csharp/csharp.config.json
@@ -112,6 +112,10 @@
         }
       ]
     },
+    "dataFlowsPath": {
+      "type": "string",
+      "description": "Localisation des flux de données générés."
+    },
     "useEFMigrations": {
       "type": "boolean",
       "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -55,6 +55,9 @@ public class CodeActionHandler : CodeActionHandlerBase
                     case ModelErrorType.TMD1008:
                         codeActions.AddRange(GetCodeActionMissingDecoratorImport(request, diagnostic, modelFile));
                         break;
+                    case ModelErrorType.TMD2000:
+                        codeActions.AddRange(GetCodeActionMissingDataFlowImport(request, diagnostic, modelFile));
+                        break;
                     default:
                         break;
                 }
@@ -226,6 +229,22 @@ domain:
                 : 0;
 
         return _modelStore.Decorators.Where(c => c.Name == decoratorName)
+            .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
+    }
+
+    protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDataFlowImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
+    {
+        var fs = request.TextDocument.Uri.GetFileSystemPath();
+        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var line = text.ElementAt(diagnostic.Range.Start.Line);
+        var dataFlowName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
+        var useIndex = modelFile!.Uses.Any()
+            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
+            : text.First().StartsWith("-")
+                ? 1
+                : 0;
+
+        return _modelStore.DataFlows.Where(c => c.Name == dataFlowName)
             .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
     }
 

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -216,22 +216,6 @@ domain:
             .Select(classToImport => GetFileImportAction(diagnostic, modelFile, classToImport.ModelFile, useIndex));
     }
 
-    protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDecoratorImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
-    {
-        var fs = request.TextDocument.Uri.GetFileSystemPath();
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
-        var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var decoratorName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
-        var useIndex = modelFile!.Uses.Any()
-            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
-            : text.First().StartsWith("-")
-                ? 1
-                : 0;
-
-        return _modelStore.Decorators.Where(c => c.Name == decoratorName)
-            .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
-    }
-
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDataFlowImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
     {
         var fs = request.TextDocument.Uri.GetFileSystemPath();
@@ -245,6 +229,22 @@ domain:
                 : 0;
 
         return _modelStore.DataFlows.Where(c => c.Name == dataFlowName)
+            .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
+    }
+
+    protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDecoratorImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
+    {
+        var fs = request.TextDocument.Uri.GetFileSystemPath();
+        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var line = text.ElementAt(diagnostic.Range.Start.Line);
+        var decoratorName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
+        var useIndex = modelFile!.Uses.Any()
+            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
+            : text.First().StartsWith("-")
+                ? 1
+                : 0;
+
+        return _modelStore.Decorators.Where(c => c.Name == decoratorName)
             .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
     }
 

--- a/TopModel.LanguageServer/CodeLensHandler.cs
+++ b/TopModel.LanguageServer/CodeLensHandler.cs
@@ -69,7 +69,20 @@ public class CodeLensHandler : CodeLensHandlerBase
                             decorator.GetLocation()!.Start.Line - 1
                         }
                     }
-                }))));
+                })
+                .Concat(file.DataFlows.Select(dataFlow => new CodeLens
+                {
+                    Range = dataFlow.GetLocation().ToRange()!,
+                    Command = new Command()
+                    {
+                        Title = $"{_modelStore.GetDataFlowReferences(dataFlow).Count()} references",
+                        Name = "topmodel.findRef",
+                        Arguments = new JArray
+                        {
+                            dataFlow.GetLocation()!.Start.Line - 1
+                        }
+                    }
+                })))));
         }
 
         return Task.FromResult<CodeLensContainer>(new());

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -43,7 +43,7 @@ public class DefinitionHandler : DefinitionHandlerBase
                     TargetRange = objet switch
                     {
                         Class or Endpoint or Domain => selectionRange with { End = new() { Line = selectionRange.Start.Line + 2, Character = 200 } },
-                        Decorator or (Decorator, _) => selectionRange with { End = new() { Line = selectionRange.Start.Line + 1, Character = 200 } },
+                        Decorator or (Decorator, _) or DataFlow => selectionRange with { End = new() { Line = selectionRange.Start.Line + 1, Character = 200 } },
                         _ => selectionRange with { End = new() { Line = selectionRange.Start.Line, Character = 200 } }
                     },
                     TargetSelectionRange = selectionRange,

--- a/TopModel.LanguageServer/DocumentSymbolHandler.cs
+++ b/TopModel.LanguageServer/DocumentSymbolHandler.cs
@@ -84,6 +84,20 @@ public class DocumentSymbolHandler : DocumentSymbolHandlerBase
                     }
                 };
             }))
+            .Concat(file.DataFlows.Select(d =>
+            {
+                return new SymbolInformation
+                {
+                    Deprecated = false,
+                    Kind = SymbolKind.Operator,
+                    Name = d.Name,
+                    Location = new Location
+                    {
+                        Range = d.GetLocation()?.ToRange()!,
+                        Uri = request.TextDocument.Uri
+                    }
+                };
+            }))
             .Concat(file.Converters.Select(c =>
             {
                 return new SymbolInformation

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -44,6 +44,7 @@ public class HoverHandler : HoverHandlerBase
                         AliasProperty p => p.Comment,
                         Domain d => d.Label,
                         Decorator d => d.Description,
+                        DataFlow d => $"Flux de données '{d.Name}'",
                         (Decorator d, _) => d.Description,
                         _ => string.Empty
                     }))

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -19,6 +19,7 @@ public static class OmnisharpExtensions
             Class classe => classe.Name,
             Domain domain => domain.Name,
             Decorator decorator => decorator.Name,
+            DataFlow dataFlow => dataFlow.Name,
             AliasProperty property => property.OriginalProperty?.Name ?? property.Name,
             IProperty property => property.Name,
             _ => null
@@ -41,6 +42,7 @@ public static class OmnisharpExtensions
         var definedObjects = file.Classes.Where(c => c.Name.GetLocation()!.Start.Line - 1 == position.Line || c.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>()
             .Concat(file.Domains.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
             .Concat(file.Decorators.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
+            .Concat(file.DataFlows.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
             .Concat(file.Properties.Where(p => p.GetLocation()!.Start.Line - 1 == position.Line));
 
         var definedObject = definedObjects.Count() == 1 ? definedObjects.Single() : null;
@@ -55,6 +57,8 @@ public static class OmnisharpExtensions
                     .Concat(modelStore.GetDomainReferences(domain).Select(d => (Reference: (Reference)d.Reference, d.File))),
                 Decorator decorator => new[] { (Reference: decorator.Name.GetLocation()!, File: decorator.GetFile()!) }
                     .Concat(modelStore.GetDecoratorReferences(decorator).Select(d => (Reference: (Reference)d.Reference, d.File))),
+                DataFlow dataFlow => new[] { (Reference: dataFlow.Name.GetLocation()!, File: dataFlow.GetFile()!) }
+                    .Concat(modelStore.GetDataFlowReferences(dataFlow).Select(d => (Reference: (Reference)d.Reference, d.File))),
                 IProperty property => new[] { (Reference: property.GetLocation()!, File: property.GetFile()!) }
                     .Concat(modelStore.GetPropertyReferences(property, includeTransitive).Select(d => (d.Reference, d.File))),
                 _ => null!

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -61,6 +61,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
                 var type = reference switch
                 {
                     ClassReference or DecoratorReference => SemanticTokenType.Class,
+                    DataFlowReference => SemanticTokenType.Operator,
                     DomainReference => SemanticTokenType.EnumMember,
                     Reference r when r.ReferenceName == "this" || r.ReferenceName == "false" => SemanticTokenType.Keyword,
                     _ => SemanticTokenType.Function

--- a/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
+++ b/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
@@ -71,6 +71,19 @@ public class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
                     Uri = _facade.GetFilePath(d.GetFile())
                 }
             };
+        })).Concat(_modelStore.DataFlows.Select(d =>
+        {
+            return new SymbolInformation
+            {
+                Deprecated = false,
+                Kind = SymbolKind.Operator,
+                Name = d.Name,
+                Location = new Location
+                {
+                    Range = d.GetLocation().ToRange()!,
+                    Uri = _facade.GetFilePath(d.GetFile())
+                }
+            };
         })).Where(s => s.Name.ShouldMatch(request.Query)).ToList());
     }
 

--- a/TopModel.Utils/FileWriter.cs
+++ b/TopModel.Utils/FileWriter.cs
@@ -53,7 +53,7 @@ public class FileWriter : TextWriter
     /// <summary>
     /// Active la lecture et l'écriture d'un entête avec un hash du fichier.
     /// </summary>
-    public bool EnableHeader { get; init; } = true;
+    public bool EnableHeader { get; set; } = true;
 
     /// <summary>
     /// Message à mettre dans le header.

--- a/docs/generator/csharp.md
+++ b/docs/generator/csharp.md
@@ -10,6 +10,7 @@ Le générateur C# peut générer les fichiers suivants :
 - Un fichier de contrôleur pour chaque fichier d'endpoints dans le modèle, si les APIs sont générées en mode serveur.
 - Un fichier de client d'API pour chaque fichier d'endpoints dans le modèle, si les APIs sont générées en mode client.
 - 2 fichiers par module (interface + implémentation) contenant des accesseurs de listes de référence pour Kinetix (si demandé).
+- Un fichier par flux de données et un fichier d'enregistrement de flux par module (si demandés).
 
 Le code généré n'a aucune dépendance externe à part EF Core et Kinetix, et uniquement s'ils sont explicitement demandés dans la configuration.
 
@@ -61,6 +62,10 @@ Les clients d'API sont générés comme des classes partielles avec 2 méthodes 
 ### Génération des accesseurs de références
 
 Les implémentations d'accesseurs de listes de références pour Kinetix utilisent EF Core si un DbContext est configuré et l'ORM Kinetix (`Kinetix.DataAccess.Sql`) dans le cas contraire. Ils sont générés pour les classes marquées comme `reference`.
+
+### Génération des flux de données
+
+_(en preview, documentation à venir)_
 
 ## Configuration
 
@@ -173,6 +178,16 @@ Les implémentations d'accesseurs de listes de références pour Kinetix utilise
   _Valeur par défaut_: `"{DbContextPath}/Reference"`
 
   _Variables par tag_: **oui** (plusieurs accesseurs pourraient être générés si un fichier à plusieurs tags)
+
+- `dataFlowsPath`
+
+  Localisation des flux de données générés. Cette variable doit être renseignées pour que les flux soient générés.
+
+  Le chemin des fichiers cibles sera calculé en remplaçant les `:` par des `/` dans cette valeur, tandis que le nom du namespace des classes générées sera calculé en prenant ce qui est à droite du dernier `:` et en remplaçant tous les `/` par des `.`.
+
+  _Templating_: `{module}`
+
+  _Variables par tag_: **oui** (plusieurs flux de données pourraient être générés si un fichier à plusieurs tags)
 
 - `referenceAccessorsName`
 

--- a/samples/generators/angular/topmodel.config.schema.json
+++ b/samples/generators/angular/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/csharp/topmodel.config.schema.json
+++ b/samples/generators/csharp/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/database/topmodel.config.schema.json
+++ b/samples/generators/database/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/focus/topmodel.config.schema.json
+++ b/samples/generators/focus/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/jpa/topmodel.config.schema.json
+++ b/samples/generators/jpa/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/open-api/topmodel.config.schema.json
+++ b/samples/generators/open-api/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/pg/topmodel.config.schema.json
+++ b/samples/generators/pg/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/php/topmodel.config.schema.json
+++ b/samples/generators/php/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/ssdt/topmodel.config.schema.json
+++ b/samples/generators/ssdt/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",

--- a/samples/generators/translation/topmodel.config.schema.json
+++ b/samples/generators/translation/topmodel.config.schema.json
@@ -40,7 +40,13 @@
     },
     "useLegacyRoleNames": {
       "type": "boolean",
-      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés"
+      "description": "Transforme les noms de rôles d'associations en upper case (au lieu de constant case) pour déterminer le nom SQL des propriétés",
+      "default": "false"
+    },
+    "useLegacyAssociationCompositionMappers": {
+      "type": "boolean",
+      "description": "Permet de mapper les compositions OneToMany et ManyToMany à des compositions avec un kind non null. Sans garantie de résultat...",
+      "default": false
     },
     "i18n": {
       "type": "object",
@@ -194,6 +200,10 @@
               }
             ]
           },
+          "dataFlowsPath": {
+            "type": "string",
+            "description": "Localisation des flux de données générés."
+          },
           "useEFMigrations": {
             "type": "boolean",
             "description": "Utilise les migrations EF pour créer/mettre à jour la base de données."
@@ -229,10 +239,6 @@
           "dbSchema": {
             "type": "string",
             "description": "Le nom du schéma de base de données à cibler (si non renseigné, EF utilise 'dbo')."
-          },
-          "useLatestCSharp": {
-            "type": "boolean",
-            "description": "Utilise les features C# 10 dans la génération."
           },
           "kinetix": {
             "type": "boolean",
@@ -273,6 +279,18 @@
           "useEFComments": {
             "type": "boolean",
             "description": "Annote les tables et les colonnes générées par EF avec les commentaires du modèle (nécessite `UseEFMigrations`)."
+          },
+          "useRecords": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Utilise des records (mutables) au lieu de classes pour la génération de classes.",
+            "enum": [
+              true,
+              false,
+              "dtos-only"
+            ]
           }
         }
       }
@@ -367,15 +385,28 @@
             "description": "Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.",
             "default": "../domains"
           },
-          "targetFramework": {
+          "apiMode": {
             "type": "string",
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
-              "focus",
               "angular",
               "vanilla"
             ]
+          },
+          "entityMode": {
+            "type": "string",
+            "description": "Framework cible pour la génération.",
+            "default": "typed",
+            "enum": [
+              "untyped",
+              "typed"
+            ]
+          },
+          "entityTypesPath": {
+            "type": "string",
+            "description": "Chemin d'import des type d'entités",
+            "default": "@focus4/stores"
           },
           "resourceMode": {
             "type": "string",


### PR DESCRIPTION
Fix #242

Cette PR introduit un nouvel objet dans la modélisation : le flux de données (**`dataFlow`**). Un flux de données défini une classe et une connection cible, une ou plusieurs classes et connections sources, et un mode d'insertion (`insert`, `replace`, `merge` ou `mergeDisable`). Les sources peuvent être soit concaténées (par défaut), soit faire l'objet d'une jointure (si des propriétés de jointures sont renseignées).

Un générateur C# a été mis au point pour gérer des représentations de ces flux de données dans une librairie "Kinetix" cible pour les intégrer dans un ETL "custom".

Cette fonctionnalité sera en "preview" car la lib cible en question n'est pas encore publiée (une release de TopModel avec la fonctionnalité permettra de finaliser son développement), et parce que toutes les combinaisons voulues de classes sources vers la classe cible ne sont pas encore gérées (car ces combinaisons peuvent utiliser les mappers `from` et `to` définis sur les classes). Par conséquent, aucune erreur n'est encore levée si une combinaison n'est pas gérée. 

La représentation d'un `dataFlow` pourra encore être amenée à évoluer avant la release "définitive". Pour toutes ces raisons, la documentation sera écrite pour la version finale.