### PR TITLE
|tmdgen] Fixes / features divers OpenApiGenerator

### DIFF
--- a/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
@@ -136,10 +136,10 @@ public abstract class DatabaseTmdGenerator : ModelGenerator, IDisposable
 
     private TmdProperty ColumnToProperty(TmdClass classe, DbColumn column, string trigram, ConstraintKey? primaryKeyConstraint, ConstraintKey? foreignConstraint)
     {
-        var domain = TmdGenUtils.GetDomainString(_config.Domains, column.ColumnName, column.Scale, column.Precision);
+        var domain = TmdGenUtils.GetDomainString(_config.Domains, name: column.ColumnName, scale: column.Scale, precision: column.Precision);
         if (domain == column.ColumnName)
         {
-            domain = TmdGenUtils.GetDomainString(_config.Domains, column.DataType, column.Scale, column.Precision);
+            domain = TmdGenUtils.GetDomainString(_config.Domains, type: column.DataType, scale: column.Scale, precision: column.Precision);
         }
 
         var columnName = column.ColumnName;

--- a/TopModel.ModelGenerator/OpenApi/OpenApiUtils.cs
+++ b/TopModel.ModelGenerator/OpenApi/OpenApiUtils.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.OpenApi.Models;
+
+namespace TopModel.ModelGenerator.OpenApi;
+
+public static class OpenApiUtils
+{
+    public static string Format(this string? description)
+    {
+        if (description == null)
+        {
+            return string.Empty;
+        }
+
+        if (description.Contains('"') || description.Contains('\n') || description.Contains(':'))
+        {
+            var lines = description.ReplaceLineEndings().Split(Environment.NewLine);
+            if (string.IsNullOrWhiteSpace(lines.Last()))
+            {
+                lines = lines.SkipLast(1).ToArray();
+            }
+
+            return $"|{Environment.NewLine}{string.Join(Environment.NewLine, lines.Select(line => $"        {line}"))}";
+        }
+        else
+        {
+            return description;
+        }
+    }
+
+    public static string GetDomain(this OpenApiConfig config, string name, OpenApiSchema schema)
+    {
+        var resolvedDomain = TmdGenUtils.GetDomainString(config.Domains, name: name);
+        if (resolvedDomain == name)
+        {
+            return GetDomainSchema(config, schema);
+        }
+
+        return resolvedDomain;
+    }
+
+    public static IDictionary<string, OpenApiSchema> GetProperties(this OpenApiSchema schema)
+    {
+        if (schema.Type == "array")
+        {
+            return schema.Items.GetProperties();
+        }
+
+        return schema.Properties
+            .Concat(schema.AllOf.Where(a => a.Type == "object").SelectMany(a => a.Properties))
+            .ToDictionary(a => a.Key, a => a.Value);
+    }
+
+    public static OpenApiSchema? GetRequestBodySchema(this OpenApiOperation operation)
+    {
+        return operation.RequestBody?.Content.First().Value.Schema;
+    }
+
+    public static IDictionary<string, OpenApiSchema> GetSchemas(this OpenApiDocument model, HashSet<string>? references = null)
+    {
+        return model.Components.Schemas
+            .Where(s =>
+                s.Value.Type == "object"
+                || s.Value.AllOf.Any() && s.Value.AllOf.All(a => a.Type == "object" || a.Reference != null)
+                || s.Value.Type == "array" && s.Value.Items.Type == "object")
+            .Where(s => references == null || references.Contains(s.Key))
+            .ToDictionary(a => a.Key, a => a.Value);
+    }
+
+    public static string Unplurialize(this string name)
+    {
+        return name.EndsWith("ies") ? $"{name[..^3]}y" : name.TrimEnd('s');
+    }
+
+    private static string GetDomainCore(this OpenApiSchema schema)
+    {
+        var length = schema.MaxLength != null ? $"{schema.MaxLength}" : string.Empty;
+
+        if (schema.Format != null)
+        {
+            return schema.Format + length;
+        }
+        else if (schema.Type == "array")
+        {
+            return $"{GetDomainCore(schema.Items)}-array";
+        }
+        else if (schema.Type == "object" && schema.AdditionalProperties != null)
+        {
+            return $"{GetDomainCore(schema.AdditionalProperties)}-map";
+        }
+
+        return schema.Type + length;
+    }
+
+    private static string GetDomainSchema(this OpenApiConfig config, OpenApiSchema schema)
+    {
+        var domain = GetDomainCore(schema);
+        return TmdGenUtils.GetDomainString(config.Domains, type: domain);
+    }
+}

--- a/TopModel.ModelGenerator/TmdGenUtils.cs
+++ b/TopModel.ModelGenerator/TmdGenUtils.cs
@@ -4,38 +4,38 @@ namespace TopModel.ModelGenerator;
 
 public static class TmdGenUtils
 {
-    public static string GetDomainString(IList<DomainMapping> domains, string nameOrType, string? scale = null, string? precision = null)
+    public static string GetDomainString(IList<DomainMapping> domains, string? type = null, string? name = null, string? scale = null, string? precision = null)
     {
         return domains.Select(d =>
         {
             var score = 0;
-            if (d.Name != null)
+            if (d.Name != null && name != null)
             {
                 if (d.Name.StartsWith('/'))
                 {
-                    if (Regex.IsMatch(nameOrType, d.Name[1..^1]))
+                    if (Regex.IsMatch(name, d.Name[1..^1]))
                     {
                         score += 10000;
                     }
                 }
                 else
                 {
-                    if (nameOrType == d.Name)
+                    if (name == d.Name)
                     {
                         score += 100000;
                     }
                 }
             }
-            else if (d.Type != null)
+            else if (d.Type != null && type != null)
             {
                 if (d.Type.StartsWith('/'))
                 {
-                    if (Regex.IsMatch(nameOrType, d.Type[1..^1]))
+                    if (Regex.IsMatch(type, d.Type[1..^1]))
                     {
                         score += 100;
                     }
                 }
-                else if (nameOrType == d.Type)
+                else if (type == d.Type)
                 {
                     score += 1000;
                 }
@@ -52,6 +52,6 @@ public static class TmdGenUtils
             }
 
             return (score, d.Domain);
-        }).Where(t => t.score >= 10).OrderByDescending(t => t.score).FirstOrDefault().Domain ?? nameOrType;
+        }).Where(t => t.score >= 10).OrderByDescending(t => t.score).FirstOrDefault().Domain ?? name ?? type ?? string.Empty;
     }
 }

--- a/samples/generators/open-api/Petstore/Model.tmd
+++ b/samples/generators/open-api/Petstore/Model.tmd
@@ -17,17 +17,17 @@ class:
     - name: code
       domain: DO_ENTIER
       required: true
-      comment: "code"
+      comment: code
 
     - name: type
       domain: DO_LIBELLE
       required: true
-      comment: "type"
+      comment: type
 
     - name: message
       domain: DO_LIBELLE
       required: true
-      comment: "message"
+      comment: message
 ---
 class:
   name: Category
@@ -38,12 +38,12 @@ class:
     - name: id
       domain: DO_ID
       required: true
-      comment: "id"
+      comment: id
 
     - name: name
       domain: DO_LIBELLE
       required: true
-      comment: "name"
+      comment: name
 ---
 class:
   name: Order
@@ -54,22 +54,22 @@ class:
     - name: id
       domain: DO_ID
       required: true
-      comment: "id"
+      comment: id
 
     - name: petId
       domain: DO_ID
       required: true
-      comment: "petId"
+      comment: petId
 
     - name: quantity
       domain: DO_ENTIER
       required: true
-      comment: "quantity"
+      comment: quantity
 
     - name: shipDate
       domain: DO_DATE_TIME
       required: true
-      comment: "shipDate"
+      comment: shipDate
 
     - alias:
         class: OrderStatus
@@ -77,7 +77,7 @@ class:
     - name: complete
       domain: DO_BOOLEAN
       required: true
-      comment: "complete"
+      comment: complete
 ---
 class:
   name: OrderStatus
@@ -88,7 +88,7 @@ class:
     - name: status
       domain: DO_LIBELLE
       required: true
-      comment: "Order Status"
+      comment: Order Status
 
   values:
     value0: { status: placed }
@@ -104,26 +104,26 @@ class:
     - name: id
       domain: DO_ID
       required: true
-      comment: "id"
+      comment: id
 
     - name: name
       domain: DO_LIBELLE
       required: true
-      comment: "name"
+      comment: name
 
     - composition: Category
       name: category
-      comment: "category"
+      comment: category
 
     - name: photoUrls
       domain: DO_LIBELLE
       required: true
-      comment: "photoUrls"
+      comment: photoUrls
 
     - composition: Tag
       name: tags
       domain: DO_LIST
-      comment: "tags"
+      comment: tags
 
     - alias:
         class: PetStatus
@@ -137,7 +137,7 @@ class:
     - name: status
       domain: DO_LIBELLE
       required: true
-      comment: "pet status in the store"
+      comment: pet status in the store
 
   values:
     value0: { status: available }
@@ -153,12 +153,12 @@ class:
     - name: id
       domain: DO_ID
       required: true
-      comment: "id"
+      comment: id
 
     - name: name
       domain: DO_LIBELLE
       required: true
-      comment: "name"
+      comment: name
 ---
 class:
   name: User
@@ -169,39 +169,39 @@ class:
     - name: id
       domain: DO_ID
       required: true
-      comment: "id"
+      comment: id
 
     - name: username
       domain: DO_LIBELLE
       required: true
-      comment: "username"
+      comment: username
 
     - name: firstName
       domain: DO_LIBELLE
       required: true
-      comment: "firstName"
+      comment: firstName
 
     - name: lastName
       domain: DO_LIBELLE
       required: true
-      comment: "lastName"
+      comment: lastName
 
     - name: email
       domain: DO_LIBELLE
       required: true
-      comment: "email"
+      comment: email
 
     - name: password
       domain: DO_LIBELLE
       required: true
-      comment: "password"
+      comment: password
 
     - name: phone
       domain: DO_LIBELLE
       required: true
-      comment: "phone"
+      comment: phone
 
     - name: userStatus
       domain: DO_ENTIER
       required: true
-      comment: "User Status"
+      comment: User Status

--- a/samples/generators/open-api/Petstore/Pet.tmd
+++ b/samples/generators/open-api/Petstore/Pet.tmd
@@ -14,125 +14,125 @@ endpoint:
   name: addPet
   method: POST
   route: pet
-  description: "Add a new pet to the store"
+  description: Add a new pet to the store
   preservePropertyCasing: true
   params:
     - composition: Pet
       name: body
-      comment: "body"
+      comment: body
   returns:
     composition: Pet
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: deletePet
   method: DELETE
   route: pet/{petId}
-  description: "Deletes a pet"
+  description: Deletes a pet
   preservePropertyCasing: true
   params:
     - name: petId
       domain: DO_ID
-      comment: "Pet id to delete"
+      comment: Pet id to delete
 ---
 endpoint:
   name: findPetsByStatus
   method: GET
   route: pet/findByStatus
-  description: "Finds Pets by status"
+  description: Finds Pets by status
   preservePropertyCasing: true
   params:
     - name: status
       domain: DO_LIBELLE
-      comment: "Status values that need to be considered for filter"
+      comment: Status values that need to be considered for filter
   returns:
     composition: Pet
     name: Result
     domain: DO_LIST
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: findPetsByTags
   method: GET
   route: pet/findByTags
-  description: "Finds Pets by tags"
+  description: Finds Pets by tags
   preservePropertyCasing: true
   params:
     - name: tags
       domain: DO_LIBELLE
-      comment: "Tags to filter by"
+      comment: Tags to filter by
   returns:
     composition: Pet
     name: Result
     domain: DO_LIST
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: getPetById
   method: GET
   route: pet/{petId}
-  description: "Find pet by ID"
+  description: Find pet by ID
   preservePropertyCasing: true
   params:
     - name: petId
       domain: DO_ID
-      comment: "ID of pet to return"
+      comment: ID of pet to return
   returns:
     composition: Pet
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: updatePet
   method: PUT
   route: pet
-  description: "Update an existing pet"
+  description: Update an existing pet
   preservePropertyCasing: true
   params:
     - composition: Pet
       name: body
-      comment: "body"
+      comment: body
   returns:
     composition: Pet
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: updatePetWithForm
   method: POST
   route: pet/{petId}
-  description: "Updates a pet in the store with form data"
+  description: Updates a pet in the store with form data
   preservePropertyCasing: true
   params:
     - name: petId
       domain: DO_ID
-      comment: "ID of pet that needs to be updated"
+      comment: ID of pet that needs to be updated
     - name: name
       domain: DO_LIBELLE
-      comment: "Name of pet that needs to be updated"
+      comment: Name of pet that needs to be updated
     - name: status
       domain: DO_LIBELLE
-      comment: "Status of pet that needs to be updated"
+      comment: Status of pet that needs to be updated
 ---
 endpoint:
   name: uploadFile
   method: POST
   route: pet/{petId}/uploadImage
-  description: "uploads an image"
+  description: uploads an image
   preservePropertyCasing: true
   params:
     - name: body
       domain: DO_FILE
       required: true
-      comment: "body"
+      comment: body
     - name: petId
       domain: DO_ID
-      comment: "ID of pet to update"
+      comment: ID of pet to update
     - name: additionalMetadata
       domain: DO_LIBELLE
-      comment: "Additional Metadata"
+      comment: Additional Metadata
   returns:
     composition: ApiResponse
     name: Result
-    comment: "Result"
+    comment: Result

--- a/samples/generators/open-api/Petstore/Store.tmd
+++ b/samples/generators/open-api/Petstore/Store.tmd
@@ -14,51 +14,51 @@ endpoint:
   name: deleteOrder
   method: DELETE
   route: store/order/{orderId}
-  description: "Delete purchase order by ID"
+  description: Delete purchase order by ID
   preservePropertyCasing: true
   params:
     - name: orderId
       domain: DO_ID
-      comment: "ID of the order that needs to be deleted"
+      comment: ID of the order that needs to be deleted
 ---
 endpoint:
   name: getInventory
   method: GET
   route: store/inventory
-  description: "Returns pet inventories by status"
+  description: Returns pet inventories by status
   preservePropertyCasing: true
   returns:
     name: Result
     domain: DO_ENTIER_MAP
     required: true
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: getOrderById
   method: GET
   route: store/order/{orderId}
-  description: "Find purchase order by ID"
+  description: Find purchase order by ID
   preservePropertyCasing: true
   params:
     - name: orderId
       domain: DO_ID
-      comment: "ID of order that needs to be fetched"
+      comment: ID of order that needs to be fetched
   returns:
     composition: Order
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: placeOrder
   method: POST
   route: store/order
-  description: "Place an order for a pet"
+  description: Place an order for a pet
   preservePropertyCasing: true
   params:
     - composition: Order
       name: body
-      comment: "body"
+      comment: body
   returns:
     composition: Order
     name: Result
-    comment: "Result"
+    comment: Result

--- a/samples/generators/open-api/Petstore/User.tmd
+++ b/samples/generators/open-api/Petstore/User.tmd
@@ -14,91 +14,91 @@ endpoint:
   name: createUser
   method: POST
   route: user
-  description: "Create user"
+  description: Create user
   preservePropertyCasing: true
   params:
     - composition: User
       name: body
-      comment: "body"
+      comment: body
 ---
 endpoint:
   name: createUsersWithListInput
   method: POST
   route: user/createWithList
-  description: "Creates list of users with given input array"
+  description: Creates list of users with given input array
   preservePropertyCasing: true
   params:
     - composition: User
       name: body
       domain: DO_LIST
-      comment: "body"
+      comment: body
   returns:
     composition: User
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: deleteUser
   method: DELETE
   route: user/{username}
-  description: "Delete user"
+  description: Delete user
   preservePropertyCasing: true
   params:
     - name: username
       domain: DO_LIBELLE
-      comment: "The name that needs to be deleted"
+      comment: The name that needs to be deleted
 ---
 endpoint:
   name: getUserByName
   method: GET
   route: user/{username}
-  description: "Get user by user name"
+  description: Get user by user name
   preservePropertyCasing: true
   params:
     - name: username
       domain: DO_LIBELLE
-      comment: "The name that needs to be fetched. Use user1 for testing. "
+      comment: The name that needs to be fetched. Use user1 for testing. 
   returns:
     composition: User
     name: Result
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: loginUser
   method: GET
   route: user/login
-  description: "Logs user into the system"
+  description: Logs user into the system
   preservePropertyCasing: true
   params:
     - name: password
       domain: DO_LIBELLE
-      comment: "The password for login in clear text"
+      comment: The password for login in clear text
     - name: username
       domain: DO_LIBELLE
-      comment: "The user name for login"
+      comment: The user name for login
   returns:
     name: Result
     domain: DO_LIBELLE
     required: true
-    comment: "Result"
+    comment: Result
 ---
 endpoint:
   name: logoutUser
   method: GET
   route: user/logout
-  description: "Logs out current logged in user session"
+  description: Logs out current logged in user session
   preservePropertyCasing: true
 ---
 endpoint:
   name: updateUser
   method: PUT
   route: user/{username}
-  description: "Update user"
+  description: Update user
   preservePropertyCasing: true
   params:
     - composition: User
       name: body
-      comment: "body"
+      comment: body
     - name: username
       domain: DO_LIBELLE
-      comment: "name that need to be deleted"
+      comment: name that need to be deleted


### PR DESCRIPTION
- Pour les mappings de domaines, vérifie `name` sur le nom de la propriété et `type` sur son type uniquement, au lieu de mélanger les deux (concerne aussi pour le générateur depuis BDD)
- Gestion des schémas  `{"type": "array", "items": {"type": "object", "properties": "...."}}` en générant un type du nom du schéma au singulier (vite fait ^^) avec lse propriétés du type de `"items"`, avec toutes les compositions dessus générées avec un domaine `"list"`.
- Gestions des schémas `{"allOf": [{"type": "object"}, {"$ref": "..."}]}` en fusionnant toutes les propriétés des types (c'est ce que fait Swagger UI d'ailleurs).
- Fix génération des commentaires en mettant un `|` et un retour à la ligne dès qu'il y a un caractère problématique dedans (au lieu de dire "c'est bon je mets des guillemets partout ça va passer")