### PR TITLE
[JAVA] Enumérations représentant totalement l'entité

### DIFF
--- a/TopModel.Generator.Jpa/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaEnumGenerator.cs
@@ -105,6 +105,7 @@ public class JpaEnumGenerator : GeneratorBase<JpaConfig>
 
                 if (prop is AssociationProperty ap && codeProperty.PrimaryKey && ap.Association.Values.Any(r => r.Value.ContainsKey(ap.Property) && r.Value[ap.Property] == value))
                 {
+                    fw.AddImport($"{Config.GetEnumPackageName(ap.Association.EnumKey.Class, tag)}.{ap.Association.NamePascal + ap.Association.EnumKey}");
                     value = ap.Association.NamePascal + ap.Association.EnumKey + "." + value;
                     isString = false;
                 }

--- a/TopModel.Generator.Jpa/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaEnumGenerator.cs
@@ -133,7 +133,13 @@ public class JpaEnumGenerator : GeneratorBase<JpaConfig>
             fw.WriteLine();
             fw.WriteDocStart(1, $@"{prop.NameByClassPascal}");
             fw.WriteDocEnd(1);
-            fw.WriteLine(1, $@"private final {Config.GetType(prop)} {prop.NameByClassCamel};");
+            var fieldName = prop.NameByClassCamel;
+            if (prop is AssociationProperty ap)
+            {
+                fieldName = $"{ap.Association.NameCamel}{ap.Association.EnumKey}";
+            }
+
+            fw.WriteLine(1, $@"private final {Config.GetType(prop)} {fieldName};");
         }
 
         WriteConstructor(property, classe, fw, properties);
@@ -143,8 +149,14 @@ public class JpaEnumGenerator : GeneratorBase<JpaConfig>
             fw.WriteLine();
             fw.WriteDocStart(1, "Getter");
             fw.WriteDocEnd(1);
-            fw.WriteLine(1, $@"public {Config.GetType(prop)} get{prop.NameByClassCamel.ToFirstUpper()}(){{");
-            fw.WriteLine(2, $@"return this.{prop.NameByClassCamel};");
+            var fieldName = prop.NameByClassCamel;
+            if (prop is AssociationProperty ap)
+            {
+                fieldName = $"{ap.Association.NameCamel}{ap.Association.EnumKey}";
+            }
+
+            fw.WriteLine(1, $@"public {Config.GetType(prop)} get{fieldName.ToFirstUpper()}(){{");
+            fw.WriteLine(2, $@"return this.{fieldName};");
             fw.WriteLine(1, $@"}}");
         }
 
@@ -160,15 +172,28 @@ public class JpaEnumGenerator : GeneratorBase<JpaConfig>
         constructorAsString.Add($@"{Config.GetEnumName(property, classe)}(");
 
         constructorAsString.Add(properties.Select((prop, index) =>
-           $@"final {Config.GetType(prop)} {prop.NameByClassCamel} {(prop == properties.Last() ? string.Empty : ",")}")
-           .Aggregate(string.Empty, (acc, curr) => acc + curr));
+            {
+                var fieldName = prop.NameByClassCamel;
+                if (prop is AssociationProperty ap)
+                {
+                    fieldName = $"{ap.Association.NameCamel}{ap.Association.EnumKey}";
+                }
+
+                return $@"final {Config.GetType(prop)} {fieldName} {(prop == properties.Last() ? string.Empty : ",")}";
+            }).Aggregate(string.Empty, (acc, curr) => acc + curr));
 
         constructorAsString.Add("){");
         fw.WriteLine(1, constructorAsString.Aggregate(string.Empty, (acc, curr) => acc + curr));
         foreach (var prop in properties)
         {
+            var fieldName = prop.NameByClassCamel;
+            if (prop is AssociationProperty ap)
+            {
+                fieldName = $"{ap.Association.NameCamel}{ap.Association.EnumKey}";
+            }
+
             // Constructeur set
-            fw.WriteLine(2, $@" this.{prop.NameByClassCamel} = {prop.NameByClassCamel};");
+            fw.WriteLine(2, $@" this.{fieldName} = {fieldName};");
         }
 
         fw.WriteLine(1, "}");

--- a/TopModel.Generator.Jpa/JpaModelConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelConstructorGenerator.cs
@@ -40,7 +40,8 @@ public class JpaModelConstructorGenerator
                 {
                     var javaType = _config.GetType(prop, useClassForAssociation: classe.IsPersistent && !_config.UseJdbc && prop is AssociationProperty asp && asp.Association.IsPersistent);
                     javaType = javaType.Split("<")[0];
-                    val = $@"{classe.EnumKey!.NameCamel}.{prop.NameByClassCamel.WithPrefix(getterPrefix)}() != null ? new {javaType}({classe.EnumKey!.NameCamel}.{prop.NameByClassCamel.WithPrefix(getterPrefix)}()) : null";
+                    var fieldName = $"{ap.Association.NameCamel}{ap.Association.EnumKey}";
+                    val = $@"{classe.EnumKey!.NameCamel}.{fieldName.WithPrefix(getterPrefix)}() != null ? new {javaType}({classe.EnumKey!.NameCamel}.{fieldName.WithPrefix(getterPrefix)}()) : null";
                 }
                 else if (_config.CanClassUseEnums(classe, prop: prop))
                 {

--- a/TopModel.Generator.Jpa/JpaModelGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaModelGenerator.cs
@@ -406,9 +406,9 @@ public class JpaModelGenerator : ClassGeneratorBase<JpaConfig>
 
         fw.WriteLine();
 
-        fw.WriteLine(2, "private Class<?> type;");
+        fw.WriteLine(2, "private final Class<?> type;");
         fw.WriteLine();
-        fw.WriteLine(2, "private Fields(Class<?> type) {");
+        fw.WriteLine(2, "Fields(Class<?> type) {");
         fw.WriteLine(3, "this.type = type;");
         fw.WriteLine(2, "}");
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/profil/ProfilRead.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/profil/ProfilRead.java
@@ -192,9 +192,9 @@ public class ProfilRead implements Serializable {
         DATE_MODIFICATION(LocalDateTime.class), //
         UTILISATEURS(List.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/profil/ProfilWrite.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/profil/ProfilWrite.java
@@ -86,9 +86,9 @@ public class ProfilWrite implements Serializable {
         LIBELLE(String.class), //
         DROITS(List.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/utilisateur/UtilisateurRead.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/utilisateur/UtilisateurRead.java
@@ -319,9 +319,9 @@ public class UtilisateurRead implements Serializable {
         DATE_CREATION(LocalDateTime.class), //
         DATE_MODIFICATION(LocalDateTime.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/utilisateur/UtilisateurWrite.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/dtos/securite/utilisateur/UtilisateurWrite.java
@@ -237,9 +237,9 @@ public class UtilisateurWrite implements Serializable {
         PROFIL_ID(Integer.class), //
         TYPE_UTILISATEUR_CODE(TypeUtilisateurCode.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
@@ -76,7 +76,7 @@ public class Droit {
 	public Droit(DroitCode code) {
 		this.code = code;
 		this.libelle = code.getLibelle();
-		this.typeDroit = code.getTypeDroit() != null ? new TypeDroit(code.getTypeDroit()) : null;
+		this.typeDroit = code.getTypeDroitCode() != null ? new TypeDroit(code.getTypeDroitCode()) : null;
 	}
 
 	/**

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
@@ -75,24 +75,8 @@ public class Droit {
 	 */
 	public Droit(DroitCode code) {
 		this.code = code;
-		switch(code) {
-		case CREATE :
-			this.libelle = "securite.profil.droit.values.Create";
-			this.typeDroit = TypeDroit.WRITE;
-			break;
-		case DELETE :
-			this.libelle = "securite.profil.droit.values.Delete";
-			this.typeDroit = TypeDroit.ADMIN;
-			break;
-		case READ :
-			this.libelle = "securite.profil.droit.values.Read";
-			this.typeDroit = TypeDroit.READ;
-			break;
-		case UPDATE :
-			this.libelle = "securite.profil.droit.values.Update";
-			this.typeDroit = TypeDroit.WRITE;
-			break;
-		}
+		this.libelle = code.getLibelle();
+		this.typeDroit = code.getTypeDroit() != null ? new TypeDroit(code.getTypeDroit()) : null;
 	}
 
 	/**
@@ -130,9 +114,9 @@ public class Droit {
         LIBELLE(String.class), //
         TYPE_DROIT(TypeDroit.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Profil.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Profil.java
@@ -207,9 +207,9 @@ public class Profil {
         DATE_MODIFICATION(LocalDateTime.class), //
         UTILISATEURS(Utilisateur.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/TypeDroit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/TypeDroit.java
@@ -63,17 +63,7 @@ public class TypeDroit {
 	 */
 	public TypeDroit(TypeDroitCode code) {
 		this.code = code;
-		switch(code) {
-		case ADMIN :
-			this.libelle = "securite.profil.typeDroit.values.Admin";
-			break;
-		case READ :
-			this.libelle = "securite.profil.typeDroit.values.Read";
-			break;
-		case WRITE :
-			this.libelle = "securite.profil.typeDroit.values.Write";
-			break;
-		}
+		this.libelle = code.getLibelle();
 	}
 
 	/**
@@ -101,9 +91,9 @@ public class TypeDroit {
         CODE(TypeDroitCode.class), //
         LIBELLE(String.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
@@ -63,17 +63,7 @@ public class TypeUtilisateur {
 	 */
 	public TypeUtilisateur(TypeUtilisateurCode code) {
 		this.code = code;
-		switch(code) {
-		case ADMIN :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Admin";
-			break;
-		case CLIENT :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Client";
-			break;
-		case GEST :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Gestionnaire";
-			break;
-		}
+		this.libelle = code.getLibelle();
 	}
 
 	/**
@@ -101,9 +91,9 @@ public class TypeUtilisateur {
         CODE(TypeUtilisateurCode.class), //
         LIBELLE(String.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/Utilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/Utilisateur.java
@@ -312,9 +312,9 @@ public class Utilisateur {
         DATE_CREATION(LocalDateTime.class), //
         DATE_MODIFICATION(LocalDateTime.class);
 
-		private Class<?> type;
+		private final Class<?> type;
 
-		private Fields(Class<?> type) {
+		Fields(Class<?> type) {
 			this.type = type;
 		}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
@@ -11,17 +11,48 @@ public enum DroitCode {
 	/**
 	 * Création.
 	 */
-	CREATE,
-	/**
-	 * Suppression.
-	 */
-	DELETE,
+	CREATE("securite.profil.droit.values.Create", TypeDroitCode.WRITE), 
 	/**
 	 * Lecture.
 	 */
-	READ,
+	READ("securite.profil.droit.values.Read", TypeDroitCode.READ), 
 	/**
 	 * Mise à jour.
 	 */
-	UPDATE
+	UPDATE("securite.profil.droit.values.Update", TypeDroitCode.WRITE), 
+	/**
+	 * Suppression.
+	 */
+	DELETE("securite.profil.droit.values.Delete", TypeDroitCode.ADMIN); 
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+
+	/**
+	 * TypeDroit.
+	 */
+	private final TypeDroitCode typeDroit;
+	/**
+	 * Enum constructor.
+	 */
+	DroitCode(final String libelle ,final TypeDroitCode typeDroit ){
+		 this.libelle = libelle;
+		 this.typeDroit = typeDroit;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public String getLibelle(){
+		return this.libelle;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public TypeDroitCode getTypeDroit(){
+		return this.typeDroit;
+	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
@@ -33,13 +33,13 @@ public enum DroitCode {
 	/**
 	 * TypeDroit.
 	 */
-	private final TypeDroitCode typeDroit;
+	private final TypeDroitCode typeDroitCode;
 	/**
 	 * Enum constructor.
 	 */
-	DroitCode(final String libelle ,final TypeDroitCode typeDroit ){
+	DroitCode(final String libelle ,final TypeDroitCode typeDroitCode ){
 		 this.libelle = libelle;
-		 this.typeDroit = typeDroit;
+		 this.typeDroitCode = typeDroitCode;
 	}
 
 	/**
@@ -52,7 +52,7 @@ public enum DroitCode {
 	/**
 	 * Getter.
 	 */
-	public TypeDroitCode getTypeDroit(){
-		return this.typeDroit;
+	public TypeDroitCode getTypeDroitCode(){
+		return this.typeDroitCode;
 	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitCode.java
@@ -9,15 +9,33 @@ package topmodel.jpa.sample.demo.enums.securite.profil;
  */
 public enum TypeDroitCode {
 	/**
-	 * Administration.
-	 */
-	ADMIN,
-	/**
 	 * Lecture.
 	 */
-	READ,
+	READ("securite.profil.typeDroit.values.Read"), 
 	/**
 	 * Ecriture.
 	 */
-	WRITE
+	WRITE("securite.profil.typeDroit.values.Write"), 
+	/**
+	 * Administration.
+	 */
+	ADMIN("securite.profil.typeDroit.values.Admin"); 
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+	/**
+	 * Enum constructor.
+	 */
+	TypeDroitCode(final String libelle ){
+		 this.libelle = libelle;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public String getLibelle(){
+		return this.libelle;
+	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurCode.java
@@ -11,13 +11,31 @@ public enum TypeUtilisateurCode {
 	/**
 	 * Administrateur.
 	 */
-	ADMIN,
-	/**
-	 * Client.
-	 */
-	CLIENT,
+	ADMIN("securite.utilisateur.typeUtilisateur.values.Admin"), 
 	/**
 	 * Gestionnaire.
 	 */
-	GEST
+	GEST("securite.utilisateur.typeUtilisateur.values.Gestionnaire"), 
+	/**
+	 * Client.
+	 */
+	CLIENT("securite.utilisateur.typeUtilisateur.values.Client"); 
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+	/**
+	 * Enum constructor.
+	 */
+	TypeUtilisateurCode(final String libelle ){
+		 this.libelle = libelle;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public String getLibelle(){
+		return this.libelle;
+	}
 }

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.1.2
 custom:
-  ../../../TopModel.Generator.Jpa: 0cb6ca08aebf5b6bd3e7ad6858854160
+  ../../../TopModel.Generator.Jpa: b33f821a19a58bf955992b62067567d2
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.1.2
 custom:
-  ../../../TopModel.Generator.Jpa: 3507a5e9995725086a8473dfef9acf32
+  ../../../TopModel.Generator.Jpa: 0cb6ca08aebf5b6bd3e7ad6858854160
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.1.2
 custom:
-  ../../../TopModel.Generator.Jpa: b1ab441870ce2af095217a3622f3f615
+  ../../../TopModel.Generator.Jpa: 3507a5e9995725086a8473dfef9acf32
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
Permet d'avoir toutes les données statiques dans l’énumération.
Attention, le tri des values a été supprimé pour respecter l'ordre dans les fichiers TMD, ceci afin de permettre la gestion des cycles (par exemple les parents).
La régression attendue peut se produire pour les projets qui utilisent l'ordinal de l'enum comme PK (comportement par defaut d'hibernate), mais il est préférable dans ce cas que le projet gère l'ordre, la solution étant donc de trier les values dans le TMD.

   

```
     var refs = GetAllValues(classe)
 --           .OrderBy(x => x.Name, StringComparer.Ordinal)
            .ToList();
```