### PR TITLE
[JPA] Spring-batch dataFlows, mode JDBC et séparation des values/enums #281, #290, #291

### DIFF
--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -546,7 +546,8 @@ public abstract class GeneratorConfigBase
 
     private static string ReplaceVariable(string value, string varName, string varValue)
     {
-        return Regex.Replace(value, $"\\{{{varName}(:\\w+)?\\}}", m => m.Value.Trim('{', '}').GetTransformation()(varValue));
+        MatchEvaluator matchEvaluator = m => m.Value.Trim('{', '}').GetTransformation()(varValue);
+        return Regex.Replace(value, $"\\{{{varName}(:\\w+)?\\}}", matchEvaluator);
     }
 
     private bool FilterAnnotations(TargetedText annotation, IProperty property, string tag)

--- a/TopModel.Generator.Jpa/FlowTree.cs
+++ b/TopModel.Generator.Jpa/FlowTree.cs
@@ -1,0 +1,124 @@
+﻿using TopModel.Core;
+
+namespace TopModel.Generator.Jpa;
+
+public class FlowTree
+{
+    private readonly bool _hasIndependantFlows = false;
+
+    public FlowTree(List<DataFlow> flows)
+    {
+        RootFlows = flows.Where(f => !flows.Intersect(f.DependsOn).Any()).ToList();
+        if (RootFlows.Count > 1)
+        {
+            var independantTrees = new List<List<DataFlow>>();
+            while (RootFlows.Any(f => !independantTrees.SelectMany(t => t).Contains(f)))
+            {
+                var f = RootFlows.Where(f => !independantTrees.SelectMany(t => t).Contains(f)).First();
+                var subFlowDataFlows = new List<DataFlow>();
+                var stack = new Queue<DataFlow>();
+                stack.Enqueue(f);
+                var flowsToAdd = new List<DataFlow>();
+                while (stack.TryDequeue(out var s))
+                {
+                    subFlowDataFlows.Add(s);
+                    foreach (var depFlow in flows.Where(f => !Subflows.SelectMany(s => s.Flows).Concat(subFlowDataFlows).Contains(f)).Where(f => s.DependsOn.Contains(f) || f.DependsOn.Contains(s)))
+                    {
+                        stack.Enqueue(depFlow);
+                    }
+                }
+
+                if (RootFlows.TrueForAll(r => subFlowDataFlows.Contains(r)))
+                {
+                    break;
+                }
+                else
+                {
+                    _hasIndependantFlows = true;
+                    independantTrees.Add(subFlowDataFlows);
+                    Subflows.Add(new FlowTree(subFlowDataFlows));
+                }
+            }
+        }
+
+        while (flows.Any(f => !Flows.Contains(f)))
+        {
+            var f = flows.Where(f => !Flows.Contains(f)).First();
+            var subFlowDataFlows = new List<DataFlow>();
+            var stack = new Queue<DataFlow>();
+            stack.Enqueue(f);
+            var flowsToAdd = new List<DataFlow>();
+            while (stack.TryDequeue(out var s))
+            {
+                subFlowDataFlows.Add(s);
+                foreach (var depFlow in flows.Where(f => !Flows.Concat(subFlowDataFlows).Contains(f)).Where(f => s.DependsOn.Contains(f) || f.DependsOn.Contains(s)))
+                {
+                    stack.Enqueue(depFlow);
+                }
+            }
+
+            Subflows.Add(new FlowTree(subFlowDataFlows));
+        }
+    }
+
+    public List<DataFlow> RootFlows { get; set; } = new();
+
+    public List<FlowTree> Subflows { get; set; } = new();
+
+    public List<DataFlow> Flows => RootFlows.Concat(Subflows.SelectMany(s => s.Flows)).Distinct().ToList();
+
+    public string ToFlow(int indentLevel)
+    {
+        var indent = "	";
+        for (int i = 0; i < indentLevel; i++)
+        {
+            indent += "	";
+        }
+
+        if (Flows.Count == 1)
+        {
+            return $"{Flows.First().Name.ToCamelCase()}Flow";
+        }
+
+        if (_hasIndependantFlows)
+        {
+            var result = $" //\n{indent}new FlowBuilder<Flow>(\"{string.Join('-', Flows.Select(r => r.Name))}\")";
+            result += $" //\n{indent}.split(taskExecutor)";
+            result += $" //\n{indent}.add( //\n{indent}	{string.Join($", ", Subflows.Select(s => $"{s.ToFlow(indentLevel + 1)}"))})";
+            result += $" //\n{indent}.end()";
+
+            return result;
+        }
+        else
+        {
+            var result = $" //\n{indent}new FlowBuilder<Flow>(\"{string.Join('-', Flows.Select(r => r.Name))}\")";
+            if (RootFlows.Count == 1)
+            {
+                result += $" //\n{indent} .start({RootFlows.First().Name.ToCamelCase()}Flow)";
+            }
+            else
+            {
+                result += $" //\n{indent} .start(new FlowBuilder<Flow>(\"{string.Join('-', RootFlows.Select(r => r.Name))}\")";
+                result += $" //\n{indent}   .split(taskExecutor)";
+                result += $" //\n{indent}   .add({string.Join(", ", RootFlows.Select(s => $"{s.Name.ToCamelCase()}Flow"))})";
+                result += $" //\n{indent}   .end())";
+            }
+
+            if (Subflows.Count == 1)
+            {
+                result += $"//\n{indent} .next({Subflows.First().ToFlow(indentLevel + 1)})";
+            }
+            else
+            {
+                result += $" //\n{indent} .next(";
+                result += $" //\n{indent}  new FlowBuilder<Flow>(\"{string.Join('-', Subflows.SelectMany(s => s.Flows).Select(r => r.Name))}\")";
+                result += $" //\n{indent}   .split(taskExecutor)";
+                result += $" //\n{indent}   .add({string.Join(", ", Subflows.Select(s => s.ToFlow(indentLevel + 1)))})";
+                result += $" //\n{indent} .end())";
+            }
+
+            result += $"  //\n{indent} .build()";
+            return result;
+        }
+    }
+}

--- a/TopModel.Generator.Jpa/GeneratorRegistration.cs
+++ b/TopModel.Generator.Jpa/GeneratorRegistration.cs
@@ -27,6 +27,11 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
             services.AddGenerator<JpaDaoGenerator, JpaConfig>(config, number);
         }
 
+        if (config.DataFlowsPath != null)
+        {
+            services.AddGenerator<SpringDataFlowGenerator, JpaConfig>(config, number);
+        }
+
         if (config.ResourcesPath != null)
         {
             services.AddGenerator<JpaResourceGenerator, JpaConfig>(config, number);

--- a/TopModel.Generator.Jpa/GeneratorRegistration.cs
+++ b/TopModel.Generator.Jpa/GeneratorRegistration.cs
@@ -21,7 +21,7 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
         services.AddGenerator<JpaModelGenerator, JpaConfig>(config, number);
         services.AddGenerator<JpaModelInterfaceGenerator, JpaConfig>(config, number);
         services.AddGenerator<JpaMapperGenerator, JpaConfig>(config, number);
-
+        services.AddGenerator<JpaEnumGenerator, JpaConfig>(config, number);
         if (config.DaosPath != null)
         {
             services.AddGenerator<JpaDaoGenerator, JpaConfig>(config, number);

--- a/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
+++ b/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
@@ -9,7 +9,7 @@ public static class ImportsJpaExtensions
         return $"{config.GetPackageName(classe, tag)}.{classe.NamePascal}";
     }
 
-    public static List<string> GetImports(this Class classe, JpaConfig config, string tag)
+    public static List<string> GetImports(this Class classe, JpaConfig config, string tag, IEnumerable<Class> availableClasses)
     {
         var imports = new List<string>();
 
@@ -19,9 +19,9 @@ public static class ImportsJpaExtensions
         }
 
         imports
-            .AddRange(classe.FromMappers.SelectMany(fm => fm.Params).Select(fmp => fmp.Class.GetImport(config, tag)));
+            .AddRange(classe.FromMappers.Where(fm => fm.Params.All(fmp => availableClasses.Contains(fmp.Class))).SelectMany(fm => fm.Params).Select(fmp => fmp.Class.GetImport(config, tag)));
         imports
-            .AddRange(classe.ToMappers.Select(fmp => fmp.Class.GetImport(config, tag)));
+            .AddRange(classe.ToMappers.Where(tm => availableClasses.Contains(tm.Class)).Select(fmp => fmp.Class.GetImport(config, tag)));
         return imports;
     }
 

--- a/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
+++ b/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
@@ -52,11 +52,6 @@ public static class ImportsJpaExtensions
         imports.AddRange(config.GetDomainImports(ap, tag));
         imports.Add(ap.Association.GetImport(config, tag));
 
-        if (ap.Association.Reference)
-        {
-            imports.AddRange(ap.Property.GetTypeImports(config, tag));
-        }
-
         return imports;
     }
 
@@ -71,21 +66,14 @@ public static class ImportsJpaExtensions
     private static List<string> GetTypeImports(this AliasProperty ap, JpaConfig config, string tag)
     {
         var imports = new List<string>();
-        if (ap.Class != null && ap.Property is AssociationProperty asp)
-        {
-            if (config.CanClassUseEnums(asp.Association))
-            {
-                imports.AddRange(asp.Property.GetTypeImports(config, tag));
-            }
-        }
 
         if (config.CanClassUseEnums(ap.Property.Class))
         {
-            imports.Add(ap.Property.Class.GetImport(config, tag));
+            imports.Add($"{config.GetEnumPackageName(ap.Property.Class, tag)}.{config.GetEnumName(ap.Property.Class)}");
         }
         else if (ap.Property is AssociationProperty apr && config.CanClassUseEnums(apr.Property.Class))
         {
-            imports.Add(apr.Association.GetImport(config, tag));
+            imports.Add($"{config.GetEnumPackageName(apr.Association, tag)}.{config.GetEnumName(apr.Association)}");
         }
 
         imports.AddRange(config.GetDomainImports(ap, tag));
@@ -106,6 +94,11 @@ public static class ImportsJpaExtensions
         else if (rp is RegularProperty rpr)
         {
             imports.AddRange(rpr.GetTypeImports(config, tag));
+        }
+
+        if (rp.Class != null && config.CanClassUseEnums(rp.Class) && rp == rp.Class.EnumKey)
+        {
+            imports.Add($"{config.GetEnumPackageName(rp.Class, tag)}.{config.GetEnumName(rp.Class)}");
         }
 
         return imports;

--- a/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
+++ b/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
@@ -18,10 +18,14 @@ public static class ImportsJpaExtensions
             imports.Add(classe.GetImport(config, tag));
         }
 
-        imports
-            .AddRange(classe.FromMappers.Where(fm => fm.Params.All(fmp => availableClasses.Contains(fmp.Class))).SelectMany(fm => fm.Params).Select(fmp => fmp.Class.GetImport(config, tag)));
-        imports
-            .AddRange(classe.ToMappers.Where(tm => availableClasses.Contains(tm.Class)).Select(fmp => fmp.Class.GetImport(config, tag)));
+        if (config.MappersInClass)
+        {
+            imports
+                .AddRange(classe.FromMappers.Where(fm => fm.Params.All(fmp => availableClasses.Contains(fmp.Class))).SelectMany(fm => fm.Params).Select(fmp => fmp.Class.GetImport(config, tag)));
+            imports
+                .AddRange(classe.ToMappers.Where(tm => availableClasses.Contains(tm.Class)).Select(fmp => fmp.Class.GetImport(config, tag)));
+        }
+
         return imports;
     }
 

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -151,7 +151,7 @@ public class JpaConfig : GeneratorConfigBase
 
     public string GetEnumName(Class classe)
     {
-        return $"{classe.NamePascal}{classe.EnumKey!.NamePascal}";
+        return $"{classe.NamePascal}{classe.EnumKey!.Name.ToPascalCase()}";
     }
 
     public string GetEnumFileName(Class classe, string tag)

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -106,7 +106,8 @@ public class JpaConfig : GeneratorConfigBase
         nameof(DtosPath),
         nameof(ApiPath),
         nameof(ApiGeneration),
-        nameof(ResourcesPath)
+        nameof(ResourcesPath),
+        nameof(DbSchema)
     };
 
     public override string[] PropertiesWithModuleVariableSupport => new[]

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -45,6 +45,11 @@ public class JpaConfig : GeneratorConfigBase
     public bool EnumShortcutMode { get; set; }
 
     /// <summary>
+    /// Nom du schéma sur lequel les entités sont sauvegardées
+    /// </summary>
+    public string? DbSchema { get; set; }
+
+    /// <summary>
     /// Option pour générer des adders pour les associations oneToMany et ManyToMany
     /// </summary>
     public bool AssociationAdders { get; set; } = false;
@@ -73,6 +78,16 @@ public class JpaConfig : GeneratorConfigBase
     /// Mode de génération des séquences.
     /// </summary>
     public IdentityConfig Identity { get; set; } = new() { Mode = IdentityMode.IDENTITY };
+
+    /// <summary>
+    /// Location des flux de données générés.
+    /// </summary>
+    public string? DataFlowsPath { get; set; }
+
+    /// <summary>
+    /// Taille des chunks à extraire et insérer
+    /// </summary>
+    public long DataFlowsBulkSize { get; set; } = 100000;
 
     public override string[] PropertiesWithLangVariableSupport => new[]
     {
@@ -116,6 +131,23 @@ public class JpaConfig : GeneratorConfigBase
             OutputDirectory,
             ResolveVariables(classe.IsPersistent ? EntitiesPath : DtosPath, tag, module: classe.Namespace.Module).ToFilePath(),
             $"{classe.NamePascal}.java");
+    }
+
+    public string GetDataFlowFilePath(DataFlow df, string tag)
+    {
+        return Path.Combine(
+            OutputDirectory,
+            ResolveVariables(DataFlowsPath!, tag: tag, module: df.ModelFile.Namespace.ModulePath).ToFilePath(),
+            $"{df.Name.ToPascalCase()}Flow.java");
+    }
+
+    public string GetDataFlowConfigFilePath(string module)
+    {
+        return Path.Combine(
+            OutputDirectory,
+            ResolveVariables(DataFlowsPath!, module: module).ToFilePath()
+            .ToFilePath(),
+            $"{module.ToPascalCase()}JobConfiguration.java");
     }
 
     public string GetMapperFilePath((Class Classe, FromMapper Mapper) mapper, string tag)

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -90,6 +90,11 @@ public class JpaConfig : GeneratorConfigBase
     public bool UseJdbc { get; set; } = false;
 
     /// <summary>
+    /// Indique s'il faut ajouter les mappers en tant méthode ou constructeur dans les classes qui les déclarent.
+    /// </summary>
+    public bool MappersInClass { get; set; } = true;
+
+    /// <summary>
     /// Taille des chunks à extraire et insérer
     /// </summary>
     public long DataFlowsBulkSize { get; set; } = 100000;

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -85,6 +85,11 @@ public class JpaConfig : GeneratorConfigBase
     public string? DataFlowsPath { get; set; }
 
     /// <summary>
+    /// Génération en mode JDBC.
+    /// </summary>
+    public bool UseJdbc { get; set; } = false;
+
+    /// <summary>
     /// Taille des chunks à extraire et insérer
     /// </summary>
     public long DataFlowsBulkSize { get; set; } = 100000;
@@ -114,7 +119,7 @@ public class JpaConfig : GeneratorConfigBase
 
     public override bool CanClassUseEnums(Class classe, IEnumerable<Class>? availableClasses = null, IFieldProperty? prop = null)
     {
-        return base.CanClassUseEnums(classe, availableClasses, prop)
+        return !this.UseJdbc && base.CanClassUseEnums(classe, availableClasses, prop)
             && !classe.Properties.OfType<AssociationProperty>().Any(a => a.Association != classe && !CanClassUseEnums(a.Association, availableClasses));
     }
 

--- a/TopModel.Generator.Jpa/JpaDaoGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaDaoGenerator.cs
@@ -50,7 +50,7 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
         WriteImports(fw, classe, tag);
         fw.WriteLine();
         var pk = classe.PrimaryKey.Count() > 1 ? $"{classe.NamePascal}.{classe.NamePascal}Id" : Config.GetType(classe.PrimaryKey.Single());
-        fw.WriteLine($"public interface {classe.NamePascal}DAO extends {(classe.Reference ? "CrudRepository" : "JpaRepository")}<{classe.NamePascal}, {pk}> {{");
+        fw.WriteLine($"public interface {classe.NamePascal}DAO extends {(classe.Reference || Config.UseJdbc ? "CrudRepository" : "JpaRepository")}<{classe.NamePascal}, {pk}> {{");
         fw.WriteLine();
         fw.WriteLine("}");
     }
@@ -61,8 +61,11 @@ public class JpaDaoGenerator : ClassGeneratorBase<JpaConfig>
         {
             classe.GetImport(Config, tag)
         };
-
-        if (classe.Reference)
+        if (Config.UseJdbc)
+        {
+            imports.Add("org.springframework.data.repository.CrudRepository");
+        }
+        else if (classe.Reference)
         {
             imports.Add("org.springframework.data.repository.CrudRepository");
         }

--- a/TopModel.Generator.Jpa/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaEnumGenerator.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Generator.Core;
+
+namespace TopModel.Generator.Jpa;
+
+/// <summary>
+/// Générateur de fichiers de modèles JPA.
+/// </summary>
+public class JpaEnumGenerator : ClassGeneratorBase<JpaConfig>
+{
+    private readonly ILogger<JpaEnumGenerator> _logger;
+
+    private readonly Dictionary<string, string> _newableTypes = new()
+    {
+        ["List"] = "ArrayList",
+        ["Set"] = "HashSet"
+    };
+
+    public JpaEnumGenerator(ILogger<JpaEnumGenerator> logger, ModelConfig modelConfig)
+        : base(logger)
+    {
+        _logger = logger;
+    }
+
+    public override string Name => "JpaEnumGen";
+
+    protected override bool FilterClass(Class classe)
+    {
+        return !classe.Abstract && Config.CanClassUseEnums(classe, Classes.ToList());
+    }
+
+    protected override string GetFileName(Class classe, string tag)
+    {
+        return Config.GetEnumFileName(classe, tag);
+    }
+
+    protected override void HandleClass(string fileName, Class classe, string tag)
+    {
+        var packageName = Config.GetEnumPackageName(classe, tag);
+        using var fw = new JavaWriter(Config.GetEnumFileName(classe, tag), _logger, packageName, null);
+        fw.WriteLine();
+        var codeProperty = classe.EnumKey!;
+        fw.WriteDocStart(0, $"Enumération des valeurs possibles de la propriété {codeProperty.NamePascal} de la classe {classe.NamePascal}");
+        fw.WriteDocEnd(0);
+        fw.WriteLine($@"public enum {classe.NamePascal}{codeProperty.NamePascal} {{");
+        var i = 0;
+        foreach (var value in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            i++;
+            var isLast = i == classe.Values.Count();
+            if (classe.DefaultProperty != null)
+            {
+                fw.WriteDocStart(1, $"{value.Value[classe.DefaultProperty]}");
+                fw.WriteDocEnd(1);
+            }
+
+            fw.WriteLine(1, $"{value.Value[codeProperty]}{(isLast ? ";" : ",")}");
+        }
+
+        fw.WriteLine("}");
+    }
+}

--- a/TopModel.Generator.Jpa/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaEnumGenerator.cs
@@ -43,7 +43,7 @@ public class JpaEnumGenerator : ClassGeneratorBase<JpaConfig>
         var codeProperty = classe.EnumKey!;
         fw.WriteDocStart(0, $"Enumération des valeurs possibles de la propriété {codeProperty.NamePascal} de la classe {classe.NamePascal}");
         fw.WriteDocEnd(0);
-        fw.WriteLine($@"public enum {classe.NamePascal}{codeProperty.NamePascal} {{");
+        fw.WriteLine($@"public enum {Config.GetEnumName(classe)} {{");
         var i = 0;
         foreach (var value in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
         {

--- a/TopModel.Generator.Jpa/JpaMapperGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaMapperGenerator.cs
@@ -83,7 +83,11 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
 
         if (Config.UseJdbc)
         {
-            return (Getter: $"{sourceName}.{getterPrefix}{propertySource.NamePascal}()", CheckSourceNull: false);
+            getter = $"{sourceName}.{getterPrefix}{propertySource.NamePascal.ToFirstUpper()}()";
+            return (Getter: Config.GetConvertedValue(
+                getter,
+                (propertySource as IFieldProperty)?.Domain,
+                (propertyTarget as IFieldProperty)?.Domain), CheckSourceNull: false);
         }
 
         var checkSourceNull = false;

--- a/TopModel.Generator.Jpa/JpaMapperGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaMapperGenerator.cs
@@ -81,6 +81,11 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
             fw.AddImports(Config.GetImplementation(converter)!.Imports);
         }
 
+        if (Config.UseJdbc)
+        {
+            return (Getter: $"{sourceName}.{getterPrefix}{propertySource.NamePascal}()", CheckSourceNull: false);
+        }
+
         var checkSourceNull = false;
         if ((!propertySource.Class.IsPersistent && !propertyTarget.Class.IsPersistent)
             || !(propertySource is AssociationProperty || propertyTarget is AssociationProperty))
@@ -253,6 +258,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
                 var propertySource = mapping.Value!;
                 var getterPrefix = Config.GetType(propertyTarget!) == "boolean" ? "is" : "get";
                 var (getter, checkSourceNull) = GetSourceGetter(propertySource, propertyTarget, classe, fw, param.Name.ToCamelCase(), tag);
+                var propertyTargetName = Config.UseJdbc ? propertyTarget.NamePascal : propertyTarget.NameByClassPascal;
                 if (classe.Abstract)
                 {
                     if (!isFirst)
@@ -266,7 +272,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
 
                     if (checkSourceNull)
                     {
-                        hydrate += $"{param.Name}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}() != null ? {getter} : null";
+                        hydrate += $"{param.Name}.{propertyTargetName.WithPrefix(getterPrefix)}() != null ? {getter} : null";
                     }
                     else
                     {
@@ -282,7 +288,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
                             fw.WriteLine(3, $"if ({param.Name}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}() != null) {{");
                         }
 
-                        fw.WriteLine(3 + (checkSourceNull ? 1 : 0), $"target.{propertyTarget!.NameByClassPascal.WithPrefix("set")}({getter});");
+                        fw.WriteLine(3 + (checkSourceNull ? 1 : 0), $"target.{propertyTargetName!.WithPrefix("set")}({getter});");
 
                         if (checkSourceNull)
                         {
@@ -369,6 +375,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
             var propertySource = mapping.Key;
             var getterPrefix = Config.GetType(propertyTarget!) == "boolean" ? "is" : "get";
             var (getter, checkSourceNull) = GetSourceGetter(propertySource, propertyTarget!, classe, fw, "source", tag);
+            var propertyTargetName = Config.UseJdbc ? propertyTarget!.NamePascal : propertyTarget!.NameByClassPascal;
             if (mapper.Class.Abstract)
             {
                 if (!isFirst)
@@ -382,7 +389,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
 
                 if (checkSourceNull)
                 {
-                    hydrate += $"source.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}() != null ? {getter} : null";
+                    hydrate += $"source.{propertyTargetName.WithPrefix(getterPrefix)}() != null ? {getter} : null";
                 }
                 else
                 {
@@ -398,7 +405,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
                         fw.WriteLine(2, $"if (source.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}() != null) {{");
                     }
 
-                    fw.WriteLine(2 + (checkSourceNull ? 1 : 0), $"target.{propertyTarget!.NameByClassPascal.WithPrefix("set")}({getter});");
+                    fw.WriteLine(2 + (checkSourceNull ? 1 : 0), $"target.{propertyTargetName.WithPrefix("set")}({getter});");
 
                     if (checkSourceNull)
                     {

--- a/TopModel.Generator.Jpa/JpaMapperGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaMapperGenerator.cs
@@ -155,13 +155,14 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
                 {
                     if (apTarget.Type.IsToMany())
                     {
-                        getter = $@"{sourceName}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}().stream().map({apTarget.Association.NamePascal}.Values::getEntity).collect(Collectors.toList())";
+                        getter = $@"{sourceName}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}().stream().map({apTarget.Association.NamePascal}::new).collect(Collectors.toList())";
                         fw.AddImport($"{Config.GetEnumPackageName(apTarget.Association, tag)}.{Config.GetEnumName(apTarget.Association)}");
                         fw.AddImport("java.util.stream.Collectors");
                     }
                     else
                     {
-                        getter = $"{apTarget.Association.NamePascal}.Values.getEntity({sourceName}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}())";
+                        getter = $"new {apTarget.Association.NamePascal}({sourceName}.{propertySource.NameByClassPascal.WithPrefix(getterPrefix)}())";
+                    fw.AddImport(apTarget.Association.GetImport(Config, tag));
                         checkSourceNull = true;
                     }
                 }

--- a/TopModel.Generator.Jpa/JpaMapperGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaMapperGenerator.cs
@@ -216,9 +216,9 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
             }
         }
 
-        fw.WriteReturns(1, $"Une nouvelle instance de '{classe}' ou bien l'instance passée en paramètres sur lesquels les champs sources ont été mappée");
+        fw.WriteReturns(1, $"Une nouvelle instance de '{classe.NamePascal}' ou bien l'instance passée en paramètres sur lesquels les champs sources ont été mappée");
         fw.WriteDocEnd(1);
-        fw.WriteLine(1, $"public static {classe.NamePascal} create{classe}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name.ToCamelCase()}"))}, {classe} target) {{");
+        fw.WriteLine(1, $"public static {classe.NamePascal} create{classe.NamePascal}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name.ToCamelCase()}"))}, {classe.NamePascal} target) {{");
         fw.WriteLine(2, "if (target == null) {");
         if (classe.Abstract)
         {

--- a/TopModel.Generator.Jpa/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelConstructorGenerator.cs
@@ -25,7 +25,7 @@ public class JpaModelConstructorGenerator
         {
             var (clazz, mapper) = fromMapper;
             fw.WriteLine();
-            fw.WriteDocStart(1, $"Crée une nouvelle instance de '{classe}'");
+            fw.WriteDocStart(1, $"Crée une nouvelle instance de '{classe.NamePascal}'");
             if (mapper.Comment != null)
             {
                 fw.WriteLine(1, $" * {mapper.Comment}");
@@ -38,19 +38,19 @@ public class JpaModelConstructorGenerator
                     fw.WriteLine(1, $" * {param.Comment}");
                 }
 
-                fw.WriteParam(param.Name.ToCamelCase(), $"Instance de '{param.Class}'");
+                fw.WriteParam(param.Name.ToCamelCase(), $"Instance de '{param.Class.NamePascal}'");
             }
 
-            fw.WriteReturns(1, $"Une nouvelle instance de '{classe}'");
+            fw.WriteReturns(1, $"Une nouvelle instance de '{classe.NamePascal}'");
             fw.WriteDocEnd(1);
-            fw.WriteLine(1, $"public {classe}({string.Join(", ", mapper.Params.Select(p => $"{p.Class} {p.Name.ToCamelCase()}"))}) {{");
+            fw.WriteLine(1, $"public {classe.NamePascal}({string.Join(", ", mapper.Params.Select(p => $"{p.Class.NamePascal} {p.Name.ToCamelCase()}"))}) {{");
             if (classe.Extends != null)
             {
                 fw.WriteLine(2, $"super();");
             }
 
             var (mapperNs, mapperModelPath) = _config.GetMapperLocation(fromMapper);
-            fw.WriteLine(2, $"{_config.GetMapperName(mapperNs, mapperModelPath)}.create{classe}({string.Join(", ", mapper.Params.Select(p => p.Name.ToCamelCase()))}, this);");
+            fw.WriteLine(2, $"{_config.GetMapperName(mapperNs, mapperModelPath)}.create{classe.NamePascal}({string.Join(", ", mapper.Params.Select(p => p.Name.ToCamelCase()))}, this);");
             fw.AddImport(_config.GetMapperImport(mapperNs, mapperModelPath, tag)!);
             fw.WriteLine(1, "}");
         }

--- a/TopModel.Generator.Jpa/JpaModelGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelGenerator.cs
@@ -94,7 +94,10 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
         JpaModelPropertyGenerator.WriteProperties(fw, classe, tag);
         JpaModelPropertyGenerator.WriteCompositePrimaryKeyClass(fw, classe);
         JpaModelConstructorGenerator.WriteNoArgConstructor(fw, classe);
-        JpaModelConstructorGenerator.WriteFromMappers(fw, classe, AvailableClasses, tag);
+        if (Config.MappersInClass)
+        {
+            JpaModelConstructorGenerator.WriteFromMappers(fw, classe, AvailableClasses, tag);
+        }
 
         WriteGetters(fw, classe, tag);
         WriteSetters(fw, classe, tag);
@@ -108,7 +111,10 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
             }
         }
 
-        WriteToMappers(fw, classe, tag);
+        if (Config.MappersInClass)
+        {
+            WriteToMappers(fw, classe, tag);
+        }
 
         if ((Config.FieldsEnum & Target.Persisted) > 0 && classe.IsPersistent
             || (Config.FieldsEnum & Target.Dto) > 0 && !classe.IsPersistent)

--- a/TopModel.Generator.Jpa/JpaModelGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelGenerator.cs
@@ -72,7 +72,7 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
         WriteImports(fw, classe, tag);
         fw.WriteLine();
 
-        WriteAnnotations(fw, classe);
+        WriteAnnotations(fw, classe, tag);
 
         var extends = Config.GetClassExtends(classe);
         var implements = Config.GetClassImplements(classe).ToList();
@@ -184,7 +184,7 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
         }
     }
 
-    private void WriteAnnotations(JavaWriter fw, Class classe)
+    private void WriteAnnotations(JavaWriter fw, Class classe, string tag)
     {
         fw.WriteDocStart(0, classe.Comment);
         fw.WriteDocEnd(0);
@@ -197,9 +197,9 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
             if (Config.UseJdbc)
             {
                 var table = @$"@Table(name = ""{classe.SqlName}""";
-                if (Config.DbSchema != null)
+                if (Config.ResolveVariables(Config.DbSchema!, tag: tag) != null)
                 {
-                    table += @$", schema = ""{Config.DbSchema}""";
+                    table += @$", schema = ""{Config.ResolveVariables(Config.DbSchema!, tag: tag)}""";
                 }
 
                 table += ")";
@@ -209,9 +209,9 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
             else
             {
                 var table = @$"@Table(name = ""{classe.SqlName}""";
-                if (Config.DbSchema != null)
+                if (Config.ResolveVariables(Config.DbSchema!, tag: tag) != null)
                 {
-                    table += @$", schema = ""{Config.DbSchema}""";
+                    table += @$", schema = ""{Config.ResolveVariables(Config.DbSchema!, tag: tag)}""";
                 }
 
                 fw.AddImport($"{javaOrJakarta}.persistence.Table");
@@ -439,7 +439,7 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
 
     private void WriteImports(JavaWriter fw, Class classe, string tag)
     {
-        var imports = classe.GetImports(Config, tag);
+        var imports = classe.GetImports(Config, tag, AvailableClasses);
         imports.AddRange(Config.GetDecoratorImports(classe));
         foreach (var property in classe.GetProperties(AvailableClasses))
         {

--- a/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
@@ -290,6 +290,7 @@ public class JpaModelPropertyGenerator
                     column += $", scale = {property.Domain.Scale}";
                 }
 
+                column += @$", columnDefinition = ""{property.Domain.Implementations["sql"].Type}""";
                 column += ")";
                 fw.AddImport($"{javaOrJakarta}.persistence.Column");
             }

--- a/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
@@ -193,7 +193,7 @@ public class JpaModelPropertyGenerator
                 var defaultValue = _config.GetValue(property, _classes);
                 if (defaultValue != "null")
                 {
-                    suffix = $" = {defaultValue}.getEntity()";
+                    suffix = $" = new {property.Association.NamePascal}({defaultValue})";
                 }
             }
 

--- a/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelPropertyGenerator.cs
@@ -307,7 +307,7 @@ public class JpaModelPropertyGenerator
             fw.AddImport($"{javaOrJakarta}.validation.constraints.NotNull");
         }
 
-        if (property.PrimaryKey && classe.Reference && classe.Values.Any() && !_config.UseJdbc)
+        if (_config.CanClassUseEnums(classe) && property.PrimaryKey && !_config.UseJdbc)
         {
             fw.AddImports(new List<string>
             {

--- a/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
+++ b/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
@@ -254,7 +254,7 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
                 "VARCHAR" => "VarChar",
                 _ => sqlType.ToPascalCase()
             };
-            fw.WriteLine(3, $@"map(""{property.SqlName}"", DataType.{dataType}, {dataFlow.Class.NamePascal}::{(Config.GetType(property) == "boolean" ? "is" : "get")}{property.NamePascal});");
+            fw.WriteLine(3, $@"map(""{property.SqlName}"", DataType.{dataType}, {dataFlow.Class.NamePascal}::{(Config.GetType(property) == "boolean" ? "is" : "get")}{property.NamePascal.ToFirstUpper()});");
         }
 
         fw.WriteLine(2, "}");
@@ -277,7 +277,11 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
             WriteBeanTruncateStep(fw, dataFlow);
         }
 
-        WriteBeanReader(fw, dataFlow, tag);
+        if (dataFlow.Sources[0].Mode == DataFlowSourceMode.QueryAll)
+        {
+            WriteBeanReader(fw, dataFlow, tag);
+        }
+
         WriteBeanWriter(fw, dataFlow, tag);
         fw.WriteLine("}");
     }

--- a/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
+++ b/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
@@ -1,0 +1,284 @@
+﻿using System.Data;
+using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Core.FileModel;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+
+namespace TopModel.Generator.Jpa;
+
+public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
+{
+    private readonly ILogger<SpringDataFlowGenerator> _logger;
+
+    public SpringDataFlowGenerator(ILogger<SpringDataFlowGenerator> logger)
+        : base(logger)
+    {
+        _logger = logger;
+    }
+
+    public override IEnumerable<string> GeneratedFiles => Files.Values.SelectMany(f => f.DataFlows)
+        .SelectMany(df => Config.Tags.Intersect(df.ModelFile.Tags)
+            .SelectMany(tag => new[] { Config.GetDataFlowFilePath(df, tag) }))
+        .Distinct()
+        .Concat(Files.Values.Where(f => f.DataFlows.Any()).Select(f => Config.GetDataFlowConfigFilePath(f.Namespace.Module)))
+        ;
+
+    public override string Name => "SpringDataFlowGen";
+
+    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    {
+        foreach (var file in files)
+        {
+            foreach (var dataFlow in file.DataFlows)
+            {
+                foreach (var (tag, fileName) in Config.Tags.Intersect(file.Tags)
+                    .Select(tag => (tag, fileName: Config.GetDataFlowFilePath(dataFlow, tag)))
+                    .DistinctBy(t => t.fileName))
+                {
+                    HandleDataFlow(fileName, dataFlow, tag);
+                }
+            }
+        }
+
+        foreach (var module in files.Where(f => f.DataFlows.Any()).Select(f => f.Namespace.Module))
+        {
+            WriteModuleConfig(module, files.Where(f => f.Namespace.Module == module).SelectMany(f => f.DataFlows));
+        }
+    }
+
+    private static void WriteBeanFlow(JavaWriter fw, DataFlow dataFlow)
+    {
+        fw.AddImport("org.springframework.context.annotation.Bean");
+        fw.AddImport("org.springframework.batch.core.job.flow.Flow");
+        fw.AddImport("org.springframework.beans.factory.annotation.Qualifier");
+        fw.AddImport("org.springframework.batch.core.Step");
+        fw.AddImport("org.springframework.batch.core.job.builder.FlowBuilder");
+
+        fw.WriteLine();
+        fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}Flow"")");
+        fw.WriteLine(1, @$"public static Flow {dataFlow.Name.ToCamelCase()}Flow(");
+        if (dataFlow.Type == DataFlowType.Replace)
+        {
+            fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}TruncateStep"") Step {dataFlow.Name.ToCamelCase()}TruncateStep,");
+        }
+
+        fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}Step"") Step {dataFlow.Name.ToCamelCase()}Step) {{");
+        fw.WriteLine(2, @$"return new FlowBuilder<Flow>(""{dataFlow.Name.ToPascalCase()}Flow"") //");
+        if (dataFlow.Type == DataFlowType.Replace)
+        {
+            fw.WriteLine(3, @$".start({dataFlow.Name.ToCamelCase()}TruncateStep) //");
+            fw.WriteLine(3, @$".next({dataFlow.Name.ToCamelCase()}Step) //");
+        }
+        else
+        {
+            fw.WriteLine(3, @$".start({dataFlow.Name.ToCamelCase()}Step) //");
+        }
+
+        fw.WriteLine(3, ".build();");
+        fw.WriteLine(1, "}");
+    }
+
+    private static void WriteBeanTruncateStep(JavaWriter fw, DataFlow dataFlow)
+    {
+        fw.WriteLine();
+        fw.AddImport("io.github.kleecontrib.spring.batch.tasklet.QueryTasklet");
+        fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}TruncateStep"")");
+        fw.WriteLine(1, @$"public static Step {dataFlow.Name.ToCamelCase()}TruncateStep( //");
+        fw.WriteLine(1, @$"		JobRepository jobRepository, //");
+        fw.WriteLine(1, @$"		PlatformTransactionManager transactionManager, //");
+        fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Target}"") DataSource dataSource) {{");
+        fw.WriteLine(1, @$"return new StepBuilder(""{dataFlow.Name.ToPascalCase()}TruncateStep"", jobRepository) //");
+        fw.WriteLine(2, @$"		.tasklet(new QueryTasklet(dataSource, ""truncate table {dataFlow.Class.SqlName}""), transactionManager) //");
+
+        fw.WriteLine(3, ".build();");
+        fw.WriteLine(1, "}");
+    }
+
+    private void HandleDataFlow(string fileName, DataFlow dataFlow, string tag)
+    {
+        var packageName = Config.ResolveVariables(
+            Config.DataFlowsPath!,
+            tag,
+            module: dataFlow.ModelFile.Namespace.Module).ToPackageName();
+
+        using var fw = new JavaWriter(fileName, _logger, packageName);
+        WriteClassFlow(fw, dataFlow, tag);
+    }
+
+    private void WriteBeanReader(JavaWriter fw, DataFlow dataFlow)
+    {
+        fw.WriteLine();
+        var query = $"select * from {(Config.DbSchema == null ? string.Empty : $"{Config.DbSchema}.")}{dataFlow.Sources.First().Class.SqlName}";
+        if (dataFlow.Sources.First().Mode == DataFlowSourceMode.Partial)
+        {
+            query = string.Empty;
+        }
+
+        var javaOrJakarta = Config.PersistenceMode.ToString().ToLower();
+        fw.AddImport($"{javaOrJakarta}.persistence.EntityManagerFactory");
+        fw.AddImport("org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder");
+        fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}Reader"")");
+        fw.WriteLine(1, @$"public static ItemReader<{dataFlow.Sources.First().Class.NamePascal}> {dataFlow.Name.ToCamelCase()}Reader( //");
+        fw.WriteLine(1, @$"		EntityManagerFactory entityManagerFactory, //");
+        fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Sources.First().Source}"") DataSource datasource) {{");
+        fw.WriteLine(2, $"return new JdbcCursorItemReaderBuilder<{dataFlow.Sources.First().Class.NamePascal}>() //");
+        fw.WriteLine(2, @$"		.name(""{dataFlow.Name.ToPascalCase()}Reader"") //");
+        fw.WriteLine(2, @$"		.beanRowMapper({dataFlow.Sources.First().Class.NamePascal}.class) //");
+        fw.WriteLine(2, @$"		.sql(""{query}"") //");
+        fw.WriteLine(2, @$"		.fetchSize({Config.DataFlowsBulkSize}) //");
+        fw.WriteLine(2, @$"		.dataSource(datasource) //");
+        fw.WriteLine(2, @$"		.build();");
+        fw.WriteLine(1, "}");
+    }
+
+    private void WriteBeanStep(JavaWriter fw, DataFlow dataFlow, string tag)
+    {
+        fw.AddImport("org.springframework.batch.core.step.builder.StepBuilder");
+        fw.AddImport("org.springframework.batch.core.repository.JobRepository");
+        fw.AddImport("org.springframework.transaction.PlatformTransactionManager");
+        fw.AddImport("org.springframework.batch.item.ItemReader");
+        fw.AddImport("org.springframework.batch.item.ItemWriter");
+        fw.AddImport(dataFlow.Sources.First().Class.GetImport(Config, tag));
+        fw.AddImport(dataFlow.Class.GetImport(Config, tag));
+
+        fw.WriteLine();
+        fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}Step"")");
+        fw.WriteLine(1, @$"public static Step {dataFlow.Name.ToCamelCase()}Step(");
+        fw.WriteLine(1, @$"		JobRepository jobRepository, //");
+        fw.WriteLine(1, @$"		PlatformTransactionManager transactionManager, //");
+        fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Name.ToPascalCase()}Reader"") ItemReader<{dataFlow.Sources.First().Class.NamePascal}> reader, //");
+        fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Name.ToPascalCase()}Writer"") ItemWriter<{dataFlow.Class.NamePascal}> writer //");
+        fw.WriteLine(1, ") {");
+        fw.WriteLine(2, @$"return new StepBuilder(""{dataFlow.Name.ToPascalCase()}Step"", jobRepository) //");
+        fw.WriteLine(3, @$".<{dataFlow.Sources.First().Class.NamePascal}, {dataFlow.Class.NamePascal}>chunk({Config.DataFlowsBulkSize}, transactionManager) //");
+        fw.WriteLine(3, ".reader(reader) //");
+        if (dataFlow.Sources.First().Class != dataFlow.Class)
+        {
+            fw.WriteLine(3, $".processor({dataFlow.Class.NamePascal}::new) //");
+        }
+
+        fw.WriteLine(3, ".writer(writer) //");
+        fw.WriteLine(3, ".build();");
+        fw.WriteLine(1, "}");
+    }
+
+    private void WriteBeanWriter(JavaWriter fw, DataFlow dataFlow)
+    {
+        fw.AddImport("io.github.kleecontrib.spring.batch.bulk.upsert.BulkItemWriter");
+        fw.AddImport("javax.sql.DataSource");
+
+        fw.WriteLine();
+        fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}Writer"")");
+        fw.WriteLine(1, @$"public static ItemWriter<{dataFlow.Class.NamePascal}> {dataFlow.Name.ToCamelCase()}Writer(@Qualifier(""{dataFlow.Target}"") DataSource targetDataSource) {{");
+        fw.WriteLine(2, @$"return new BulkItemWriter<>(targetDataSource, new {dataFlow.Class.NamePascal}Mapping());");
+        fw.WriteLine(1, "}");
+
+        WriteBulkMappingWriter(fw, dataFlow);
+    }
+
+    private void WriteBulkMappingWriter(JavaWriter fw, DataFlow dataFlow)
+    {
+        fw.WriteLine();
+        if (dataFlow.Type != DataFlowType.Merge)
+        {
+            fw.AddImport("de.bytefish.pgbulkinsert.mapping.AbstractMapping");
+            fw.WriteLine(1, @$"private static class {dataFlow.Class.NamePascal}Mapping extends AbstractMapping<{dataFlow.Class.NamePascal}> {{");
+        }
+        else
+        {
+            fw.AddImport("io.github.kleecontrib.spring.batch.bulk.mapping.AbstractUpsertMapping");
+            fw.WriteLine(1, @$"private static class {dataFlow.Class.NamePascal}Mapping extends AbstractUpsertMapping<{dataFlow.Class.NamePascal}> {{");
+        }
+
+        fw.WriteLine(2, @$"public {dataFlow.Class.NamePascal}Mapping() {{");
+        if (dataFlow.Type != DataFlowType.Merge)
+        {
+            fw.WriteLine(3, @$"super(""{Config.DbSchema}"", ""{dataFlow.Class.SqlName}"");");
+        }
+        else
+        {
+            fw.WriteLine(3, @$"super(""{Config.DbSchema}"", ""{dataFlow.Class.SqlName}"", ""{string.Join(',', dataFlow.Class.PrimaryKey.Select(pk => pk.SqlName))}"");");
+        }
+
+        fw.AddImport("de.bytefish.pgbulkinsert.pgsql.constants.DataType");
+        foreach (var property in dataFlow.Class.Properties.OfType<IFieldProperty>())
+        {
+            var sqlType = property.Domain.Implementations["sql"].Type ?? string.Empty;
+            string dataType = sqlType.ToUpper() switch
+            {
+                "VARCHAR" => "VarChar",
+                _ => sqlType.ToPascalCase()
+            };
+            fw.WriteLine(3, $@"map(""{property.SqlName}"", DataType.{dataType}, {dataFlow.Class.NamePascal}::{(Config.GetType(property) == "boolean" ? "is" : "get")}{property.NamePascal});");
+        }
+
+        fw.WriteLine(2, "}");
+        fw.WriteLine(1, "}");
+    }
+
+    private void WriteClassFlow(JavaWriter fw, DataFlow dataFlow, string tag)
+    {
+        fw.AddImport("org.springframework.context.annotation.Configuration");
+        fw.WriteLine();
+        fw.WriteLine("@Configuration");
+        var javaOrJakarta = Config.PersistenceMode.ToString().ToLower();
+        fw.AddImport($"{javaOrJakarta}.annotation.Generated");
+        fw.WriteLine("@Generated(\"TopModel : https://github.com/klee-contrib/topmodel\")");
+        fw.WriteClassDeclaration($"{dataFlow.Name}Flow", null);
+        WriteBeanFlow(fw, dataFlow);
+        WriteBeanStep(fw, dataFlow, tag);
+        if (dataFlow.Type == DataFlowType.Replace)
+        {
+            WriteBeanTruncateStep(fw, dataFlow);
+        }
+
+        WriteBeanReader(fw, dataFlow);
+        WriteBeanWriter(fw, dataFlow);
+        fw.WriteLine("}");
+    }
+
+    private void WriteModuleConfig(string module, IEnumerable<DataFlow> flows)
+    {
+        var configFilePath = Config.GetDataFlowConfigFilePath(module);
+        var packageName = Config.ResolveVariables(
+            Config.DataFlowsPath!,
+            module: module).ToPackageName();
+        using var fw = new JavaWriter(configFilePath, _logger, packageName);
+        fw.AddImport("org.springframework.context.annotation.Configuration");
+        fw.AddImport("org.springframework.context.annotation.Bean");
+        fw.AddImport("org.springframework.batch.core.Job");
+        fw.AddImport("org.springframework.batch.core.repository.JobRepository");
+        fw.AddImport("org.springframework.beans.factory.annotation.Qualifier");
+        fw.AddImport("org.springframework.batch.core.job.flow.Flow");
+        fw.AddImport("org.springframework.batch.core.job.builder.JobBuilder");
+        fw.AddImport("org.springframework.batch.core.launch.support.RunIdIncrementer");
+        fw.AddImport("org.springframework.batch.core.job.builder.FlowBuilder");
+        fw.AddImport("org.springframework.core.task.TaskExecutor");
+        fw.AddImport("org.springframework.context.annotation.Import");
+        fw.WriteLine();
+        fw.WriteLine("@Configuration");
+        var javaOrJakarta = Config.PersistenceMode.ToString().ToLower();
+        fw.AddImport($"{javaOrJakarta}.annotation.Generated");
+        fw.WriteLine("@Generated(\"TopModel : https://github.com/klee-contrib/topmodel\")");
+        fw.WriteLine(@$"@Import({{{string.Join(", ", flows.Select(f => $@"{f.Name.ToPascalCase()}Flow.class"))}}})");
+
+        var className = configFilePath.Split("\\").Last().Split('.').First();
+        fw.WriteClassDeclaration($"{className}", null);
+        fw.WriteLine(1, @$"@Bean(""{module.ToPascalCase()}Job"")");
+        fw.WriteLine(1, @$"public Job {module.ToCamelCase()}Job( //");
+        fw.WriteLine(1, @$"			JobRepository jobRepository, //");
+        fw.WriteLine(1, @$"			TaskExecutor taskExecutor, //");
+        fw.WriteLine("			" + string.Join(", //\n			", flows.Select(f => $@"@Qualifier(""{f.Name}Flow"") Flow {f.Name.ToCamelCase()}Flow")));
+        fw.WriteLine(1, ") {");
+        fw.WriteLine(2, $@"return new JobBuilder(""{module.ToPascalCase()}Job"", jobRepository) //");
+        fw.WriteLine(2, $@"		.incrementer(new RunIdIncrementer()) //");
+
+        var flowTree = new FlowTree(flows.ToList());
+        fw.WriteLine(2, $"		.start({flowTree.ToFlow(0)})");
+        fw.WriteLine(2, "		.end()");
+        fw.WriteLine(2, "		.build();");
+        fw.WriteLine(1, "}");
+        fw.WriteLine("}");
+    }
+}

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -101,7 +101,12 @@
     },
     "useJdbc": {
       "type": "boolean",
-      "description": "Générer les entités en mode JDBC"
+      "description": "Générer les entités en mode JDBC",
+      "default": "false"
+    },
+    "mappersInClass": {
+      "type": "boolean",
+      "description": "Indique s'il faut ajouter les mappers en tant méthode ou constructeur dans les classes qui les déclarent"
     },
     "dataFlowsPath": {
       "type": "string",

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -99,6 +99,10 @@
       "type": "string",
       "description": "Localisation des ressources, relative au répertoire de génération."
     },
+    "useJdbc": {
+      "type": "boolean",
+      "description": "Générer les entités en mode JDBC"
+    },
     "dataFlowsPath": {
       "type": "string",
       "description": "Localisation des flux de données générés."

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -99,6 +99,18 @@
       "type": "string",
       "description": "Localisation des ressources, relative au répertoire de génération."
     },
+    "dataFlowsPath": {
+      "type": "string",
+      "description": "Localisation des flux de données générés."
+    },
+    "dataFlowsBulkSize": {
+      "type": "number",
+      "description": "Taille des chunks à extraire et insérer"
+    },
+    "dbSchema": {
+      "type": "string",
+      "description": "Nom du schéma sur lequel les entités sont sauvegardées"
+    },
     "enumShortcutMode": {
       "type": "boolean",
       "description": "Option pour générer des getters et setters vers l'enum des références plutôt que sur la table",

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -52,6 +52,7 @@
           "JpaInterfaceGen",
           "JpaMapperGenerator",
           "JpaDaoGen",
+          "JpaEnumGenerator",
           "JpaResourceGen",
           "SpringApiServerGen",
           "SpringApiClientGen"
@@ -73,6 +74,11 @@
     "dtosPath": {
       "type": "string",
       "description": "Localisation des classes non persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen:{app}/dtos/{module}'."
+    },
+    "enumsPath": {
+      "type": "string",
+      "description": "Localisation des enums du modèle, relative au répertoire de génération.",
+      "default": "javagen:{app}/enums/{module}"
     },
     "apiPath": {
       "type": "string",

--- a/TopModel.ModelGenerator/TmdWriter.cs
+++ b/TopModel.ModelGenerator/TmdWriter.cs
@@ -48,7 +48,7 @@ public class TmdWriter : IDisposable
             _writer.WriteLine($"uses: ");
             foreach (var u in _file.Uses.OrderBy(u => u.Name).Where(u => u.Name != _file.Name))
             {
-                _writer.WriteLine($"  - {_modelRoot}{u.Module}/{u.Name}");
+                _writer.WriteLine($"  - {_modelRoot.Replace('\\', '/')}{u.Module}/{u.Name}");
             }
         }
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/AbstractUtilisateurApiClient.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/AbstractUtilisateurApiClient.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
 
 import topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurDto;
 import topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurSearch;
-import topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur;
+import topmodel.jpa.sample.demo.enums.utilisateur.TypeUtilisateurCode;
 
 @Generated("TopModel : https://github.com/klee-contrib/topmodel")
 public abstract class AbstractUtilisateurApiClient {
@@ -93,7 +93,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return uriBuilder avec les query params remplis
 	 */
-	protected UriComponentsBuilder findAllByTypeUriComponentsBuilder(TypeUtilisateur.Values typeUtilisateurCode) {
+	protected UriComponentsBuilder findAllByTypeUriComponentsBuilder(TypeUtilisateurCode typeUtilisateurCode) {
 		String uri = host + "/utilisateur/list";
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));
 		if (typeUtilisateurCode != null) {
@@ -108,7 +108,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param typeUtilisateurCode Type d'utilisateur en Many to one
 	 * @return Liste des utilisateurs
 	 */
-	public ResponseEntity<List<UtilisateurSearch>> findAllByType(TypeUtilisateur.Values typeUtilisateurCode){
+	public ResponseEntity<List<UtilisateurSearch>> findAllByType(TypeUtilisateurCode typeUtilisateurCode){
 		HttpHeaders headers = this.getHeaders();
 		UriComponentsBuilder uri = this.findAllByTypeUriComponentsBuilder(typeUtilisateurCode);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.GET, new HttpEntity<>(headers), new ParameterizedTypeReference<List<UtilisateurSearch>>() {});
@@ -148,7 +148,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param dateModification Date de modification de l'utilisateur
 	 * @return uriBuilder avec les query params remplis
 	 */
-	protected UriComponentsBuilder searchUriComponentsBuilder(Long utiId, Long age, Long profilId, String email, String nom, Boolean actif, TypeUtilisateur.Values typeUtilisateurCode, List<Long> utilisateursEnfant, LocalDate dateCreation, LocalDateTime dateModification) {
+	protected UriComponentsBuilder searchUriComponentsBuilder(Long utiId, Long age, Long profilId, String email, String nom, Boolean actif, TypeUtilisateurCode typeUtilisateurCode, List<Long> utilisateursEnfant, LocalDate dateCreation, LocalDateTime dateModification) {
 		String uri = host + "/utilisateur/search";
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(URI.create(uri));
 		uriBuilder.queryParam("utiId", utiId);
@@ -205,7 +205,7 @@ public abstract class AbstractUtilisateurApiClient {
 	 * @param dateModification Date de modification de l'utilisateur
 	 * @return Utilisateurs matchant les critères
 	 */
-	public ResponseEntity<Page<UtilisateurSearch>> search(Long utiId, Long age, Long profilId, String email, String nom, Boolean actif, TypeUtilisateur.Values typeUtilisateurCode, List<Long> utilisateursEnfant, LocalDate dateCreation, LocalDateTime dateModification){
+	public ResponseEntity<Page<UtilisateurSearch>> search(Long utiId, Long age, Long profilId, String email, String nom, Boolean actif, TypeUtilisateurCode typeUtilisateurCode, List<Long> utilisateursEnfant, LocalDate dateCreation, LocalDateTime dateModification){
 		HttpHeaders headers = this.getHeaders();
 		UriComponentsBuilder uri = this.searchUriComponentsBuilder(utiId, age, profilId, email, nom, actif, typeUtilisateurCode, utilisateursEnfant, dateCreation, dateModification);
 		return this.restTemplate.exchange(uri.build().toUri(), HttpMethod.POST, new HttpEntity<>(headers), new ParameterizedTypeReference<Page<UtilisateurSearch>>() {});

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/server/securite/utilisateur/UtilisateurApiController.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/server/securite/utilisateur/UtilisateurApiController.java
@@ -23,7 +23,7 @@ import jakarta.validation.Valid;
 
 import topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurDto;
 import topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurSearch;
-import topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur;
+import topmodel.jpa.sample.demo.enums.utilisateur.TypeUtilisateurCode;
 
 @RequestMapping("utilisateur")
 @Generated("TopModel : https://github.com/klee-contrib/topmodel")
@@ -51,7 +51,7 @@ public interface UtilisateurApiController {
 	 * @return Liste des utilisateurs
 	 */
 	@GetMapping(path = "/list")
-	List<UtilisateurSearch> findAllByType(@RequestParam(value = "typeUtilisateurCode", required = false) TypeUtilisateur.Values typeUtilisateurCode);
+	List<UtilisateurSearch> findAllByType(@RequestParam(value = "typeUtilisateurCode", required = false) TypeUtilisateurCode typeUtilisateurCode);
 
 	/**
 	 * Sauvegarde un utilisateur.
@@ -77,5 +77,5 @@ public interface UtilisateurApiController {
 	 * @return Utilisateurs matchant les critères
 	 */
 	@PostMapping(path = "/search")
-	Page<UtilisateurSearch> search(@RequestParam(value = "utiId", required = true) Long utiId, @RequestParam(value = "age", required = false) Long age, @RequestParam(value = "profilId", required = false) Long profilId, @RequestParam(value = "email", required = false) String email, @RequestParam(value = "nom", required = false) String nom, @RequestParam(value = "actif", required = false) Boolean actif, @RequestParam(value = "typeUtilisateurCode", required = false) TypeUtilisateur.Values typeUtilisateurCode, @RequestParam(value = "utilisateursEnfant", required = false) List<Long> utilisateursEnfant, @RequestParam(value = "dateCreation", required = false) LocalDate dateCreation, @RequestParam(value = "dateModification", required = false) LocalDateTime dateModification);
+	Page<UtilisateurSearch> search(@RequestParam(value = "utiId", required = true) Long utiId, @RequestParam(value = "age", required = false) Long age, @RequestParam(value = "profilId", required = false) Long profilId, @RequestParam(value = "email", required = false) String email, @RequestParam(value = "nom", required = false) String nom, @RequestParam(value = "actif", required = false) Boolean actif, @RequestParam(value = "typeUtilisateurCode", required = false) TypeUtilisateurCode typeUtilisateurCode, @RequestParam(value = "utilisateursEnfant", required = false) List<Long> utilisateursEnfant, @RequestParam(value = "dateCreation", required = false) LocalDate dateCreation, @RequestParam(value = "dateModification", required = false) LocalDateTime dateModification);
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/ProfilDto.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/ProfilDto.java
@@ -10,10 +10,10 @@ import java.util.List;
 import jakarta.annotation.Generated;
 
 import topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurDto;
-import topmodel.jpa.sample.demo.entities.securite.Droit;
 import topmodel.jpa.sample.demo.entities.securite.Profil;
 import topmodel.jpa.sample.demo.entities.securite.SecuriteMappers;
-import topmodel.jpa.sample.demo.entities.securite.TypeProfil;
+import topmodel.jpa.sample.demo.enums.securite.DroitCode;
+import topmodel.jpa.sample.demo.enums.securite.TypeProfilCode;
 
 /**
  * Objet métier non persisté représentant Profil.
@@ -33,13 +33,13 @@ public class ProfilDto implements Serializable {
 	 * Type de profil.
 	 * Alias of {@link topmodel.jpa.sample.demo.entities.securite.Profil#getTypeProfilCode() Profil#getTypeProfilCode()} 
 	 */
-	private TypeProfil.Values typeProfilCode;
+	private TypeProfilCode typeProfilCode;
 
 	/**
 	 * Liste des droits de l'utilisateur.
 	 * Alias of {@link topmodel.jpa.sample.demo.entities.securite.Profil#getDroits() Profil#getDroits()} 
 	 */
-	private List<Droit.Values> droits;
+	private List<DroitCode> droits;
 
 	/**
 	 * Liste paginée des utilisateurs de ce profil.
@@ -81,7 +81,7 @@ public class ProfilDto implements Serializable {
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.dtos.securite.ProfilDto#typeProfilCode typeProfilCode}.
 	 */
-	public TypeProfil.Values getTypeProfilCode() {
+	public TypeProfilCode getTypeProfilCode() {
 		return this.typeProfilCode;
 	}
 
@@ -90,7 +90,7 @@ public class ProfilDto implements Serializable {
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.dtos.securite.ProfilDto#droits droits}.
 	 */
-	public List<Droit.Values> getDroits() {
+	public List<DroitCode> getDroits() {
 		return this.droits;
 	}
 
@@ -124,7 +124,7 @@ public class ProfilDto implements Serializable {
 	 * Set the value of {@link topmodel.jpa.sample.demo.dtos.securite.ProfilDto#typeProfilCode typeProfilCode}.
 	 * @param typeProfilCode value to set
 	 */
-	public void setTypeProfilCode(TypeProfil.Values typeProfilCode) {
+	public void setTypeProfilCode(TypeProfilCode typeProfilCode) {
 		this.typeProfilCode = typeProfilCode;
 	}
 
@@ -132,7 +132,7 @@ public class ProfilDto implements Serializable {
 	 * Set the value of {@link topmodel.jpa.sample.demo.dtos.securite.ProfilDto#droits droits}.
 	 * @param droits value to set
 	 */
-	public void setDroits(List<Droit.Values> droits) {
+	public void setDroits(List<DroitCode> droits) {
 		this.droits = droits;
 	}
 
@@ -167,7 +167,7 @@ public class ProfilDto implements Serializable {
 	 */
 	public enum Fields  {
         ID(Long.class), //
-        TYPE_PROFIL_CODE(TypeProfil.Values.class), //
+        TYPE_PROFIL_CODE(TypeProfilCode.class), //
         DROITS(List.class), //
         UTILISATEURS(List.class), //
         SECTEURS(List.class);

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/utilisateur/UtilisateurDto.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/utilisateur/UtilisateurDto.java
@@ -12,9 +12,9 @@ import java.util.List;
 import jakarta.annotation.Generated;
 import jakarta.validation.constraints.Email;
 
-import topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur;
 import topmodel.jpa.sample.demo.entities.utilisateur.Utilisateur;
 import topmodel.jpa.sample.demo.entities.utilisateur.UtilisateurMappers;
+import topmodel.jpa.sample.demo.enums.utilisateur.TypeUtilisateurCode;
 
 /**
  * Objet non persisté de communication avec le serveur.
@@ -65,7 +65,7 @@ public class UtilisateurDto implements Serializable {
 	 * Type d'utilisateur en Many to one.
 	 * Alias of {@link topmodel.jpa.sample.demo.entities.utilisateur.Utilisateur#getTypeUtilisateurCode() Utilisateur#getTypeUtilisateurCode()} 
 	 */
-	private TypeUtilisateur.Values typeUtilisateurCode = TypeUtilisateur.Values.ADM;
+	private TypeUtilisateurCode typeUtilisateurCode = TypeUtilisateurCode.ADM;
 
 	/**
 	 * Utilisateur enfants.
@@ -165,7 +165,7 @@ public class UtilisateurDto implements Serializable {
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurDto#typeUtilisateurCode typeUtilisateurCode}.
 	 */
-	public TypeUtilisateur.Values getTypeUtilisateurCode() {
+	public TypeUtilisateurCode getTypeUtilisateurCode() {
 		return this.typeUtilisateurCode;
 	}
 
@@ -257,7 +257,7 @@ public class UtilisateurDto implements Serializable {
 	 * Set the value of {@link topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurDto#typeUtilisateurCode typeUtilisateurCode}.
 	 * @param typeUtilisateurCode value to set
 	 */
-	public void setTypeUtilisateurCode(TypeUtilisateur.Values typeUtilisateurCode) {
+	public void setTypeUtilisateurCode(TypeUtilisateurCode typeUtilisateurCode) {
 		this.typeUtilisateurCode = typeUtilisateurCode;
 	}
 
@@ -324,7 +324,7 @@ public class UtilisateurDto implements Serializable {
         EMAIL(String.class), //
         NOM(String.class), //
         ACTIF(Boolean.class), //
-        TYPE_UTILISATEUR_CODE(TypeUtilisateur.Values.class), //
+        TYPE_UTILISATEUR_CODE(TypeUtilisateurCode.class), //
         UTILISATEURS_ENFANT(List.class), //
         DATE_CREATION(LocalDate.class), //
         DATE_MODIFICATION(LocalDateTime.class), //

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/utilisateur/UtilisateurSearch.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/utilisateur/UtilisateurSearch.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import jakarta.annotation.Generated;
 
-import topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur;
+import topmodel.jpa.sample.demo.enums.utilisateur.TypeUtilisateurCode;
 
 @Generated("TopModel : https://github.com/klee-contrib/topmodel")
 public interface UtilisateurSearch {
@@ -62,7 +62,7 @@ public interface UtilisateurSearch {
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.dtos.utilisateur.UtilisateurSearch#typeUtilisateurCode typeUtilisateurCode}.
 	 */
-	TypeUtilisateur.Values getTypeUtilisateurCode();
+	TypeUtilisateurCode getTypeUtilisateurCode();
 
 	/**
 	 * Getter for utilisateursEnfant.

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Droit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Droit.java
@@ -19,6 +19,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import topmodel.jpa.sample.demo.enums.securite.DroitCode;
+
 /**
  * Droits de l'application.
  */
@@ -33,14 +35,14 @@ public class Droit {
 	 * Code du droit.
 	 */
 	@Id
-	@Column(name = "DRO_CODE", nullable = false, length = 3)
+	@Column(name = "DRO_CODE", nullable = false, length = 3, columnDefinition = "varchar")
 	@Enumerated(EnumType.STRING)
-	private Droit.Values code;
+	private DroitCode code;
 
 	/**
 	 * Libellé du droit.
 	 */
-	@Column(name = "DRO_LIBELLE", nullable = false, length = 3)
+	@Column(name = "DRO_LIBELLE", nullable = false, length = 3, columnDefinition = "varchar")
 	private String libelle;
 
 	/**
@@ -56,12 +58,38 @@ public class Droit {
 	public Droit() {
 	}
 
+	public static final Droit CRE = new Droit(DroitCode.CRE);
+	public static final Droit MOD = new Droit(DroitCode.MOD);
+	public static final Droit SUP = new Droit(DroitCode.SUP);
+
+	/**
+	 * Enum constructor.
+	 * @param code Code dont on veut obtenir l'instance.
+	 */
+	public Droit(DroitCode code) {
+		this.code = code;
+		switch(code) {
+		case CRE :
+			this.libelle = "securite.droit.values.CRE";
+			this.typeProfil = TypeProfil.ADM;
+			break;
+		case MOD :
+			this.libelle = "securite.droit.values.MOD";
+			this.typeProfil = null;
+			break;
+		case SUP :
+			this.libelle = "securite.droit.values.SUP";
+			this.typeProfil = null;
+			break;
+		}
+	}
+
 	/**
 	 * Getter for code.
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.entities.securite.Droit#code code}.
 	 */
-	public Droit.Values getCode() {
+	public DroitCode getCode() {
 		return this.code;
 	}
 
@@ -87,7 +115,7 @@ public class Droit {
 	 * Set the value of {@link topmodel.jpa.sample.demo.entities.securite.Droit#code code}.
 	 * @param code value to set
 	 */
-	public void setCode(Droit.Values code) {
+	public void setCode(DroitCode code) {
 		this.code = code;
 	}
 
@@ -111,7 +139,7 @@ public class Droit {
 	 * Enumération des champs de la classe {@link topmodel.jpa.sample.demo.entities.securite.Droit Droit}.
 	 */
 	public enum Fields  {
-        CODE(Droit.Values.class), //
+        CODE(DroitCode.class), //
         LIBELLE(String.class), //
         TYPE_PROFIL(TypeProfil.class);
 
@@ -123,57 +151,6 @@ public class Droit {
 
 		public Class<?> getType() {
 			return this.type;
-		}
-	}
-
-	public enum Values {
-		CRE("securite.droit.values.CRE", TypeProfil.Values.ADM), //
-		MOD("securite.droit.values.MOD", null), //
-		SUP("securite.droit.values.SUP", null); 
-
-		/**
-		 * Libellé du droit.
-		 */
-		private final String libelle;
-
-		/**
-		 * Type de profil pouvant faire l'action.
-		 */
-		private final TypeProfil.Values typeProfilCode;
-
-		/**
-		 * All arg constructor.
-		 */
-		private Values(String libelle, TypeProfil.Values typeProfilCode) {
-			this.libelle = libelle;
-			this.typeProfilCode = typeProfilCode;
-		}
-
-		/**
-		 * Méthode permettant de récupérer l'entité correspondant au code.
-		 *
-		 * @return instance de {@link topmodel.jpa.sample.demo.entities.securite.Droit} correspondant au code courant.
-		 */
-		public Droit getEntity() {
-			Droit entity = new Droit();
-			entity.code = this;
-			entity.libelle = this.libelle;
-			entity.typeProfilCode = this.typeProfilCode;
-			return entity;
-		}
-
-		/**
-		 * Libellé du droit.
-		 */
-		public String getLibelle(){
-			return this.libelle;
-		}
-
-		/**
-		 * Type de profil pouvant faire l'action.
-		 */
-		public TypeProfil.Values getTypeProfilCode(){
-			return this.typeProfilCode;
 		}
 	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Profil.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Profil.java
@@ -34,9 +34,9 @@ public class Profil {
 	/**
 	 * Id technique.
 	 */
-	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "PRO_ID", nullable = false)
+	@Id
+	@Column(name = "PRO_ID", nullable = false, columnDefinition = "int8")
 	private Long id;
 
 	/**

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Secteur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/Secteur.java
@@ -26,9 +26,9 @@ public class Secteur {
 	/**
 	 * Id technique.
 	 */
-	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "SEC_ID", nullable = false)
+	@Id
+	@Column(name = "SEC_ID", nullable = false, columnDefinition = "int8")
 	private Long id;
 
 	/**

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/SecuriteMappers.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/SecuriteMappers.java
@@ -11,6 +11,7 @@ import jakarta.annotation.Generated;
 
 import topmodel.jpa.sample.demo.dtos.securite.ProfilDto;
 import topmodel.jpa.sample.demo.dtos.securite.SecteurDto;
+import topmodel.jpa.sample.demo.enums.securite.DroitCode;
 
 @Generated("TopModel : https://github.com/klee-contrib/topmodel")
 public class SecuriteMappers {
@@ -104,10 +105,10 @@ public class SecuriteMappers {
 
 		target.setId(source.getId());
 		if (source.getTypeProfilCode() != null) {
-			target.setTypeProfil(source.getTypeProfilCode().getEntity());
+			target.setTypeProfil(new TypeProfil(source.getTypeProfilCode()));
 		}
 
-		target.setDroits(source.getDroits().stream().map(Droit.Values::getEntity).collect(Collectors.toList()));
+		target.setDroits(source.getDroits().stream().map(Droit::new).collect(Collectors.toList()));
 		return target;
 	}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/TypeProfil.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/TypeProfil.java
@@ -16,6 +16,8 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import topmodel.jpa.sample.demo.enums.securite.TypeProfilCode;
+
 /**
  * Type d'utilisateur.
  */
@@ -30,14 +32,14 @@ public class TypeProfil {
 	 * Code du type d'utilisateur.
 	 */
 	@Id
-	@Column(name = "TPR_CODE", nullable = false, length = 3)
+	@Column(name = "TPR_CODE", nullable = false, length = 3, columnDefinition = "varchar")
 	@Enumerated(EnumType.STRING)
-	private TypeProfil.Values code;
+	private TypeProfilCode code;
 
 	/**
 	 * Libellé du type d'utilisateur.
 	 */
-	@Column(name = "TPR_LIBELLE", nullable = false, length = 3)
+	@Column(name = "TPR_LIBELLE", nullable = false, length = 3, columnDefinition = "varchar")
 	private String libelle;
 
 	/**
@@ -46,12 +48,31 @@ public class TypeProfil {
 	public TypeProfil() {
 	}
 
+	public static final TypeProfil ADM = new TypeProfil(TypeProfilCode.ADM);
+	public static final TypeProfil GES = new TypeProfil(TypeProfilCode.GES);
+
+	/**
+	 * Enum constructor.
+	 * @param code Code dont on veut obtenir l'instance.
+	 */
+	public TypeProfil(TypeProfilCode code) {
+		this.code = code;
+		switch(code) {
+		case ADM :
+			this.libelle = "securite.typeProfil.values.ADM";
+			break;
+		case GES :
+			this.libelle = "securite.typeProfil.values.GES";
+			break;
+		}
+	}
+
 	/**
 	 * Getter for code.
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.entities.securite.TypeProfil#code code}.
 	 */
-	public TypeProfil.Values getCode() {
+	public TypeProfilCode getCode() {
 		return this.code;
 	}
 
@@ -68,7 +89,7 @@ public class TypeProfil {
 	 * Set the value of {@link topmodel.jpa.sample.demo.entities.securite.TypeProfil#code code}.
 	 * @param code value to set
 	 */
-	public void setCode(TypeProfil.Values code) {
+	public void setCode(TypeProfilCode code) {
 		this.code = code;
 	}
 
@@ -84,7 +105,7 @@ public class TypeProfil {
 	 * Enumération des champs de la classe {@link topmodel.jpa.sample.demo.entities.securite.TypeProfil TypeProfil}.
 	 */
 	public enum Fields  {
-        CODE(TypeProfil.Values.class), //
+        CODE(TypeProfilCode.class), //
         LIBELLE(String.class);
 
 		private Class<?> type;
@@ -95,42 +116,6 @@ public class TypeProfil {
 
 		public Class<?> getType() {
 			return this.type;
-		}
-	}
-
-	public enum Values {
-		ADM("securite.typeProfil.values.ADM"), //
-		GES("securite.typeProfil.values.GES"); 
-
-		/**
-		 * Libellé du type d'utilisateur.
-		 */
-		private final String libelle;
-
-		/**
-		 * All arg constructor.
-		 */
-		private Values(String libelle) {
-			this.libelle = libelle;
-		}
-
-		/**
-		 * Méthode permettant de récupérer l'entité correspondant au code.
-		 *
-		 * @return instance de {@link topmodel.jpa.sample.demo.entities.securite.TypeProfil} correspondant au code courant.
-		 */
-		public TypeProfil getEntity() {
-			TypeProfil entity = new TypeProfil();
-			entity.code = this;
-			entity.libelle = this.libelle;
-			return entity;
-		}
-
-		/**
-		 * Libellé du type d'utilisateur.
-		 */
-		public String getLibelle(){
-			return this.libelle;
 		}
 	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/TypeUtilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/TypeUtilisateur.java
@@ -16,6 +16,8 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import topmodel.jpa.sample.demo.enums.utilisateur.TypeUtilisateurCode;
+
 /**
  * Type d'utilisateur.
  */
@@ -30,14 +32,14 @@ public class TypeUtilisateur {
 	 * Code du type d'utilisateur.
 	 */
 	@Id
-	@Column(name = "TUT_CODE", nullable = false, length = 3)
+	@Column(name = "TUT_CODE", nullable = false, length = 3, columnDefinition = "varchar")
 	@Enumerated(EnumType.STRING)
-	private TypeUtilisateur.Values code;
+	private TypeUtilisateurCode code;
 
 	/**
 	 * Libellé du type d'utilisateur.
 	 */
-	@Column(name = "TUT_LIBELLE", nullable = false, length = 3)
+	@Column(name = "TUT_LIBELLE", nullable = false, length = 3, columnDefinition = "varchar")
 	private String libelle;
 
 	/**
@@ -46,12 +48,35 @@ public class TypeUtilisateur {
 	public TypeUtilisateur() {
 	}
 
+	public static final TypeUtilisateur ADM = new TypeUtilisateur(TypeUtilisateurCode.ADM);
+	public static final TypeUtilisateur CLI = new TypeUtilisateur(TypeUtilisateurCode.CLI);
+	public static final TypeUtilisateur GES = new TypeUtilisateur(TypeUtilisateurCode.GES);
+
+	/**
+	 * Enum constructor.
+	 * @param code Code dont on veut obtenir l'instance.
+	 */
+	public TypeUtilisateur(TypeUtilisateurCode code) {
+		this.code = code;
+		switch(code) {
+		case ADM :
+			this.libelle = "utilisateur.typeUtilisateur.values.ADM";
+			break;
+		case CLI :
+			this.libelle = "utilisateur.typeUtilisateur.values.CLI";
+			break;
+		case GES :
+			this.libelle = "utilisateur.typeUtilisateur.values.GES";
+			break;
+		}
+	}
+
 	/**
 	 * Getter for code.
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur#code code}.
 	 */
-	public TypeUtilisateur.Values getCode() {
+	public TypeUtilisateurCode getCode() {
 		return this.code;
 	}
 
@@ -68,7 +93,7 @@ public class TypeUtilisateur {
 	 * Set the value of {@link topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur#code code}.
 	 * @param code value to set
 	 */
-	public void setCode(TypeUtilisateur.Values code) {
+	public void setCode(TypeUtilisateurCode code) {
 		this.code = code;
 	}
 
@@ -84,7 +109,7 @@ public class TypeUtilisateur {
 	 * Enumération des champs de la classe {@link topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur TypeUtilisateur}.
 	 */
 	public enum Fields  {
-        CODE(TypeUtilisateur.Values.class), //
+        CODE(TypeUtilisateurCode.class), //
         LIBELLE(String.class);
 
 		private Class<?> type;
@@ -95,43 +120,6 @@ public class TypeUtilisateur {
 
 		public Class<?> getType() {
 			return this.type;
-		}
-	}
-
-	public enum Values {
-		ADM("utilisateur.typeUtilisateur.values.ADM"), //
-		CLI("utilisateur.typeUtilisateur.values.CLI"), //
-		GES("utilisateur.typeUtilisateur.values.GES"); 
-
-		/**
-		 * Libellé du type d'utilisateur.
-		 */
-		private final String libelle;
-
-		/**
-		 * All arg constructor.
-		 */
-		private Values(String libelle) {
-			this.libelle = libelle;
-		}
-
-		/**
-		 * Méthode permettant de récupérer l'entité correspondant au code.
-		 *
-		 * @return instance de {@link topmodel.jpa.sample.demo.entities.utilisateur.TypeUtilisateur} correspondant au code courant.
-		 */
-		public TypeUtilisateur getEntity() {
-			TypeUtilisateur entity = new TypeUtilisateur();
-			entity.code = this;
-			entity.libelle = this.libelle;
-			return entity;
-		}
-
-		/**
-		 * Libellé du type d'utilisateur.
-		 */
-		public String getLibelle(){
-			return this.libelle;
 		}
 	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/Utilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/Utilisateur.java
@@ -44,15 +44,15 @@ public class Utilisateur {
 	/**
 	 * Id technique.
 	 */
-	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "UTI_ID", nullable = false)
+	@Id
+	@Column(name = "UTI_ID", nullable = false, columnDefinition = "int8")
 	private Long id;
 
 	/**
 	 * Age en années de l'utilisateur.
 	 */
-	@Column(name = "UTI_AGE", nullable = true, precision = 20, scale = 9)
+	@Column(name = "UTI_AGE", nullable = true, precision = 20, scale = 9, columnDefinition = "numeric")
 	private Long age = 6l;
 
 	/**
@@ -65,19 +65,19 @@ public class Utilisateur {
 	/**
 	 * Email de l'utilisateur.
 	 */
-	@Column(name = "UTI_EMAIL", nullable = true, length = 50)
+	@Column(name = "UTI_EMAIL", nullable = true, length = 50, columnDefinition = "varchar")
 	private String email;
 
 	/**
 	 * Nom de l'utilisateur.
 	 */
-	@Column(name = "UTI_NOM", nullable = true, length = 3)
+	@Column(name = "UTI_NOM", nullable = true, length = 3, columnDefinition = "varchar")
 	private String nom = "Jabx";
 
 	/**
 	 * Si l'utilisateur est actif.
 	 */
-	@Column(name = "UTI_ACTIF", nullable = true)
+	@Column(name = "UTI_ACTIF", nullable = true, columnDefinition = "boolean")
 	private Boolean actif;
 
 	/**
@@ -85,7 +85,7 @@ public class Utilisateur {
 	 */
 	@ManyToOne(fetch = FetchType.LAZY, optional = true, targetEntity = TypeUtilisateur.class)
 	@JoinColumn(name = "TUT_CODE", referencedColumnName = "TUT_CODE")
-	private TypeUtilisateur typeUtilisateur = TypeUtilisateur.Values.ADM.getEntity();
+	private TypeUtilisateur typeUtilisateur = new TypeUtilisateur(TypeUtilisateurCode.ADM);
 
 	/**
 	 * Utilisateur parent.
@@ -103,14 +103,14 @@ public class Utilisateur {
 	/**
 	 * Date de création de l'utilisateur.
 	 */
-	@Column(name = "UTI_DATE_CREATION", nullable = true)
+	@Column(name = "UTI_DATE_CREATION", nullable = true, columnDefinition = "date")
 	@CreatedDate
 	private LocalDate dateCreation;
 
 	/**
 	 * Date de modification de l'utilisateur.
 	 */
-	@Column(name = "UTI_DATE_MODIFICATION", nullable = true)
+	@Column(name = "UTI_DATE_MODIFICATION", nullable = true, columnDefinition = "date")
 	@LastModifiedDate
 	private LocalDateTime dateModification;
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/UtilisateurMappers.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/UtilisateurMappers.java
@@ -78,7 +78,7 @@ public class UtilisateurMappers {
 		target.setNom(source.getNom());
 		target.setActif(source.getActif());
 		if (source.getTypeUtilisateurCode() != null) {
-			target.setTypeUtilisateur(source.getTypeUtilisateurCode().getEntity());
+			target.setTypeUtilisateur(new TypeUtilisateur(source.getTypeUtilisateurCode()));
 		}
 
 		target.setDateCreation(source.getDateCreation());

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/DroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/DroitCode.java
@@ -1,0 +1,23 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.securite;
+
+/**
+ * Enumération des valeurs possibles de la propriété Code de la classe Droit.
+ */
+public enum DroitCode {
+	/**
+	 * Créer.
+	 */
+	CRE,
+	/**
+	 * Modifier.
+	 */
+	MOD,
+	/**
+	 * Supprimer.
+	 */
+	SUP;
+}

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/TypeProfilCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/TypeProfilCode.java
@@ -1,0 +1,19 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.securite;
+
+/**
+ * Enumération des valeurs possibles de la propriété Code de la classe TypeProfil.
+ */
+public enum TypeProfilCode {
+	/**
+	 * Administrateur.
+	 */
+	ADM,
+	/**
+	 * Gestionnaire.
+	 */
+	GES;
+}

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/utilisateur/TypeUtilisateurCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/utilisateur/TypeUtilisateurCode.java
@@ -1,0 +1,23 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.utilisateur;
+
+/**
+ * Enumération des valeurs possibles de la propriété Code de la classe TypeUtilisateur.
+ */
+public enum TypeUtilisateurCode {
+	/**
+	 * Administrateur.
+	 */
+	ADM,
+	/**
+	 * Client.
+	 */
+	CLI,
+	/**
+	 * Gestionnaire.
+	 */
+	GES;
+}

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -25,5 +25,8 @@ generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/TypeUtilisateur.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/Utilisateur.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/utilisateur/UtilisateurMappers.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/DroitCode.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/TypeProfilCode.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/utilisateur/TypeUtilisateurCode.java
   - ../generators/jpa/src/main/resources/i18n/model/securite.properties
   - ../generators/jpa/src/main/resources/i18n/model/utilisateur.properties


### PR DESCRIPTION
# Spring-batch dataFlows, mode JDBC et séparation des values/enums

Implémentation du générateur de dataflows spring-batch.

## Fichiers générés

### Flow

Le générateur créé un fichier par dataFlow, comprenant 

- Reader
- Writer
- TruncateTasklet éventuellement
- Step
- Flow

La génération s'appuie sur spring-batch, mais aussi la librairie spring-batch-bulk, qui permet des performances exceptionnelles grâce à l'utilisation du bulk insert postgres (avec la commande `COPY`)

#### Reader

Le reader privilégié est le reader `JdbcCursorItemReaderBuilder`. Il permet d'obtenir les meilleures performances, et offre une meilleure flexibilité (choix de la source de données, requête).

#### Replace

Le truncate se fait avec la classe `TaskletQuery` de la librairie spring-batch-bulk. Nous aurions pu utiliser un `deleteAll` mais il est nettement moins performant que le `truncate` ;)

#### Processor

Si la classe source et la classe cible sont différentes, un processor est ajouté pour appeler le mapper de l'une vers l'autre

#### Writer

Les writers utilisent le PgBulkWriter de la librairie spring-batch-bulk. Il existe deux modes

##### Insert

Le writer copy directement les données dans la table cible. TopModel génère le mapping permettant de faire cette insertion.

#### Upsert

Le writer copy les données dans une table temporaire, puis recopie les données de table à table. En cas de conflit sur la clé primaire, un update est effectué. TopModel génère le mapping permettant de faire cette insertion.

### Job

Le générateur créé un fichier de configuration de job par module. Ce job ordonnance les lancement des flow selon ce qui a été paramétré dans avec les mots clés `dependsOn`. Il import les configurations nécessaires à son bon fonctionnement.

## Limitations et mises en garde

- Ne fonctionne que de base à base
- La base cible ne peut être qu'une base de données `Postgresql`
- Il est obligatoire de définir un dbSchema
- Mult-source non supporté
- Mode `partial` non supporté
- Un mapper doit exister de la classe source vers la classe cible (sauf s'il s'agit de la même classe)
- Deux jobs ne peuvent pas dépendre l'un de l'autre s'ils ne sont pas dans le même module
- Prenons les flow A, B, C et D, i C dépend de A et B et D dépend de A, alors D ne se lancera qu'après A et B (alors qu'en théorie il pourrait se lancer directement après A).

Breaking Changes : 

- Suppression de la classe imbriquée [Nom de la classe].Values pour les listes de ref
  - En remplacement du getEntity, récupérer l'instance soit avec le constructeur new [Nom de la classe]([élément du type de la clé primaire]), soit directement avec l'instance statique de la classe [Nom de la classe].[Clé de l'instance]
  - En remplacement du type de la clé primaire, une enum [Nom de la classe][Nom de la clé primaire] est générée au chemin spécifié dans la config : `enumsPath`


Fix: #281 #290 #291