### PR TITLE
Compositions sur classes persistées (en JSON)

### DIFF
--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -142,7 +142,8 @@ public class PropertyLoader : ILoader<IProperty>
             case Scalar { Value: "composition" } s:
                 var cp = new CompositionProperty
                 {
-                    Location = new Reference(s)
+                    Location = new Reference(s),
+                    UseLegacyRoleName = _modelConfig.UseLegacyRoleNames
                 };
 
                 while (parser.Current is not MappingEnd)
@@ -169,6 +170,9 @@ public class PropertyLoader : ILoader<IProperty>
                             break;
                         case "required":
                             cp.Required = value!.Value == "true";
+                            break;
+                        case "trigram":
+                            cp.Trigram = new LocatedString(value);
                             break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -43,6 +43,9 @@ public class CompositionProperty : IProperty
     public bool Required { get; set; } = true;
 
 #nullable enable
+
+    public LocatedString? Trigram { get; set; }
+
     public IFieldProperty? CompositionPrimaryKey
     {
         get
@@ -56,6 +59,8 @@ public class CompositionProperty : IProperty
             return cpPks.Count() == 1 ? cpPks.Single() : null;
         }
     }
+
+    public bool UseLegacyRoleName { get; init; }
 
 #nullable disable
     public ClassReference Reference { get; set; }

--- a/TopModel.Core/Model/IFieldProperty.cs
+++ b/TopModel.Core/Model/IFieldProperty.cs
@@ -1,12 +1,8 @@
-﻿using TopModel.Utils;
-
-namespace TopModel.Core;
+﻿namespace TopModel.Core;
 
 public interface IFieldProperty : IProperty
 {
     string? DefaultValue { get; }
-
-    LocatedString? Trigram { get; set; }
 
     IFieldProperty ResourceProperty => Decorator != null && Parent != Decorator
         ? Decorator.Properties.OfType<IFieldProperty>().First(p => p.Name == Name).ResourceProperty
@@ -23,44 +19,4 @@ public interface IFieldProperty : IProperty
         : this;
 
     string CommentResourceKey => $"comments.{CommentResourceProperty.Parent.Namespace.ModuleCamel}.{CommentResourceProperty.Parent.NameCamel}.{CommentResourceProperty.NameCamel}";
-
-    string SqlName
-    {
-        get
-        {
-            var prop = (this as AliasProperty)?.PersistentProperty ?? this;
-
-            var ap = (prop as AssociationProperty) ?? ((prop as AliasProperty)?.Property as AssociationProperty);
-
-            var apPk = ap switch
-            {
-                { Property: IFieldProperty p } => p,
-                { Association: Class classe } => classe.Properties.OfType<IFieldProperty>().FirstOrDefault(),
-                _ => null
-            };
-
-            var apPkTrigram = apPk?.Trigram ?? apPk?.Class.Trigram;
-
-            var sqlName = prop switch
-            {
-                AssociationProperty or AliasProperty { Property: AssociationProperty } => apPkTrigram != null ? apPk?.SqlName.Replace($"{apPkTrigram}_", string.Empty) : apPk?.SqlName,
-                { Class.Extends: not null, PrimaryKey: true } when Parent.PreservePropertyCasing => prop.Name.Replace(prop.Class.Name, string.Empty),
-                { Class.Extends: not null, PrimaryKey: true } => prop.Name.Replace(prop.Class.Name, string.Empty).ToConstantCase(),
-                _ when Parent.PreservePropertyCasing => prop.Name,
-                _ => prop.Name.ToConstantCase()
-            };
-
-            string? prefix = prop.Trigram ?? (apPk != null ? apPkTrigram : prop.Class.Trigram);
-            prefix = !string.IsNullOrWhiteSpace(prefix) ? $"{prefix}_" : string.Empty;
-            var suffix = ap?.Role != null
-                ? UseLegacyRoleName
-                    ? $"_{ap.Role.Replace(" ", "_").ToUpper()}"
-                    : $"_{ap.Role.ToConstantCase()}"
-                : string.Empty;
-
-            return $"{prefix}{sqlName}{suffix}";
-        }
-    }
-
-    bool UseLegacyRoleName { get; init; }
 }

--- a/TopModel.Core/Model/IProperty.cs
+++ b/TopModel.Core/Model/IProperty.cs
@@ -1,4 +1,6 @@
-﻿namespace TopModel.Core;
+﻿using TopModel.Utils;
+
+namespace TopModel.Core;
 
 public interface IProperty
 {
@@ -26,6 +28,8 @@ public interface IProperty
 
     bool Readonly { get; set; }
 
+    LocatedString? Trigram { get; set; }
+
     Class Class { get; set; }
 
     Endpoint Endpoint { get; set; }
@@ -35,6 +39,46 @@ public interface IProperty
     PropertyMapping PropertyMapping { get; set; }
 
     IPropertyContainer Parent => Class ?? (IPropertyContainer)Endpoint ?? (IPropertyContainer)Decorator ?? PropertyMapping;
+
+    string SqlName
+    {
+        get
+        {
+            var prop = (this as AliasProperty)?.PersistentProperty ?? this;
+
+            var ap = (prop as AssociationProperty) ?? ((prop as AliasProperty)?.Property as AssociationProperty);
+
+            var apPk = ap switch
+            {
+                { Property: IFieldProperty p } => p,
+                { Association: Class classe } => classe.Properties.OfType<IFieldProperty>().FirstOrDefault(),
+                _ => null
+            };
+
+            var apPkTrigram = apPk?.Trigram ?? apPk?.Class.Trigram;
+
+            var sqlName = prop switch
+            {
+                AssociationProperty or AliasProperty { Property: AssociationProperty } => apPkTrigram != null ? apPk?.SqlName.Replace($"{apPkTrigram}_", string.Empty) : apPk?.SqlName,
+                { Class.Extends: not null, PrimaryKey: true } when Parent.PreservePropertyCasing => prop.Name.Replace(prop.Class.Name, string.Empty),
+                { Class.Extends: not null, PrimaryKey: true } => prop.Name.Replace(prop.Class.Name, string.Empty).ToConstantCase(),
+                _ when Parent.PreservePropertyCasing => prop.Name,
+                _ => prop.Name.ToConstantCase()
+            };
+
+            string? prefix = prop.Trigram ?? (apPk != null ? apPkTrigram : prop.Class.Trigram);
+            prefix = !string.IsNullOrWhiteSpace(prefix) ? $"{prefix}_" : string.Empty;
+            var suffix = ap?.Role != null
+                ? UseLegacyRoleName
+                    ? $"_{ap.Role.Replace(" ", "_").ToUpper()}"
+                    : $"_{ap.Role.ToConstantCase()}"
+                : string.Empty;
+
+            return $"{prefix}{sqlName}{suffix}";
+        }
+    }
+
+    bool UseLegacyRoleName { get; init; }
 
     IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null);
 }

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -349,6 +349,10 @@
             "required": {
               "type": "boolean",
               "description": "Précise si la propriété est obligatoire (`true` par défaut sur les compositions). Une composition obligatoire sera initialisée avec une instance vide."
+            },
+            "trigram": {
+              "type": "string",
+              "description": "Surcharge locale du trigram"
             }
           }
         }

--- a/TopModel.Generator.Csharp/DbContextGenerator.cs
+++ b/TopModel.Generator.Csharp/DbContextGenerator.cs
@@ -183,6 +183,19 @@ public class DbContextGenerator : ClassGroupGeneratorBase<CsharpConfig>
             w.WriteLine();
         }
 
+        var hasJson = false;
+        foreach (var cp in classes.Distinct().SelectMany(c => c.Properties.Where(p => p is CompositionProperty)))
+        {
+            hasJson = true;
+            var sqlName = Config.UseLowerCaseSqlNames ? cp.SqlName.ToLower() : cp.SqlName;
+            w.WriteLine(2, $@"modelBuilder.Entity<{cp.Class}>().Owns{(cp.Domain == null ? "One" : "Many")}(p => p.{cp.NamePascal}, p => p.ToJson(""{sqlName}""));");
+        }
+
+        if (hasJson)
+        {
+            w.WriteLine();
+        }
+
         if (Config.UseEFMigrations)
         {
             var hasFk = false;

--- a/TopModel.Generator.Sql/Procedural/AbstractSchemaGenerator.cs
+++ b/TopModel.Generator.Sql/Procedural/AbstractSchemaGenerator.cs
@@ -38,6 +38,11 @@ public abstract class AbstractSchemaGenerator
     }
 
     /// <summary>
+    /// Type json pour les compositions.
+    /// </summary>
+    protected virtual string JsonType => "json";
+
+    /// <summary>
     /// Utilise des guillemets autour des noms d'objets dans les scripts.
     /// </summary>
     protected virtual bool UseQuotes => false;
@@ -241,7 +246,7 @@ public abstract class AbstractSchemaGenerator
         return nameValueDict;
     }
 
-    protected abstract void WriteComments(SqlFileWriter writerCrebas, Class classe, string tableName, List<IFieldProperty> properties);
+    protected abstract void WriteComments(SqlFileWriter writerCrebas, Class classe, string tableName, List<IProperty> properties);
 
     /// <summary>
     /// Gère l'auto-incrémentation des clés primaires.
@@ -405,7 +410,7 @@ public abstract class AbstractSchemaGenerator
     /// </summary>
     /// <param name="writerCrebas">Writer.</param>
     /// <param name="classe">Classe.</param>
-    private void WritePrimaryKeyConstraint(SqlFileWriter writerCrebas, Class classe, List<IFieldProperty> properties)
+    private void WritePrimaryKeyConstraint(SqlFileWriter writerCrebas, Class classe, List<IProperty> properties)
     {
         if (!properties.Any(p => p.PrimaryKey))
         {
@@ -534,7 +539,7 @@ public abstract class AbstractSchemaGenerator
             WriteType(classe, writerType);
         }
 
-        var properties = classe.Properties.OfType<IFieldProperty>().Where(p => p is not AssociationProperty ap || ap.Type == AssociationType.ManyToOne || ap.Type == AssociationType.OneToOne).ToList();
+        var properties = classe.Properties.Where(p => p is not AssociationProperty ap || ap.Type == AssociationType.ManyToOne || ap.Type == AssociationType.OneToOne).ToList();
         var t = 0;
         var classes = availableClasses.Distinct();
         if (classe.Extends != null)
@@ -568,7 +573,7 @@ public abstract class AbstractSchemaGenerator
 
         foreach (var property in properties)
         {
-            var persistentType = _config.GetType(property);
+            var persistentType = property is IFieldProperty ? _config.GetType(property, availableClasses) : JsonType;
 
             if (persistentType.ToLower().Equals("varchar") && property.Domain.Length != null)
             {

--- a/TopModel.Generator.Sql/Procedural/PostgreSchemaGenerator.cs
+++ b/TopModel.Generator.Sql/Procedural/PostgreSchemaGenerator.cs
@@ -15,11 +15,13 @@ public class PostgreSchemaGenerator : AbstractSchemaGenerator
 
     protected override string BatchSeparator => ";";
 
+    protected override string JsonType => "jsonb";
+
     protected override bool SupportsClusteredKey => false;
 
     protected override bool UseQuotes => false;
 
-    protected override void WriteComments(SqlFileWriter writerComment, Class classe, string tableName, List<IFieldProperty> properties)
+    protected override void WriteComments(SqlFileWriter writerComment, Class classe, string tableName, List<IProperty> properties)
     {
         writerComment.WriteLine();
         writerComment.WriteLine("/**");

--- a/TopModel.Generator.Sql/Procedural/SqlServerSchemaGenerator.cs
+++ b/TopModel.Generator.Sql/Procedural/SqlServerSchemaGenerator.cs
@@ -17,7 +17,7 @@ public class SqlServerSchemaGenerator : AbstractSchemaGenerator
 
     protected override bool SupportsClusteredKey => true;
 
-    protected override void WriteComments(SqlFileWriter writerCrebas, Class classe, string tableName, List<IFieldProperty> properties)
+    protected override void WriteComments(SqlFileWriter writerCrebas, Class classe, string tableName, List<IProperty> properties)
     {
         // Nothing to do
     }

--- a/samples/generators/csharp/src/Models/CSharp.Securite/Profil.Models/generated/ProfilRead.cs
+++ b/samples/generators/csharp/src/Models/CSharp.Securite/Profil.Models/generated/ProfilRead.cs
@@ -52,5 +52,6 @@ public partial class ProfilRead
     /// <summary>
     /// Utilisateurs ayant ce profil.
     /// </summary>
+    [Required]
     public ICollection<UtilisateurItem> Utilisateurs { get; set; } = new List<UtilisateurItem>();
 }


### PR DESCRIPTION
Cette PR ajoute la gestion des compositions sur les classes persistées, pour les sauvegarder dans une colonne au format JSON en base de données.

Une composition a donc maintenant un `SqlName` comme les autres propriétés, et il devient donc possible de surcharger son trigramme localement.

## Générateurs SQL
- Avant : Les compositions dans les classes persistées étaient ignorées et non générées en SQL
- Maintenant : On génère une colonne de type `json`/`jsonb` pour la composition

## Générateur C#
- Avant : Les compositions dans les classes persistées sont générées avec un attribut `[NotMapped]`
- Maintenant : On ne met plus `[NotMapped]` mais les attributs `[Column]` et `[Required]` (si nécessaire) à la place, et la configuration nécessaire pour EF Core est ajoutée dans le DbContext

_Remarque : l'annotation `[Required]` a été ajoutée pour toutes les compositions obligatoires (y compris non persistées), de façon à être raccord avec le fait qu'on génère un `required` en `requiredNonNullable` sur les compositions._

## Générateurs Java/Php

Les compositions sont générées comme des propriétés normales, ce qui ne marche probablement pas. Cette PR ne touche pas à ces générateurs donc ça va continuer de ne pas marcher comme avant 🙂