### PR TITLE
`customProperties` sur classes, endpoints et propriétés

### DIFF
--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -127,6 +127,9 @@ public class ClassLoader : ILoader<Class>
                         });
                     });
                     break;
+                case "customProperties":
+                    parser.ConsumeMapping(prop => classe.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
+                    break;
                 case "mappers":
                     parser.ConsumeMapping(prop =>
                     {

--- a/TopModel.Core/Loaders/EndpointLoader.cs
+++ b/TopModel.Core/Loaders/EndpointLoader.cs
@@ -77,6 +77,9 @@ public class EndpointLoader : ILoader<Endpoint>
                         }
                     });
                     break;
+                case "customProperties":
+                    parser.ConsumeMapping(prop => endpoint.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
+                    break;
                 default:
                     throw new ModelException(endpoint, $"Propriété ${prop} inconnue pour un endpoint");
             }

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -57,6 +57,9 @@ public class PropertyLoader : ILoader<IProperty>
                         case "trigram":
                             rp.Trigram = new LocatedString(value);
                             break;
+                        case "customProperties":
+                            parser.ConsumeMapping(prop => rp.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
+                            break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");
                     }
@@ -126,6 +129,9 @@ public class PropertyLoader : ILoader<IProperty>
                         case "trigram":
                             ap.Trigram = new LocatedString(value);
                             break;
+                        case "customProperties":
+                            parser.ConsumeMapping(prop => ap.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
+                            break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");
                     }
@@ -176,6 +182,9 @@ public class PropertyLoader : ILoader<IProperty>
                             break;
                         case "trigram":
                             cp.Trigram = new LocatedString(value);
+                            break;
+                        case "customProperties":
+                            parser.ConsumeMapping(prop => cp.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
                             break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");
@@ -280,6 +289,11 @@ public class PropertyLoader : ILoader<IProperty>
                             break;
                         case "defaultValue":
                             alp.DefaultValue = value!.Value;
+                            break;
+                        case "customProperties":
+                            var customProperties = new Dictionary<string, string>();
+                            parser.ConsumeMapping(prop => customProperties.Add(prop.Value, parser.Consume<Scalar>().Value));
+                            alp.CustomProperties = customProperties;
                             break;
                         default:
                             throw new ModelException($"Propriété ${prop} inconnue pour une propriété");

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -6,6 +6,7 @@ namespace TopModel.Core;
 public class AliasProperty : IProperty
 {
     private string? _comment;
+    private Dictionary<string, string> _customProperties = [];
     private string? _defaultValue;
     private Domain? _domain;
     private string[]? _domainParameters;
@@ -133,6 +134,21 @@ public class AliasProperty : IProperty
 
     public string? As { get; set; }
 
+    public Dictionary<string, string> CustomProperties
+    {
+        get
+        {
+            var customProperties = new Dictionary<string, string>(OriginalProperty!.CustomProperties);
+            foreach (var cp in _customProperties)
+            {
+                customProperties[cp.Key] = cp.Value;
+            }
+
+            return customProperties;
+        }
+        set => _customProperties = value;
+    }
+
     public IProperty? OriginalProperty => _property;
 
     public IProperty? PersistentProperty => (Class?.IsPersistent ?? false)
@@ -186,7 +202,8 @@ public class AliasProperty : IProperty
             Name = _name!,
             Trigram = Trigram,
             UseLegacyRoleName = UseLegacyRoleName,
-            DomainParameters = _domainParameters!
+            DomainParameters = _domainParameters!,
+            CustomProperties = _customProperties
         };
 
         if (_domain != null)
@@ -235,7 +252,8 @@ public class AliasProperty : IProperty
             As = As,
             OriginalAliasProperty = this,
             UseLegacyRoleName = UseLegacyRoleName,
-            DomainParameters = _domainParameters!
+            DomainParameters = _domainParameters!,
+            CustomProperties = _customProperties
         };
 
         if (_domain != null)

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -64,6 +64,8 @@ public class AssociationProperty : IProperty
 
     public string? DefaultValue { get; set; }
 
+    public Dictionary<string, string> CustomProperties { get; } = [];
+
     public string Name
     {
         get

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -70,6 +70,8 @@ public class Class : IPropertyContainer
 
     public List<ClassMappings> ToMappers { get; } = [];
 
+    public Dictionary<string, string> CustomProperties { get; } = [];
+
     public string PluralName
     {
         get => _pluralName ?? (Name.EndsWith("s") ? Name : $"{Name}s");

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -48,6 +48,8 @@ public class CompositionProperty : IProperty
 
     public LocatedString? Trigram { get; set; }
 
+    public Dictionary<string, string> CustomProperties { get; } = [];
+
     public IProperty? CompositionPrimaryKey
     {
         get

--- a/TopModel.Core/Model/Endpoint.cs
+++ b/TopModel.Core/Model/Endpoint.cs
@@ -37,24 +37,26 @@ public class Endpoint : IPropertyContainer
 
     public IProperty? Returns { get; set; }
 
-    public IList<IProperty> Params { get; set; } = new List<IProperty>();
+    public IList<IProperty> Params { get; set; } = [];
 
     public bool IsMultipart => Params.Any(p => p.Domain?.IsMultipart ?? false || p is CompositionProperty cp && cp.IsMultipart);
 
-    public IList<IProperty> Properties => Params.Concat(new[] { Returns! }).Where(p => p != null).ToList();
+    public IList<IProperty> Properties => Params.Concat([Returns!]).Where(p => p != null).ToList();
 
     public bool PreservePropertyCasing { get; set; }
 
-    public List<(Decorator Decorator, string[] Parameters)> Decorators { get; } = new();
+    public Dictionary<string, string> CustomProperties { get; } = [];
+
+    public List<(Decorator Decorator, string[] Parameters)> Decorators { get; } = [];
 
     public IEnumerable<ClassDependency> ClassDependencies => Properties.GetClassDependencies();
 
-    public List<DecoratorReference> DecoratorReferences { get; } = new();
+    public List<DecoratorReference> DecoratorReferences { get; } = [];
 
 #nullable disable
     internal Reference Location { get; set; }
 
-    internal List<string> OwnTags { get; set; } = new();
+    internal List<string> OwnTags { get; set; } = [];
 
 #nullable enable
 

--- a/TopModel.Core/Model/IProperty.cs
+++ b/TopModel.Core/Model/IProperty.cs
@@ -32,6 +32,8 @@ public interface IProperty
 
     LocatedString? Trigram { get; set; }
 
+    Dictionary<string, string> CustomProperties { get; }
+
     Class Class { get; set; }
 
     Endpoint Endpoint { get; set; }

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -35,6 +35,8 @@ public class RegularProperty : IProperty
 
     public string Comment { get; set; }
 
+    public Dictionary<string, string> CustomProperties { get; } = [];
+
     public Class Class { get; set; }
 
     public Endpoint Endpoint { get; set; }

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -90,6 +90,13 @@
             },
             "defaultValue": {
               "description": "Valeur par défaut de la propriété, dans les classes et les endpoints."
+            },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -154,6 +161,13 @@
             "property": {
               "type": "string",
               "description": "Propriété de la classe cible à utiliser pour la clé étrangère (au lieu de la clé primaire)."
+            },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -314,6 +328,13 @@
             },
             "defaultValue": {
               "description": "Surcharge la valeur par défaut de la propriété."
+            },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé. Elles s'ajouteront à celles de la propriété originale (avec remplacement si conflit).",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -357,6 +378,13 @@
             "trigram": {
               "type": "string",
               "description": "Surcharge locale du trigram"
+            },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         }
@@ -817,6 +845,13 @@
               "type": "object",
               "description": "Liste des valeurs de la table à insérer à la création de la base de données. Il doit d'agir d'un objet ayant pour clés un nom de ligne (qui sera utilisé pour identifier la clé en C#), et pour valeurs un objet de type JSON qui renseigne les valeurs des différentes propriétés."
             },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés de classe personnalisées, pour utilisation dans un générateur personnalisé.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "mappers": {
               "type": "object",
               "description": "Définitions de mappers vers et depuis cette classe.",
@@ -1014,6 +1049,13 @@
               "description": "Les paramètres de l'endpoint. Un paramètre, selon son type et sa présence ou non dans la route, sera automatiquement classifié comme 'Route', 'Query' ou 'Body'",
               "items": {
                 "$ref": "#/definitions/property"
+              }
+            },
+            "customProperties": {
+              "type": "object",
+              "description": "Propriétés d'endpoint personnalisées, pour utilisation dans un générateur personnalisé.",
+              "additionalProperties": {
+                "type": "string"
               }
             },
             "decorators": {


### PR DESCRIPTION
Fix #387

On peut désormais renseigner `customProperties` sur des classes, des endpoints ou des propriétés pour ajouter un ensemble de propriétés arbitraires sur ces objets, qui pourront être utilisés par des générateurs personnalisés par le suite. Aucun générateur "standard" n'utilisera de propriétés personnalisées, elles existent afin de pouvoir ajouter des informations essentielles à la bonne génération de classes ou endpoints, lorsqu'il est impossible de faire autrement avec ce qui existe déjà dans TopModel.

Dans le cas des alias, les propriétés personnalisés sont fusionnées avec les propriétés de la propriété originale (avec priorité à celle de l'alias s'il y a conflit).