### PR TITLE
[Core] Dataflows : Ajouter la possibilité de définir des Hooks #299

### DIFF
--- a/TopModel.Core/Loaders/DataFlowLoader.cs
+++ b/TopModel.Core/Loaders/DataFlowLoader.cs
@@ -36,14 +36,28 @@ public class DataFlowLoader : ILoader<DataFlow>
                         dataFlow.DependsOnReference.Add(new DataFlowReference(parser.Consume<Scalar>()));
                     });
                     break;
-                case "postQuery":
-                    dataFlow.PostQuery = value!.Value == "true";
-                    break;
-                case "preQuery":
-                    dataFlow.PreQuery = value!.Value == "true";
-                    break;
                 case "activeProperty":
                     dataFlow.ActivePropertyReference = new Reference(value!);
+                    break;
+                case "hooks":
+                    parser.ConsumeSequence(() =>
+                    {
+                        string value = parser.Consume<Scalar>().Value;
+                        FlowHook? hook = null;
+                        switch (value)
+                        {
+                            case "beforeFLow": hook = FlowHook.BeforeFLow; break;
+                            case "afterSource": hook = FlowHook.AfterSource; break;
+                            case "map": hook = FlowHook.Map; break;
+                            case "beforeTarget": hook = FlowHook.BeforeTarget; break;
+                            case "afterFLow": hook = FlowHook.AfterFLow; break;
+                        }
+
+                        if (hook != null)
+                        {
+                            dataFlow.Hooks.Add((FlowHook)hook);
+                        }
+                    });
                     break;
                 case "sources":
                     parser.ConsumeSequence(() =>

--- a/TopModel.Core/Loaders/DataFlowLoader.cs
+++ b/TopModel.Core/Loaders/DataFlowLoader.cs
@@ -46,11 +46,11 @@ public class DataFlowLoader : ILoader<DataFlow>
                         FlowHook? hook = null;
                         switch (value)
                         {
-                            case "beforeFLow": hook = FlowHook.BeforeFLow; break;
+                            case "beforeFLow": hook = FlowHook.BeforeFlow; break;
                             case "afterSource": hook = FlowHook.AfterSource; break;
                             case "map": hook = FlowHook.Map; break;
                             case "beforeTarget": hook = FlowHook.BeforeTarget; break;
-                            case "afterFLow": hook = FlowHook.AfterFLow; break;
+                            case "afterFLow": hook = FlowHook.AfterFlow; break;
                         }
 
                         if (hook != null)

--- a/TopModel.Core/Model/DataFlow.cs
+++ b/TopModel.Core/Model/DataFlow.cs
@@ -24,9 +24,7 @@ public class DataFlow
 
     public List<DataFlowReference> DependsOnReference { get; set; } = new();
 
-    public bool PostQuery { get; set; }
-
-    public bool PreQuery { get; set; }
+    public List<FlowHook> Hooks { get; set; } = new();
 
     public IFieldProperty? ActiveProperty { get; set; }
 

--- a/TopModel.Core/Model/FlowHook.cs
+++ b/TopModel.Core/Model/FlowHook.cs
@@ -1,0 +1,10 @@
+namespace TopModel.Core;
+
+public enum FlowHook
+{
+    BeforeFLow,
+    AfterSource,
+    Map,
+    BeforeTarget,
+    AfterFLow,
+}

--- a/TopModel.Core/Model/FlowHook.cs
+++ b/TopModel.Core/Model/FlowHook.cs
@@ -1,10 +1,10 @@
-namespace TopModel.Core;
+﻿namespace TopModel.Core;
 
 public enum FlowHook
 {
-    BeforeFLow,
+    BeforeFlow,
     AfterSource,
     Map,
     BeforeTarget,
-    AfterFLow,
+    AfterFlow,
 }

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -25,7 +25,9 @@
         {
           "type": "object",
           "description": "Domaine a utiliser pour le type de composition (si ce n'est pas une composition simple).",
-          "required": [ "name" ],
+          "required": [
+            "name"
+          ],
           "additionalProperties": false,
           "properties": {
             "name": {
@@ -353,7 +355,9 @@
         {
           "type": "object",
           "description": "Template de valeur à utiliser, avec des imports supplémentaires si besoin.",
-          "required": [ "value" ],
+          "required": [
+            "value"
+          ],
           "additionalProperties": false,
           "properties": {
             "value": {
@@ -1053,13 +1057,20 @@
                 "description": "Flux de données à exécuter avant celui-ci."
               }
             },
-            "postQuery": {
-              "type": "boolean",
-              "description": "Si le flux de données doit définir une requête à jouer après son exécution."
-            },
-            "preQuery": {
-              "type": "boolean",
-              "description": "Si le flux de données doit définir une requête à jouer avant son exécution."
+            "hooks": {
+              "type": "array",
+              "description": "Hooks à ajouter au flow",
+              "items": {
+                "type": "string",
+                "description": "Nom du hook",
+                "enum": [
+                  "beforeFLow",
+                  "afterSource",
+                  "map",
+                  "beforeTarget",
+                  "afterFLow"
+                ]
+              }
             },
             "activeProperty": {
               "type": "string",

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -1064,11 +1064,11 @@
                 "type": "string",
                 "description": "Nom du hook",
                 "enum": [
-                  "beforeFLow",
+                  "beforeFlow",
                   "afterSource",
                   "map",
                   "beforeTarget",
-                  "afterFLow"
+                  "afterFlow"
                 ]
               }
             },

--- a/TopModel.Generator.Csharp/DataFlowGenerator.cs
+++ b/TopModel.Generator.Csharp/DataFlowGenerator.cs
@@ -118,13 +118,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             w.WriteLine();
-            w.WriteLine(1, $"protected override bool PostQuery => true;");
+            w.WriteLine(1, $"protected override bool PostFlow => true;");
         }
 
         if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             w.WriteLine();
-            w.WriteLine(1, $"protected override bool PreQuery => true;");
+            w.WriteLine(1, $"protected override bool PreFlow => true;");
         }
 
         w.WriteLine();
@@ -268,13 +268,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             w.WriteLine();
-            w.WriteLine(1, $"protected override partial Task<int> ExecutePostQuery(IConnection connection);");
+            w.WriteLine(1, $"protected override partial Task<int> ExecutePostFlow(IConnection connection);");
         }
 
         if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             w.WriteLine();
-            w.WriteLine(1, $"protected override partial Task<int> ExecutePreQuery(IConnection connection);");
+            w.WriteLine(1, $"protected override partial Task<int> ExecutePreFlow(IConnection connection);");
         }
 
         foreach (var source in dataFlow.Sources.OrderBy(s => s.Source))
@@ -313,7 +313,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
 
         if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
-            w.WriteLine(1, $"protected override partial async Task<int> ExecutePostQuery(IConnection connection)");
+            w.WriteLine(1, $"protected override partial async Task<int> ExecutePostFlow(IConnection connection)");
             w.WriteLine(1, "{");
             w.WriteLine(1, "}");
         }
@@ -325,7 +325,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
                 w.WriteLine();
             }
 
-            w.WriteLine(1, $"protected override partial async Task<int> ExecutePreQuery(IConnection connection)");
+            w.WriteLine(1, $"protected override partial async Task<int> ExecutePreFlow(IConnection connection)");
             w.WriteLine(1, "{");
             w.WriteLine(1, "}");
         }

--- a/TopModel.Generator.Csharp/DataFlowGenerator.cs
+++ b/TopModel.Generator.Csharp/DataFlowGenerator.cs
@@ -115,13 +115,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
             w.WriteLine(1, $"public override string[] DependsOn => new[] {{ {string.Join(", ", dataFlow.DependsOn.Select(d => $"\"{d.Name.ToPascalCase()}\""))} }};");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override bool PostQuery => true;");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override bool PreQuery => true;");
@@ -265,13 +265,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
 
         w.WriteLine(1, "}");
 
-        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override partial Task<int> ExecutePostQuery(IConnection connection);");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override partial Task<int> ExecutePreQuery(IConnection connection);");
@@ -294,7 +294,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
 
     private void HandleDataFlowPartial(string fileName, DataFlow dataFlow, string tag)
     {
-        if (!dataFlow.Sources.Any(s => s.Mode == DataFlowSourceMode.Partial) && !dataFlow.Hooks.Contains(FlowHook.AfterFLow) && !dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (!dataFlow.Sources.Any(s => s.Mode == DataFlowSourceMode.Partial) && !dataFlow.Hooks.Contains(FlowHook.AfterFlow) && !dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             return;
         }
@@ -311,16 +311,16 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         w.WriteNamespace(Config.GetNamespace(dataFlow, tag));
         w.WriteClassDeclaration($"{dataFlow.Name.ToPascalCase()}Flow", null, false);
 
-        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             w.WriteLine(1, $"protected override partial async Task<int> ExecutePostQuery(IConnection connection)");
             w.WriteLine(1, "{");
             w.WriteLine(1, "}");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
-            if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+            if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
             {
                 w.WriteLine();
             }
@@ -333,7 +333,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         var partialSources = dataFlow.Sources.Where(d => d.Mode == DataFlowSourceMode.Partial).OrderBy(s => s.Source);
         foreach (var source in partialSources)
         {
-            if (dataFlow.Hooks.Contains(FlowHook.AfterFLow) || dataFlow.Hooks.Contains(FlowHook.BeforeFLow) || partialSources.ToList().IndexOf(source) > 0)
+            if (dataFlow.Hooks.Any() || partialSources.ToList().IndexOf(source) > 0)
             {
                 w.WriteLine();
             }

--- a/TopModel.Generator.Csharp/DataFlowGenerator.cs
+++ b/TopModel.Generator.Csharp/DataFlowGenerator.cs
@@ -115,13 +115,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
             w.WriteLine(1, $"public override string[] DependsOn => new[] {{ {string.Join(", ", dataFlow.DependsOn.Select(d => $"\"{d.Name.ToPascalCase()}\""))} }};");
         }
 
-        if (dataFlow.PostQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override bool PostQuery => true;");
         }
 
-        if (dataFlow.PreQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override bool PreQuery => true;");
@@ -265,13 +265,13 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
 
         w.WriteLine(1, "}");
 
-        if (dataFlow.PostQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override partial Task<int> ExecutePostQuery(IConnection connection);");
         }
 
-        if (dataFlow.PreQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
         {
             w.WriteLine();
             w.WriteLine(1, $"protected override partial Task<int> ExecutePreQuery(IConnection connection);");
@@ -294,7 +294,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
 
     private void HandleDataFlowPartial(string fileName, DataFlow dataFlow, string tag)
     {
-        if (!dataFlow.Sources.Any(s => s.Mode == DataFlowSourceMode.Partial) && !dataFlow.PostQuery && !dataFlow.PreQuery)
+        if (!dataFlow.Sources.Any(s => s.Mode == DataFlowSourceMode.Partial) && !dataFlow.Hooks.Contains(FlowHook.AfterFLow) && !dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
         {
             return;
         }
@@ -311,16 +311,16 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         w.WriteNamespace(Config.GetNamespace(dataFlow, tag));
         w.WriteClassDeclaration($"{dataFlow.Name.ToPascalCase()}Flow", null, false);
 
-        if (dataFlow.PostQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
         {
             w.WriteLine(1, $"protected override partial async Task<int> ExecutePostQuery(IConnection connection)");
             w.WriteLine(1, "{");
             w.WriteLine(1, "}");
         }
 
-        if (dataFlow.PreQuery)
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
         {
-            if (dataFlow.PostQuery)
+            if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
             {
                 w.WriteLine();
             }
@@ -333,7 +333,7 @@ public class DataFlowGenerator : GeneratorBase<CsharpConfig>
         var partialSources = dataFlow.Sources.Where(d => d.Mode == DataFlowSourceMode.Partial).OrderBy(s => s.Source);
         foreach (var source in partialSources)
         {
-            if (dataFlow.PostQuery || dataFlow.PreQuery || partialSources.ToList().IndexOf(source) > 0)
+            if (dataFlow.Hooks.Contains(FlowHook.AfterFLow) || dataFlow.Hooks.Contains(FlowHook.BeforeFLow) || partialSources.ToList().IndexOf(source) > 0)
             {
                 w.WriteLine();
             }

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -104,6 +104,11 @@ public class JpaConfig : GeneratorConfigBase
     /// </summary>
     public long DataFlowsBulkSize { get; set; } = 100000;
 
+    /// <summary>
+    /// Listeners à ajouter aux dataflows
+    /// </summary>
+    public List<string> DataFlowsListeners { get; set; } = new ();
+
     public override string[] PropertiesWithLangVariableSupport => new[]
     {
         nameof(ResourcesPath)

--- a/TopModel.Generator.Jpa/JpaMapperGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaMapperGenerator.cs
@@ -76,7 +76,7 @@ public class JpaMapperGenerator : MapperGeneratorBase<JpaConfig>
         var getterPrefix = Config.GetType(propertyTarget!) == "boolean" ? "is" : "get";
         var getter = string.Empty;
         var converter = Config.GetConverter((propertySource as IFieldProperty)?.Domain, (propertyTarget as IFieldProperty)?.Domain);
-        if (converter != null)
+        if (converter != null && Config.GetImplementation(converter) != null)
         {
             fw.AddImports(Config.GetImplementation(converter)!.Imports);
         }

--- a/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
+++ b/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
@@ -63,12 +63,12 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
             fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}TruncateStep"") Step {dataFlow.Name.ToCamelCase()}TruncateStep,");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}BeforeFLowStep"") Step {dataFlow.Name.ToCamelCase()}BeforeFLowStep,");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}AfterFLowStep"") Step {dataFlow.Name.ToCamelCase()}AfterFLowStep,");
         }
@@ -76,7 +76,7 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         fw.WriteLine(1, @$"			@Qualifier(""{dataFlow.Name.ToPascalCase()}Step"") Step {dataFlow.Name.ToCamelCase()}Step) {{");
         fw.WriteLine(2, @$"return new FlowBuilder<Flow>(""{dataFlow.Name.ToPascalCase()}Flow"") //");
         var isFirst = true;
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.BeforeFlow))
         {
             fw.WriteLine(3, @$".start({dataFlow.Name.ToCamelCase()}BeforeFLowStep) //");
             isFirst = false;
@@ -92,7 +92,7 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
             fw.WriteLine(3, @$".{(isFirst ? "start" : "next")}({dataFlow.Name.ToCamelCase()}Step) //");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.AfterFLow))
+        if (dataFlow.Hooks.Contains(FlowHook.AfterFlow))
         {
             fw.WriteLine(3, @$".next({dataFlow.Name.ToCamelCase()}AfterFLowStep) //");
         }
@@ -137,7 +137,8 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
             tagToUse = Config.Tags.Intersect(dataFlow.Sources.First().Class.ModelFile.Tags).First();
         }
 
-        var query = $"select * from {(Config.ResolveVariables(Config.DbSchema!, tag: tagToUse) == null ? string.Empty : $"{Config.ResolveVariables(Config.DbSchema!, tag: tagToUse)}.")}{dataFlow.Sources.First().Class.SqlName}";
+        var properties = dataFlow.Sources[0].Class.Properties.OfType<IFieldProperty>();
+        var query = $"select {string.Join(", ", properties.Select(p => $"{p.SqlName} as {p.NameCamel}"))} from {(Config.ResolveVariables(Config.DbSchema!, tag: tagToUse) == null ? string.Empty : $"{Config.ResolveVariables(Config.DbSchema!, tag: tagToUse)}.")}{dataFlow.Sources.First().Class.SqlName}";
         if (dataFlow.Sources.First().Mode == DataFlowSourceMode.Partial)
         {
             query = string.Empty;
@@ -167,7 +168,7 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         fw.AddImport(dataFlow.Sources.First().Class.GetImport(Config, tag));
         fw.AddImport(dataFlow.Class.GetImport(Config, tag));
 
-        var hookStep = dataFlow.Hooks.Where(h => h != FlowHook.BeforeFLow && h != FlowHook.AfterFLow);
+        var hookStep = dataFlow.Hooks.Where(h => h != FlowHook.BeforeFlow && h != FlowHook.AfterFlow);
 
         fw.WriteLine();
         fw.WriteLine(1, @$"@Bean(""{dataFlow.Name.ToPascalCase()}Step"")");
@@ -181,40 +182,50 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         {
             var isLast = index == hookStep.Count() - 1;
             var processorName = GetProcessorName(dataFlow, hook, index).ToCamelCase();
+            var processorSourceClass = GetProcessorSourceClass(hook, dataFlow);
+            var processorTargetClass = GetProcessorTargetClass(hook, dataFlow);
             fw.AddImport("org.springframework.batch.item.ItemProcessor");
-            fw.WriteLine(1, @$"		@Qualifier(""{GetProcessorName(dataFlow, hook, index)}"") ItemProcessor<{dataFlow.Sources[0].Class.NamePascal}, {dataFlow.Class.NamePascal}> {processorName}{(isLast ? string.Empty : ",")} //");
+            fw.WriteLine(1, @$"		@Qualifier(""{GetProcessorName(dataFlow, hook, index)}"") ItemProcessor<{processorSourceClass}, {processorTargetClass}> {processorName}{(isLast ? string.Empty : ",")} //");
             index++;
         }
 
+        var processors = new List<string>();
         fw.WriteLine(1, ") {");
         fw.WriteLine(2, @$"return new StepBuilder(""{dataFlow.Name.ToPascalCase()}Step"", jobRepository) //");
         fw.WriteLine(3, @$".<{dataFlow.Sources.First().Class.NamePascal}, {dataFlow.Class.NamePascal}>chunk({Config.DataFlowsBulkSize}, transactionManager) //");
         fw.WriteLine(3, ".reader(reader) //");
-        if (dataFlow.Hooks.Contains(FlowHook.AfterSource))
+        var i = 0;
+        foreach (var t in dataFlow.Hooks.Where(h => h == FlowHook.AfterSource))
         {
-            var i = 0;
-            foreach (var t in dataFlow.Hooks.Where(h => h == FlowHook.AfterSource))
-            {
-                WriteProcessorCall(fw, dataFlow, FlowHook.AfterSource, i++);
-            }
+            processors.Add(GetProcessorName(dataFlow, FlowHook.AfterSource, i++).ToCamelCase());
         }
 
         if (dataFlow.Hooks.Contains(FlowHook.Map))
         {
-            WriteProcessorCall(fw, dataFlow, FlowHook.Map, 0);
+            foreach (var t in dataFlow.Hooks.Where(h => h == FlowHook.Map))
+            {
+                processors.Add(GetProcessorName(dataFlow, FlowHook.Map, 0).ToCamelCase());
+            }
         }
         else if (dataFlow.Sources.First().Class != dataFlow.Class)
         {
-            fw.WriteLine(3, $".processor({dataFlow.Class.NamePascal}::new) //");
+            processors.Add($"({dataFlow.Sources[0].Class.NamePascal} item) -> new {dataFlow.Class.NamePascal}(item)");
         }
 
-        if (dataFlow.Hooks.Contains(FlowHook.BeforeTarget))
+        i = 0;
+        foreach (var t in dataFlow.Hooks.Where(h => h == FlowHook.BeforeTarget))
         {
-            var i = 0;
-            foreach (var t in dataFlow.Hooks.Where(h => h == FlowHook.BeforeTarget))
-            {
-                WriteProcessorCall(fw, dataFlow, FlowHook.BeforeTarget, i++);
-            }
+            processors.Add(GetProcessorName(dataFlow, FlowHook.BeforeTarget, i++).ToCamelCase());
+        }
+
+        if (processors.Count() == 1)
+        {
+            fw.WriteLine(3, $".processor({processors[0]}) //");
+        }
+        else if (processors.Count() > 1)
+        {
+            fw.AddImport("org.springframework.batch.item.support.CompositeItemProcessor");
+            fw.WriteLine(3, $".processor(new CompositeItemProcessor<>({string.Join(", ", processors)})) //");
         }
 
         fw.WriteLine(3, ".writer(writer) //");
@@ -222,9 +233,24 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         fw.WriteLine(1, "}");
     }
 
-    private void WriteProcessorCall(JavaWriter fw, DataFlow dataFlow, FlowHook flowHook, int index)
+    private string GetProcessorSourceClass(FlowHook flowHook, DataFlow flow)
     {
-        fw.WriteLine(3, $".processor({GetProcessorName(dataFlow, flowHook, index).ToCamelCase()}) //");
+        return flowHook switch
+        {
+            FlowHook.AfterSource or FlowHook.Map => flow.Sources[0].Class.NamePascal,
+            FlowHook.BeforeTarget => flow.Class.NamePascal,
+            _ => string.Empty,
+        };
+    }
+
+    private string GetProcessorTargetClass(FlowHook flowHook, DataFlow flow)
+    {
+        return flowHook switch
+        {
+            FlowHook.AfterSource => flow.Sources[0].Class.NamePascal,
+            FlowHook.BeforeTarget or FlowHook.Map => flow.Class.NamePascal,
+            _ => string.Empty,
+        };
     }
 
     private string GetProcessorName(DataFlow dataFlow, FlowHook flowHook, int index)
@@ -295,6 +321,11 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
 
                 return result;
             }).FirstOrDefault();
+        if (dataFlow.Hooks.Contains(FlowHook.Map))
+        {
+            mapper = null;
+        }
+
         foreach (var property in dataFlow.Class.Properties.OfType<IFieldProperty>()
             .Where(p => mapper == null || mapper.Params.SelectMany(pa => pa.Mappings).Select(mapping => mapping.Key).Contains(p)))
         {

--- a/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
+++ b/TopModel.Generator.Jpa/SpringDataFlowGenerator.cs
@@ -175,6 +175,12 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         fw.WriteLine(1, @$"public static Step {dataFlow.Name.ToCamelCase()}Step(");
         fw.WriteLine(1, @$"		JobRepository jobRepository, //");
         fw.WriteLine(1, @$"		PlatformTransactionManager transactionManager, //");
+        foreach (var listener in Config.DataFlowsListeners)
+        {
+            fw.AddImport("org.springframework.batch.core.StepListener");
+            fw.WriteLine(1, @$"		@Qualifier(""{listener}"") StepListener {listener.ToCamelCase()}, //");
+        }
+
         fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Name.ToPascalCase()}Reader"") ItemReader<{dataFlow.Sources.First().Class.NamePascal}> reader, //");
         fw.WriteLine(1, @$"		@Qualifier(""{dataFlow.Name.ToPascalCase()}Writer"") ItemWriter<{dataFlow.Class.NamePascal}> writer{(hookStep.Any() ? ',' : string.Empty)} //");
         var index = 0;
@@ -226,6 +232,11 @@ public class SpringDataFlowGenerator : GeneratorBase<JpaConfig>
         {
             fw.AddImport("org.springframework.batch.item.support.CompositeItemProcessor");
             fw.WriteLine(3, $".processor(new CompositeItemProcessor<>({string.Join(", ", processors)})) //");
+        }
+
+        foreach (var listener in Config.DataFlowsListeners)
+        {
+            fw.WriteLine(3, $".listener({listener.ToCamelCase()}) //");
         }
 
         fw.WriteLine(3, ".writer(writer) //");

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -126,6 +126,14 @@
       "type": "number",
       "description": "Taille des chunks à extraire et insérer"
     },
+    "dataFlowsListeners": {
+      "type": "array",
+      "description": "Listeners à ajouter à tous les dataflows",
+      "items": {
+        "type": "string",
+        "description": "Listener à ajouter à tous les dataflows"
+      }
+    },
     "dbSchema": {
       "type": "string",
       "description": "Nom du schéma sur lequel les entités sont sauvegardées"


### PR DESCRIPTION
Donne la possibilité de définir une liste de hook à rajouter dans le flow. Ces hook permettent à l'utilisateur de placer des transformation de données à certains endroits du process :
- BeforeFlow : se lance avant le traitement de manière globale (pas de transformation de données)
- AfterSource : se lance après le chargement de la / des sources : transformation des données sources avant le mapping
- Map : utilisé pour remplacer le mapping entre la/les sources et la destination
- BeforeTarget : se lance après le chargement de la / des sources : transformation des données sources après le mapping
- AfterFlow : se lance après le traitement


Fix: #299