### PR TITLE
Paramètres de domaines

### DIFF
--- a/TopModel.Core/FileModel/DomainReference.cs
+++ b/TopModel.Core/FileModel/DomainReference.cs
@@ -8,4 +8,6 @@ public class DomainReference : Reference
         : base(scalar)
     {
     }
+
+    public List<Reference> ParameterReferences { get; set; } = new();
 }

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -21,9 +21,8 @@ public class ClassLoader : ILoader<Class>
     {
         var classe = new Class();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>();
             _ = parser.TryConsume<Scalar>(out var value);
 
             switch (prop.Value)
@@ -78,9 +77,9 @@ public class ClassLoader : ILoader<Class>
                     {
                         if (parser.Current is MappingStart)
                         {
-                            parser.ConsumeMapping(() =>
+                            parser.ConsumeMapping(prop =>
                             {
-                                var decorator = new DecoratorReference(parser.Consume<Scalar>());
+                                var decorator = new DecoratorReference(prop);
 
                                 parser.ConsumeSequence(() =>
                                 {
@@ -118,24 +117,23 @@ public class ClassLoader : ILoader<Class>
                     });
                     break;
                 case "values":
-                    parser.ConsumeMapping(() =>
+                    parser.ConsumeMapping(prop =>
                     {
-                        var name = new Reference(parser.Consume<Scalar>());
+                        var name = new Reference(prop);
                         var values = new Dictionary<Reference, string>();
 
                         classe.ValueReferences.Add(name, values);
 
-                        parser.ConsumeMapping(() =>
+                        parser.ConsumeMapping(prop =>
                         {
-                            values.Add(new Reference(parser.Consume<Scalar>()), parser.Consume<Scalar>().Value);
+                            values.Add(new Reference(prop), parser.Consume<Scalar>().Value);
                         });
                     });
                     break;
                 case "mappers":
-                    parser.ConsumeMapping(() =>
+                    parser.ConsumeMapping(prop =>
                     {
-                        var subProp = parser.Consume<Scalar>().Value;
-                        switch (subProp)
+                        switch (prop.Value)
                         {
                             case "from":
                                 parser.ConsumeSequence(() =>
@@ -143,26 +141,24 @@ public class ClassLoader : ILoader<Class>
                                     var mapper = new FromMapper();
                                     classe.FromMappers.Add(mapper);
 
-                                    parser.ConsumeMapping(() =>
+                                    parser.ConsumeMapping(prop =>
                                     {
-                                        var subSubProp = parser.Consume<Scalar>();
-                                        switch (subSubProp.Value)
+                                        switch (prop.Value)
                                         {
                                             case "comment":
                                                 mapper.Comment = parser.Consume<Scalar>().Value;
                                                 break;
                                             case "params":
-                                                mapper.Reference = new LocatedString(subSubProp);
+                                                mapper.Reference = new LocatedString(prop);
                                                 parser.ConsumeSequence(() =>
                                                 {
                                                     var param = new ClassMappings();
                                                     mapper.Params.Add(param);
 
                                                     Scalar classScalar = null!;
-                                                    parser.ConsumeMapping(() =>
+                                                    parser.ConsumeMapping(prop =>
                                                     {
-                                                        var subSubSubProp = parser.Consume<Scalar>().Value;
-                                                        switch (subSubSubProp)
+                                                        switch (prop.Value)
                                                         {
                                                             case "class":
                                                                 classScalar = parser.Consume<Scalar>();
@@ -178,9 +174,9 @@ public class ClassLoader : ILoader<Class>
                                                                 param.Name = new LocatedString(parser.Consume<Scalar>());
                                                                 break;
                                                             case "mappings":
-                                                                parser.ConsumeMapping(() =>
+                                                                parser.ConsumeMapping(prop =>
                                                                 {
-                                                                    param.MappingReferences.Add(new Reference(parser.Consume<Scalar>()), new Reference(parser.Consume<Scalar>()));
+                                                                    param.MappingReferences.Add(new Reference(prop), new Reference(parser.Consume<Scalar>()));
                                                                 });
                                                                 break;
                                                         }
@@ -200,11 +196,10 @@ public class ClassLoader : ILoader<Class>
                                     var mapper = new ClassMappings { To = true };
                                     classe.ToMappers.Add(mapper);
 
-                                    parser.ConsumeMapping(() =>
+                                    parser.ConsumeMapping(prop =>
                                     {
-                                        var subSubProp = parser.Consume<Scalar>().Value;
                                         Scalar classScalar = null!;
-                                        switch (subSubProp)
+                                        switch (prop.Value)
                                         {
                                             case "class":
                                                 classScalar = parser.Consume<Scalar>();
@@ -217,9 +212,9 @@ public class ClassLoader : ILoader<Class>
                                                 mapper.Comment = parser.Consume<Scalar>().Value;
                                                 break;
                                             case "mappings":
-                                                parser.ConsumeMapping(() =>
+                                                parser.ConsumeMapping(prop =>
                                                 {
-                                                    mapper.MappingReferences.Add(new Reference(parser.Consume<Scalar>()), new Reference(parser.Consume<Scalar>()));
+                                                    mapper.MappingReferences.Add(new Reference(prop), new Reference(parser.Consume<Scalar>()));
                                                 });
                                                 break;
                                         }

--- a/TopModel.Core/Loaders/ConverterLoader.cs
+++ b/TopModel.Core/Loaders/ConverterLoader.cs
@@ -19,12 +19,11 @@ public class ConverterLoader : ILoader<Converter>
     {
         var converter = new Converter();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             _ = parser.TryConsume<Scalar>(out var value);
 
-            switch (prop)
+            switch (prop.Value)
             {
                 case "from":
                     parser.ConsumeSequence(() =>
@@ -41,7 +40,7 @@ public class ConverterLoader : ILoader<Converter>
                     });
                     break;
                 default:
-                    converter.Implementations[prop] = _fileChecker.Deserialize<ConverterImplementation>(parser);
+                    converter.Implementations[prop.Value] = _fileChecker.Deserialize<ConverterImplementation>(parser);
                     break;
             }
         });

--- a/TopModel.Core/Loaders/DataFlowLoader.cs
+++ b/TopModel.Core/Loaders/DataFlowLoader.cs
@@ -12,9 +12,8 @@ public class DataFlowLoader : ILoader<DataFlow>
     {
         var dataFlow = new DataFlow();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>();
             _ = parser.TryConsume<Scalar>(out var value);
 
             switch (prop.Value)
@@ -50,9 +49,8 @@ public class DataFlowLoader : ILoader<DataFlow>
                     parser.ConsumeSequence(() =>
                     {
                         var source = new DataFlowSource { DataFlow = dataFlow };
-                        parser.ConsumeMapping(() =>
+                        parser.ConsumeMapping(prop =>
                         {
-                            var prop = parser.Consume<Scalar>();
                             _ = parser.TryConsume<Scalar>(out var value);
 
                             switch (prop.Value)

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -20,12 +20,11 @@ public class DecoratorLoader : ILoader<Decorator>
     {
         var decorator = new Decorator();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             _ = parser.TryConsume<Scalar>(out var value);
 
-            switch (prop)
+            switch (prop.Value)
             {
                 case "name":
                     decorator.Name = new LocatedString(value);
@@ -46,7 +45,7 @@ public class DecoratorLoader : ILoader<Decorator>
                     });
                     break;
                 default:
-                    decorator.Implementations[prop] = _fileChecker.Deserialize<DecoratorImplementation>(parser);
+                    decorator.Implementations[prop.Value] = _fileChecker.Deserialize<DecoratorImplementation>(parser);
                     break;
             }
         });

--- a/TopModel.Core/Loaders/DomainLoader.cs
+++ b/TopModel.Core/Loaders/DomainLoader.cs
@@ -20,12 +20,11 @@ public class DomainLoader : ILoader<Domain>
     {
         var domain = new Domain();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             parser.TryConsume<Scalar>(out var value);
 
-            switch (prop)
+            switch (prop.Value)
             {
                 case "name":
                     domain.Name = new LocatedString(value);
@@ -46,9 +45,9 @@ public class DomainLoader : ILoader<Domain>
                     domain.BodyParam = value!.Value == "true";
                     break;
                 case "asDomains":
-                    parser.ConsumeMapping(() =>
+                    parser.ConsumeMapping(prop =>
                     {
-                        domain.AsDomainReferences[parser.Consume<Scalar>().Value] = new DomainReference(parser.Consume<Scalar>());
+                        domain.AsDomainReferences[prop.Value] = new DomainReference(parser.Consume<Scalar>());
                     });
                     break;
                 case "mediaType":
@@ -57,11 +56,9 @@ public class DomainLoader : ILoader<Domain>
                 default:
                     var implementation = new DomainImplementation();
 
-                    parser.ConsumeMapping(() =>
+                    parser.ConsumeMapping(prop =>
                     {
-                        var prop = parser.Consume<Scalar>().Value;
-
-                        switch (prop)
+                        switch (prop.Value)
                         {
                             case "type":
                                 implementation.Type = parser.Consume<Scalar>().Value;
@@ -78,7 +75,7 @@ public class DomainLoader : ILoader<Domain>
                         }
                     });
 
-                    domain.Implementations[prop] = implementation;
+                    domain.Implementations[prop.Value] = implementation;
                     break;
             }
         });

--- a/TopModel.Core/Loaders/EndpointLoader.cs
+++ b/TopModel.Core/Loaders/EndpointLoader.cs
@@ -18,12 +18,11 @@ public class EndpointLoader : ILoader<Endpoint>
     {
         var endpoint = new Endpoint();
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             parser.TryConsume<Scalar>(out var value);
 
-            switch (prop)
+            switch (prop.Value)
             {
                 case "tags":
                     parser.ConsumeSequence(() => endpoint.OwnTags.Add(parser.Consume<Scalar>().Value));
@@ -63,9 +62,9 @@ public class EndpointLoader : ILoader<Endpoint>
                     {
                         if (parser.Current is MappingStart)
                         {
-                            parser.ConsumeMapping(() =>
+                            parser.ConsumeMapping(prop =>
                             {
-                                var decorator = new DecoratorReference(parser.Consume<Scalar>());
+                                var decorator = new DecoratorReference(prop);
 
                                 parser.ConsumeSequence(() =>
                                 {

--- a/TopModel.Core/Loaders/FileChecker.cs
+++ b/TopModel.Core/Loaders/FileChecker.cs
@@ -75,11 +75,10 @@ public class FileChecker
         var config = new ModelConfig();
         parser.Consume<StreamStart>();
         parser.Consume<DocumentStart>();
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             parser.TryConsume<Scalar>(out var value);
-            switch (prop)
+            switch (prop.Value)
             {
                 case "app":
                     config.App = value!.Value;
@@ -115,7 +114,7 @@ public class FileChecker
                     });
                     break;
                 default:
-                    config.Generators.Add(prop, _deserializer.Deserialize<IEnumerable<IDictionary<string, object>>>(parser));
+                    config.Generators.Add(prop.Value, _deserializer.Deserialize<IEnumerable<IDictionary<string, object>>>(parser));
                     break;
             }
         });

--- a/TopModel.Core/Loaders/LoaderUtils.cs
+++ b/TopModel.Core/Loaders/LoaderUtils.cs
@@ -1,16 +1,55 @@
-﻿using YamlDotNet.Core;
+﻿using TopModel.Core.FileModel;
+using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
 namespace TopModel.Core.Loaders;
+
 public static class LoaderUtils
 {
-    public static void ConsumeMapping(this Parser parser, Action consumer)
+    public static DomainReference ConsumeDomain(this Parser parser, Scalar? value)
+    {
+        if (parser.Current is MappingStart)
+        {
+            Scalar? name = null;
+            var paramaters = new List<Reference>();
+            parser.ConsumeMapping(prop =>
+            {
+                switch (prop.Value)
+                {
+                    case "name":
+                        name = parser.Consume<Scalar>();
+                        break;
+                    case "parameters":
+                        parser.ConsumeSequence(() => paramaters.Add(new Reference(parser.Consume<Scalar>())));
+                        break;
+                }
+            });
+
+            if (name != null)
+            {
+                var domain = new DomainReference(name);
+                domain.ParameterReferences.AddRange(paramaters);
+                return domain;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+        else
+        {
+            return new DomainReference(value!);
+        }
+    }
+
+    public static void ConsumeMapping(this Parser parser, Action<Scalar> consumer)
     {
         parser.Consume<MappingStart>();
 
         while (parser.Current is not MappingEnd)
         {
-            consumer();
+            var prop = parser.Consume<Scalar>();
+            consumer(prop);
         }
 
         parser.Consume<MappingEnd>();

--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -50,12 +50,11 @@ public class ModelFileLoader
             Path = filePath.ToRelative(),
         };
 
-        parser.ConsumeMapping(() =>
+        parser.ConsumeMapping(prop =>
         {
-            var prop = parser.Consume<Scalar>().Value;
             parser.TryConsume<Scalar>(out var value);
 
-            switch (prop)
+            switch (prop.Value)
             {
                 case "module":
                     file.Namespace = new Namespace { App = _config.App, Module = value!.Value };
@@ -71,11 +70,10 @@ public class ModelFileLoader
                     var scalar = parser.Consume<Scalar>();
                     if (scalar.Value == "endpoints")
                     {
-                        parser.ConsumeMapping(() =>
+                        parser.ConsumeMapping(prop =>
                         {
-                            var prop = parser.Consume<Scalar>().Value;
                             parser.TryConsume<Scalar>(out var value);
-                            switch (prop)
+                            switch (prop.Value)
                             {
                                 case "fileName":
                                     file.Options.Endpoints.FileName = value!.Value;

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -25,34 +25,34 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                 while (parser.Current is not MappingEnd)
                 {
                     var prop = parser.Consume<Scalar>().Value;
-                    var value = parser.Consume<Scalar>();
+                    _ = parser.TryConsume<Scalar>(out var value);
 
                     switch (prop)
                     {
                         case "name":
-                            rp.Name = value.Value;
+                            rp.Name = value!.Value;
                             rp.Location = new Reference(value);
                             break;
                         case "label":
-                            rp.Label = value.Value;
+                            rp.Label = value!.Value;
                             break;
                         case "primaryKey":
-                            rp.PrimaryKey = value.Value == "true";
+                            rp.PrimaryKey = value!.Value == "true";
                             break;
                         case "required":
-                            rp.Required = value.Value == "true";
+                            rp.Required = value!.Value == "true";
                             break;
                         case "readonly":
-                            rp.Readonly = value.Value == "true";
+                            rp.Readonly = value!.Value == "true";
                             break;
                         case "domain":
-                            rp.DomainReference = new DomainReference(value);
+                            rp.DomainReference = parser.ConsumeDomain(value);
                             break;
                         case "defaultValue":
-                            rp.DefaultValue = value.Value;
+                            rp.DefaultValue = value!.Value;
                             break;
                         case "comment":
-                            rp.Comment = value.Value;
+                            rp.Comment = value!.Value;
                             break;
                         case "trigram":
                             rp.Trigram = new LocatedString(value);
@@ -148,24 +148,24 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                 while (parser.Current is not MappingEnd)
                 {
                     var prop = parser.Consume<Scalar>().Value;
-                    var value = parser.Consume<Scalar>();
+                    _ = parser.TryConsume<Scalar>(out var value);
 
                     switch (prop)
                     {
                         case "composition":
-                            cp.Reference = new ClassReference(value);
+                            cp.Reference = new ClassReference(value!);
                             break;
                         case "name":
-                            cp.Name = value.Value;
+                            cp.Name = value!.Value;
                             break;
                         case "domain":
-                            cp.DomainReference = new DomainReference(value);
+                            cp.DomainReference = parser.ConsumeDomain(value);
                             break;
                         case "comment":
-                            cp.Comment = value.Value;
+                            cp.Comment = value!.Value;
                             break;
                         case "readonly":
-                            cp.Readonly = value.Value == "true";
+                            cp.Readonly = value!.Value == "true";
                             break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");
@@ -231,42 +231,42 @@ public class PropertyLoader : ILoader<IEnumerable<IProperty>>
                 while (parser.Current is not MappingEnd)
                 {
                     var prop = parser.Consume<Scalar>().Value;
-                    var value = parser.Consume<Scalar>();
+                    _ = parser.TryConsume<Scalar>(out var value);
 
                     switch (prop)
                     {
                         case "prefix":
-                            alp.Prefix = value.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Prefix = value!.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "suffix":
-                            alp.Suffix = value.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Suffix = value!.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "label":
-                            alp.Label = value.Value;
+                            alp.Label = value!.Value;
                             break;
                         case "domain":
-                            alp.DomainReference = new DomainReference(value);
+                            alp.DomainReference = parser.ConsumeDomain(value);
                             break;
                         case "required":
-                            alp.Required = value.Value == "true";
+                            alp.Required = value!.Value == "true";
                             break;
                         case "readonly":
-                            alp.Readonly = value.Value == "true";
+                            alp.Readonly = value!.Value == "true";
                             break;
                         case "comment":
-                            alp.Comment = value.Value;
+                            alp.Comment = value!.Value;
                             break;
                         case "as":
-                            alp.As = value.Value;
+                            alp.As = value!.Value;
                             break;
                         case "name":
-                            alp.Name = value.Value;
+                            alp.Name = value!.Value;
                             break;
                         case "trigram":
                             alp.Trigram = new LocatedString(value);
                             break;
                         case "defaultValue":
-                            alp.DefaultValue = value.Value;
+                            alp.DefaultValue = value!.Value;
                             break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -8,6 +8,7 @@ public class AliasProperty : IFieldProperty
     private string? _comment;
     private string? _defaultValue;
     private Domain? _domain;
+    private string[]? _domainParameters;
     private string? _label;
     private string? _name;
 
@@ -102,6 +103,12 @@ public class AliasProperty : IFieldProperty
     }
 #nullable enable
 
+    public string[] DomainParameters
+    {
+        get => _domainParameters ?? _property?.DomainParameters ?? Array.Empty<string>();
+        set => _domainParameters = value;
+    }
+
     public DomainReference? DomainReference { get; set; }
 
     public string Comment
@@ -155,7 +162,8 @@ public class AliasProperty : IFieldProperty
             Suffix = Suffix,
             Name = _name!,
             Trigram = Trigram,
-            UseLegacyRoleName = UseLegacyRoleName
+            UseLegacyRoleName = UseLegacyRoleName,
+            DomainParameters = _domainParameters!
         };
 
         if (_domain != null)
@@ -202,7 +210,8 @@ public class AliasProperty : IFieldProperty
             Label = _label,
             As = As,
             OriginalAliasProperty = this,
-            UseLegacyRoleName = UseLegacyRoleName
+            UseLegacyRoleName = UseLegacyRoleName,
+            DomainParameters = _domainParameters!
         };
 
         if (_domain != null)

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -133,6 +133,8 @@ public class AssociationProperty : IFieldProperty
 
     public Domain Domain => Type.IsToMany() && (Property?.Domain?.AsDomains.TryGetValue(As, out var ld) ?? false) ? ld : Property?.Domain!;
 
+    public string[] DomainParameters => Property?.DomainParameters ?? Array.Empty<string>();
+
     public bool PrimaryKey { get; set; }
 
     public Reference? PropertyReference { get; set; }

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -20,6 +20,8 @@ public class CompositionProperty : IProperty
 
     public Domain Domain { get; set; }
 
+    public string[] DomainParameters { get; set; } = Array.Empty<string>();
+
     public string Comment { get; set; }
 
     public bool Readonly { get; set; }

--- a/TopModel.Core/Model/IProperty.cs
+++ b/TopModel.Core/Model/IProperty.cs
@@ -18,6 +18,8 @@ public interface IProperty
 
     Domain Domain { get; }
 
+    string[] DomainParameters { get; }
+
     string Comment { get; }
 
     bool Readonly { get; set; }

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -31,6 +31,8 @@ public class RegularProperty : IFieldProperty
 #nullable disable
     public Domain Domain { get; set; }
 
+    public string[] DomainParameters { get; set; } = Array.Empty<string>();
+
     public string Comment { get; set; }
 
     public Class Class { get; set; }

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -71,7 +71,7 @@ public static class ModelExtensions
                 }, File: p.GetFile());
             })
             .Concat(modelStore.Converters.SelectMany(c => c.DomainsFromReferences.Union(c.DomainsToReferences).Select(d => (Reference: d, File: c.ModelFile))).Where(r => r.Reference.ReferenceName == domain.Name))
-            .Concat(modelStore.Domains.Values.SelectMany(d => d.AsDomainReferences.Values.Select(adr => (Reference: adr, File: d.GetFile()))))
+            .Concat(modelStore.Domains.Values.SelectMany(d => d.AsDomainReferences.Values.Select(adr => (Reference: adr, File: d.GetFile()))).Where(r => r.Reference.ReferenceName == domain.Name))
             .Where(l => l.Reference is not null)
             .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
     }

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -595,6 +595,7 @@ public class ModelStore
                     }
 
                     rp.Domain = domain;
+                    rp.DomainParameters = rp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     break;
 
                 case AssociationProperty ap:
@@ -637,6 +638,7 @@ public class ModelStore
                         }
 
                         cp.Domain = cpDomain;
+                        cp.DomainParameters = cp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     }
 
                     break;
@@ -649,6 +651,7 @@ public class ModelStore
                     }
 
                     alp.Domain = aliasDomain;
+                    alp.DomainParameters = alp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     break;
             }
         }

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -16,6 +16,33 @@
         "Api_Dto_Persisted"
       ]
     },
+    "domain": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Domaine a utiliser pour le type de composition (si ce n'est pas une composition simple)."
+        },
+        {
+          "type": "object",
+          "description": "Domaine a utiliser pour le type de composition (si ce n'est pas une composition simple).",
+          "required": [ "name" ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Nom du domaine."
+            },
+            "parameters": {
+              "type": "array",
+              "description": "Paramètres du domaine.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
     "property": {
       "oneOf": [
         {
@@ -49,8 +76,7 @@
               "description": "Une propriété 'readonly' ne pourra pas être renseignée par un mapper et aucun setter ne sera généré si la classe contenant la propriété est abstraite."
             },
             "domain": {
-              "type": "string",
-              "description": "Le domaine lié à la propriété. Doit référencer un domaine défini dans le fichier de domaines."
+              "$ref": "#/definitions/domain"
             },
             "trigram": {
               "type": "string",
@@ -258,8 +284,7 @@
               ]
             },
             "domain": {
-              "type": "string",
-              "description": "Surcharge le domaine de la propriété aliasée."
+              "$ref": "#/definitions/domain"
             },
             "label": {
               "type": "string",
@@ -305,8 +330,7 @@
               "description": "Nom de la propriété."
             },
             "domain": {
-              "type": "string",
-              "description": "Domaine a utiliser pour le type de composition (si ce n'est pas une composition simple)."
+              "$ref": "#/definitions/domain"
             },
             "comment": {
               "type": "string",

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -46,6 +46,7 @@ public class CompletionHandler : CompletionHandlerBase
 
             if (currentLine.Contains("domain: ")
                 || GetParentObject(request) == "asDomains" && currentLine[..reqChar].Contains(':')
+                || GetParentObject(request) == "domain" && GetRootObject(request) != "domain" && currentLine.TrimStart().StartsWith("name:")
                 || currentLine.TrimStart().StartsWith("-")
                     && GetRootObject(request) == "converter"
                     && (text.ElementAtOrDefault(request.Position.Line - 1)?.Trim() == "to:"

--- a/docs/model/decorators.md
+++ b/docs/model/decorators.md
@@ -200,7 +200,7 @@ Il est également possible de passer des paramètres lors de l'instanciation d'u
 class:
   name: MyClass
   decorators:
-    - MyDecorator: [Param1, Param2]
+    - MyDecorator: ["Param1", "Param2"]
     - OtherDecorator
 ```
 
@@ -211,7 +211,7 @@ decorator:
   name: MyDecorator
   csharp:
     annotations:
-      - MyAnnotation("{$0}", "{$1}"))
+      - text: MyAnnotation("{$0}", "{$1}"))
 ```
 
 Génèrera l'annotation `[MyAnnotation("Param1", "Param2")]` sur `MyClass`. Si les paramètres ne sont pas renseignés, les variables `$0`, `$1` ne seront simplement pas remplacées. Et bien entendu, rien ne se passera si on passe des paramètres alors que le décorateur ne les utilise pas.

--- a/docs/model/domains.md
+++ b/docs/model/domains.md
@@ -134,6 +134,30 @@ Le tout dans les propriétés d'implémentation :
 
 Les templates des domaines des propriétés sont également valorisés. Ces variables s'ajoutent à la variable `{T}` utilisée dans les types génériques.
 
+### Paramètres
+
+Il est également possible de passer des paramètres lorsqu'on associe un domaineà une propriété, en passant un objet `{name, parameters}` au lieu du nom du domaine :
+
+```yaml
+properties:
+  - name: MyProperty
+    domain:
+      name: DO_CODE
+      parameters: ["Param1", "Param2"]
+```
+
+Les paramètres seront utilisés dans la résolution des variables `$0`, `$1`... Par exemple :
+
+```yaml
+domain:
+  name: DO_CODE
+  csharp:
+    annotations:
+      - text: MyAnnotation("{$0}", "{$1}"))
+```
+
+Génèrera l'annotation `[MyAnnotation("Param1", "Param2")]` sur la propriété `MyProperty`. Si les paramètres ne sont pas renseignés, les variables `$0`, `$1` ne seront simplement pas remplacées. Et bien entendu, rien ne se passera si on passe des paramètres alors que le domaine ne les utilise pas.
+
 ### Transformations
 
 Il est possible que la variable que vous utilisez dans votre template ne corresponde pas tout à fait à votre besoin. TopModel gère l'ajout de `transformateurs` sur les templates. Vous pouvez ajouter un `transformateur` après le nom de la variable que vous référencez, précédé de `:`. Le code généré tiendra compte de cette transformation.


### PR DESCRIPTION
Fix #285 

Il est désormais possible de passer des paramètres à un domaine, de la même façon qu'il est déjà possible de le faire pour les décorateurs. Ces paramètres pourront être utilisés dans les templates en plus des autres propriétés déjà disponibles via les variables `{$0}`, `{$1}`...

Pour passer des paramètres, il faut renseigner un domaine de la façon suivante :

```yaml
domain:
  name: DO_CODE
  parameters: ["Param1", "Param2"]
```

au lieu de `domain: DO_CODE`. La forme actuelle est bien évidemment toujours supportée.