### PR TITLE
Fix #373 : [JAVA] Enumérations représentant totalement l'entité #373

### DIFF
--- a/TopModel.Generator.Jpa/ClassGeneration/JavaDtoGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaDtoGenerator.cs
@@ -57,7 +57,7 @@ public class JavaDtoGenerator : JavaClassGeneratorBase
 
         fw.WriteClassDeclaration(classe.NamePascal, null, extends, implements);
 
-        WriteStaticMembers(fw, classe);
+        WriteStaticMembers(fw, classe, tag);
         JpaModelPropertyGenerator.WriteProperties(fw, classe, tag);
         WriteConstuctors(fw, classe, tag);
 
@@ -92,7 +92,7 @@ public class JavaDtoGenerator : JavaClassGeneratorBase
         }
     }
 
-    protected virtual void WriteStaticMembers(JavaWriter fw, Class classe)
+    protected virtual void WriteStaticMembers(JavaWriter fw, Class classe, string tag)
     {
         fw.WriteLine("	/** Serial ID */");
         fw.WriteLine(1, "private static final long serialVersionUID = 1L;");

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
@@ -33,7 +33,8 @@ public class JavaEnumConstructorGenerator : JavaConstructorGenerator
         foreach (var refValue in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
         {
             var code = refValue.Name.ToConstantCase();
-            method.AddBodyLine(1, $@"case {code} -> {code};");
+            var codeRef = refValue.Value[classe.EnumKey!].ToConstantCase();
+            method.AddBodyLine(1, $@"case {codeRef} -> {code};");
         }
 
         method.AddBodyLine("};");

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using TopModel.Core;
 using TopModel.Generator.Core;
+using TopModel.Utils;
 
 namespace TopModel.Generator.Jpa;
 
@@ -13,59 +14,62 @@ public class JavaEnumConstructorGenerator : JavaConstructorGenerator
     {
     }
 
-    public void WriteEnumConstructor(JavaWriter fw, Class classe, IEnumerable<Class> availableClasses, string tag)
+    public void WriteEnumCodeFinder(JavaWriter fw, Class classe, string tag)
+    {
+        var codeProperty = classe.EnumKey!;
+        fw.WriteLine();
+        fw.WriteDocStart(1, "Enum code finder");
+        fw.WriteParam(classe.EnumKey!.NameCamel, "Code dont on veut obtenir l'instance");
+        fw.WriteDocEnd(1);
+        var method = new JavaMethod(classe.NamePascal, "from")
+        {
+            Static = true,
+            Visibility = "public",
+        };
+        var param = new JavaMethodParameter(Config.GetType(classe.EnumKey!), codeProperty.Name.ToCamelCase());
+        method.AddParameter(param);
+
+        method.AddBodyLine($@"return switch ({param.Name}) {{");
+        foreach (var refValue in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            var code = refValue.Name.ToConstantCase();
+            method.AddBodyLine(1, $@"case {code} -> {code};");
+        }
+
+        method.AddBodyLine("};");
+
+        fw.Write(1, method);
+    }
+
+    public void WriteEnumValueConstructor(JavaWriter fw, Class classe, IEnumerable<Class> availableClasses, string tag)
     {
         var codeProperty = classe.EnumKey!;
         fw.WriteLine();
         fw.WriteDocStart(1, "Enum constructor");
-        fw.WriteParam(classe.EnumKey!.NameCamel, "Code dont on veut obtenir l'instance");
+        fw.WriteParam($"{classe.NameCamel}{Config.EnumValueSuffix}", "Enum de valeur dont on veut obtenir l'entité");
         fw.WriteDocEnd(1);
-        fw.WriteLine(1, $"public {classe.NamePascal}({Config.GetType(classe.EnumKey!)} {classe.EnumKey!.NameCamel}) {{");
+        fw.WriteLine(1, $"public {classe.NamePascal}({classe.NamePascal}{Config.EnumValueSuffix} {classe.NameCamel}{Config.EnumValueSuffix}) {{");
         if (classe.Extends != null || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
         {
             fw.WriteLine(2, $"super();");
         }
 
-        fw.WriteLine(2, $@"this.{classe.EnumKey!.NameCamel} = {classe.EnumKey!.NameCamel};");
-        if (classe.GetProperties(availableClasses).Count > 1)
+        foreach (var prop in classe.Properties)
         {
-            fw.WriteLine(2, $@"switch({classe.EnumKey!.NameCamel}) {{");
-            foreach (var refValue in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
+            var value = $"{classe.NameCamel}{Config.EnumValueSuffix}.get{prop.NameByClassPascal}()";
+            if (prop is AssociationProperty ap && Config.CanClassUseEnums(ap.Association, prop: ap.Property))
             {
-                var code = refValue.Value[codeProperty];
-                fw.WriteLine(2, $@"case {code} :");
-                foreach (var prop in classe.GetProperties(availableClasses).Where(p => p != codeProperty))
-                {
-                    var isString = Config.GetType(prop) == "String";
-                    var value = refValue.Value.ContainsKey(prop) ? refValue.Value[prop] : "null";
-                    if (value == "null")
-                    {
-                        isString = false;
-                    }
-                    else if (prop is AssociationProperty ap && Config.CanClassUseEnums(ap.Association, prop: ap.Property) && ap.Association.Values.Any(r => r.Value.ContainsKey(ap.Property) && r.Value[ap.Property] == value))
-                    {
-                        value = ap.Association.NamePascal + "." + value;
-                        isString = false;
-                        fw.AddImport(ap.Association.GetImport(Config, tag));
-                    }
-                    else if (prop is AliasProperty alp && Config.CanClassUseEnums(alp.Property.Class, prop: alp.Property))
-                    {
-                        value = Config.GetType(alp.Property) + "." + value;
-                    }
-                    else if (Config.TranslateReferences == true && classe.DefaultProperty == prop && !Config.CanClassUseEnums(classe, prop: prop))
-                    {
-                        value = refValue.ResourceKey;
-                    }
-
-                    var quote = isString ? "\"" : string.Empty;
-                    var val = quote + value + quote;
-                    fw.WriteLine(3, $@"this.{prop.NameByClassCamel} = {val};");
-                }
-
-                fw.WriteLine(3, $@"break;");
+                value = $"new {ap.Association.NamePascal}({classe.NameCamel}{Config.EnumValueSuffix}.get{prop.NameByClassPascal}{Config.EnumValueSuffix}())";
+                fw.AddImport(ap.Association.GetImport(Config, tag));
+                fw.AddImport($"{Config.GetEnumValuePackageName(ap.Association, tag)}.{ap.Association.NamePascal}{Config.EnumValueSuffix}");
+                fw.WriteLine(2, $@"if ({classe.NameCamel}{Config.EnumValueSuffix}.get{prop.NameByClassPascal}{Config.EnumValueSuffix}() != null) {{");
+                fw.WriteLine(3, $@"this.{prop.NameByClassCamel} = {value};");
+                fw.WriteLine(2, "}");
             }
-
-            fw.WriteLine(2, $@"}}");
+            else
+            {
+                fw.WriteLine(2, $@"this.{prop.NameByClassCamel} = {value};");
+            }
         }
 
         fw.WriteLine(1, $"}}");

--- a/TopModel.Generator.Jpa/ClassGeneration/JdbcEntityGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JdbcEntityGenerator.cs
@@ -107,7 +107,7 @@ public class JdbcEntityGenerator : JavaClassGeneratorBase
 
         if (Config.CanClassUseEnums(classe, Classes))
         {
-            ConstructorGenerator.WriteEnumConstructor(fw, classe, Classes, tag);
+            ConstructorGenerator.WriteEnumCodeFinder(fw, classe, tag);
         }
 
         WriteGetters(fw, classe, tag);

--- a/TopModel.Generator.Jpa/ClassGeneration/JdbcModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JdbcModelPropertyGenerator.cs
@@ -27,13 +27,9 @@ public class JdbcModelPropertyGenerator(JpaConfig config, IEnumerable<Class> cla
         return _config.GetType(property, _classes, false);
     }
 
-    public override void WriteProperties(JavaWriter fw, Class classe, string tag)
+    public override IList<IProperty> GetProperties(Class classe)
     {
-        var properties = classe.Properties.Where(p => !(p is AssociationProperty ap && (ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany)));
-        foreach (var property in properties)
-        {
-            WriteProperty(fw, property, tag);
-        }
+        return classe.Properties.Where(p => !(p is AssociationProperty ap && (ap.Type == AssociationType.OneToMany || ap.Type == AssociationType.ManyToMany))).ToList();
     }
 
     protected override IEnumerable<JavaAnnotation> GetAnnotations(AliasProperty property, string tag)

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEnumValuesGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEnumValuesGenerator.cs
@@ -1,0 +1,217 @@
+﻿using Microsoft.Extensions.Logging;
+using TopModel.Core;
+using TopModel.Core.FileModel;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+
+namespace TopModel.Generator.Jpa;
+
+/// <summary>
+/// Générateur de fichiers de modèles JPA.
+/// </summary>
+public class JpaEnumValuesGenerator : GeneratorBase<JpaConfig>
+{
+    private readonly ILogger<JpaEnumValuesGenerator> _logger;
+
+    public JpaEnumValuesGenerator(ILogger<JpaEnumValuesGenerator> logger, ModelConfig modelConfig)
+        : base(logger)
+    {
+        _logger = logger;
+    }
+
+    public override string Name => "JpaEnumValuesGen";
+
+    public override IEnumerable<string> GeneratedFiles => Files
+        .Values
+        .SelectMany(f => f.Classes.Where(FilterClass))
+        .SelectMany(c => Config.Tags.Intersect(c.Tags).SelectMany(tag => GetEnumProperties(c).Select(p => GetFileName(p, c, tag)))).Distinct();
+
+    protected bool FilterClass(Class classe)
+    {
+        return !classe.Abstract
+            && Config.CanClassUseEnums(classe, Classes.ToList())
+            && GetAllValues(classe).All(v => Config.IsEnumNameJavaValid(v.Name));
+    }
+
+    protected string GetFileName(IProperty property, Class classe, string tag)
+    {
+        return Config.GetEnumValueFileName(property, classe, tag);
+    }
+
+    protected void HandleClass(Class classe, string tag)
+    {
+        foreach (var p in GetEnumProperties(classe))
+        {
+            WriteEnum(p, classe, tag);
+        }
+    }
+
+    protected override void HandleFiles(IEnumerable<ModelFile> files)
+    {
+        foreach (var file in files)
+        {
+            foreach (var classe in file.Classes.Where(FilterClass))
+            {
+                foreach (var tag in Config.Tags.Intersect(classe.Tags))
+                {
+                    HandleClass(classe, tag);
+                }
+            }
+        }
+    }
+
+    private IEnumerable<IProperty> GetEnumProperties(Class classe)
+    {
+        List<IProperty> result = new();
+        if (classe.EnumKey != null && Config.CanClassUseEnums(classe, prop: classe.EnumKey) && !(classe.Extends != null && Config.CanClassUseEnums(classe.Extends, Classes, prop: classe.EnumKey)))
+        {
+            result.Add(classe.EnumKey);
+        }
+
+        var uks = classe.UniqueKeys.Where(uk => uk.Count == 1 && Config.CanClassUseEnums(classe, Classes, uk.Single()) && !(classe.Extends != null && Config.CanClassUseEnums(classe.Extends, Classes, prop: classe.EnumKey))).Select(uk => uk.Single());
+        result.AddRange(uks);
+        return result;
+    }
+
+    private void WriteConstructor(Class classe, JavaWriter fw, IEnumerable<IProperty> properties)
+    {
+        // Constructeur
+        fw.WriteDocStart(1, "Enum values constructor");
+        fw.WriteDocEnd(1);
+        var constructor = new JavaConstructor(classe.NamePascal + Config.EnumValueSuffix) { Visibility = "private" };
+        var methodParams = properties.Select((prop, index) =>
+            {
+                var fieldName = prop.NameByClassCamel;
+                var fieldType = Config.GetType(prop);
+                if (prop is AssociationProperty ap)
+                {
+                    fieldName = $"{ap.NameByClassCamel}{Config.EnumValueSuffix}";
+                    fieldType = $"{ap.Association.NamePascal}{Config.EnumValueSuffix}";
+                }
+
+                return new JavaMethodParameter(fieldType, fieldName) { Final = true };
+            });
+        constructor.AddParameters(methodParams);
+        fw.Write(1, constructor);
+    }
+
+    private void WriteEnum(IProperty property, Class classe, string tag)
+    {
+        var packageName = Config.GetEnumValuePackageName(classe, tag);
+        using var fw = new JavaWriter(Config.GetEnumValueFileName(property, classe, tag), _logger, packageName, null);
+        fw.WriteLine();
+        var codeProperty = classe.EnumKey!;
+        fw.WriteDocStart(0, $"Enumération des valeurs possibles de la classe {classe.NamePascal}");
+        fw.WriteDocEnd(0);
+        fw.WriteLine($@"public enum {classe.NamePascal}{Config.EnumValueSuffix} {{");
+        var i = 0;
+
+        var refs = GetAllValues(classe)
+            .ToList();
+
+        foreach (var refValue in refs)
+        {
+            if (i > 0)
+            {
+                fw.WriteLine();
+            }
+
+            i++;
+            var isLast = i == refs.Count();
+            if (classe.DefaultProperty != null)
+            {
+                fw.WriteDocStart(1, $"{refValue.Value[classe.DefaultProperty]}");
+                fw.WriteDocEnd(1);
+            }
+
+            List<string> enumAsString = [$"{refValue.Name.ToConstantCase()}("];
+            foreach (var prop in classe.Properties)
+            {
+                var isString = Config.GetType(prop) == "String";
+                var isInt = Config.GetType(prop) == "int";
+                var isBoolean = Config.GetType(prop) == "Boolean";
+                var value = refValue.Value.ContainsKey(prop) ? refValue.Value[prop] : "null";
+
+                if (prop is AssociationProperty ap && ap.Association.Values.Any(r => r.Value.ContainsKey(ap.Property) && r.Value[ap.Property] == value))
+                {
+                    fw.AddImport($"{Config.GetEnumValuePackageName(ap.Association.EnumKey!.Class, tag)}.{ap.Association.NamePascal}{Config.EnumValueSuffix}");
+                    value = ap.Association.NamePascal + "Enum." + value;
+                    isString = false;
+                }
+                else if (Config.CanClassUseEnums(classe, prop: prop))
+                {
+                    value = Config.GetType(prop) + "." + value;
+                }
+
+                if (Config.TranslateReferences == true && classe.DefaultProperty == prop && !Config.CanClassUseEnums(classe, prop: prop))
+                {
+                    value = refValue.ResourceKey;
+                }
+
+                var quote = isString ? "\"" : string.Empty;
+                var val = quote + value + quote;
+                enumAsString.Add($@"{val}{(prop == classe.Properties.Last() ? string.Empty : ", ")}");
+            }
+
+            enumAsString.Add($"){(isLast ? ";" : ",")} ");
+            fw.WriteLine(1, enumAsString.Aggregate(string.Empty, (acc, curr) => acc + curr));
+        }
+
+        foreach (var prop in classe.Properties)
+        {
+            fw.WriteLine();
+            fw.WriteDocStart(1, $@"{prop.NameByClassPascal}");
+            fw.WriteDocEnd(1);
+            var fieldName = prop.NameByClassCamel;
+            if (prop is AssociationProperty ap)
+            {
+                fieldName = $"{ap.NameByClassCamel}{Config.EnumValueSuffix}";
+                fw.WriteLine(1, $@"private final {ap.Association.NamePascal}{Config.EnumValueSuffix} {fieldName};");
+            }
+            else
+            {
+                fw.WriteLine(1, $@"private final {Config.GetType(prop)} {fieldName};");
+            }
+        }
+
+        fw.WriteLine();
+        WriteConstructor(classe, fw, classe.Properties);
+
+        foreach (var prop in classe.Properties)
+        {
+            fw.WriteLine();
+            var fieldName = prop.NameByClassCamel;
+            fw.WriteDocStart(1, $"Getter for {fieldName}");
+            fw.WriteDocEnd(1);
+            var fieldType = Config.GetType(prop);
+            if (prop is AssociationProperty ap && Config.CanClassUseEnums(ap.Association, Classes))
+            {
+                fieldName = $"{ap.NameByClassCamel}{Config.EnumValueSuffix}";
+                fieldType = $"{ap.Association.NamePascal}{Config.EnumValueSuffix}";
+            }
+
+            var method = new JavaMethod(fieldType, $"get{fieldName.ToFirstUpper()}") { Visibility = "public" };
+            method.AddBodyLine($@"return this.{fieldName};");
+            fw.Write(1, method);
+        }
+
+        fw.WriteLine();
+        WriteFromCode(fw, classe);
+
+        fw.WriteLine("}");
+    }
+
+    private void WriteFromCode(JavaWriter fw, Class classe)
+    {
+        var method = new JavaMethod($"{classe.NamePascal}{Config.EnumValueSuffix}", "from") { Visibility = "public", Static = true };
+        var codeProperty = classe.EnumKey!;
+        method.AddParameter(new JavaMethodParameter(Config.GetEnumName(codeProperty, classe), codeProperty.NameCamel));
+        method.Imports.Add("java.util.Arrays");
+        method.AddBodyLine($"return Arrays.stream({classe.NamePascal}{Config.EnumValueSuffix}.values()).filter(t -> t.get{codeProperty.NamePascal}() == {codeProperty.NameCamel}).findFirst().orElseThrow();");
+
+        fw.WriteLine();
+        fw.WriteDocStart(1, $"Get Enum from pk");
+        fw.WriteDocEnd(1);
+        fw.Write(1, method);
+    }
+}

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
@@ -234,7 +234,7 @@ public class JpaModelPropertyGenerator
     {
         var shouldWriteAssociation = property.Class.IsPersistent
             && property.Property is AssociationProperty ap
-            && !(_config.EnumsAsEnums && _config.CanClassUseEnums(ap.Association));
+            && !(_config.EnumsAsEnums && ap.Association.Values.Any());
         if (property.PrimaryKey && property.Class.IsPersistent)
         {
             foreach (var a in GetIdAnnotations(property))
@@ -278,7 +278,7 @@ public class JpaModelPropertyGenerator
     {
         if (property.Class.IsPersistent)
         {
-            if (_config.CanClassUseEnums(property.Association) && _config.EnumsAsEnums)
+            if (property.Association.Values.Any() && _config.EnumsAsEnums)
             {
                 yield return GetColumnAnnotation(property);
             }
@@ -392,14 +392,14 @@ public class JpaModelPropertyGenerator
 
     private string GetDefaultValue(IProperty property)
     {
+        var defaultValue = _config.GetValue(property, _classes);
         if (property is AssociationProperty ap)
         {
             if (ap.Association.PrimaryKey.Count() == 1 && _config.CanClassUseEnums(ap.Association, _classes, prop: ap.Association.PrimaryKey.Single()))
             {
-                var defaultValue = _config.GetValue(property, _classes);
                 if (defaultValue != "null")
                 {
-                    return $" = new {ap.Association.NamePascal}({defaultValue})";
+                    return $" = {ap.Association.NamePascal}.from({defaultValue})";
                 }
             }
 
@@ -407,7 +407,6 @@ public class JpaModelPropertyGenerator
         }
         else
         {
-            var defaultValue = _config.GetValue(property, _classes);
             var suffix = defaultValue != "null" ? $" = {defaultValue}" : string.Empty;
             return suffix;
         }

--- a/TopModel.Generator.Jpa/GeneratorRegistration.cs
+++ b/TopModel.Generator.Jpa/GeneratorRegistration.cs
@@ -10,10 +10,16 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
     /// <inheritdoc cref="IGeneratorRegistration{T}.Register" />
     public void Register(IServiceCollection services, JpaConfig config, int number)
     {
+        if (config.EnumsValuesPath == "default")
+        {
+            config.EnumsValuesPath = config.EnumsPath;
+        }
+
         TrimSlashes(config, c => c.EntitiesPath);
         TrimSlashes(config, c => c.DaosPath);
         TrimSlashes(config, c => c.DtosPath);
         TrimSlashes(config, c => c.EnumsPath);
+        TrimSlashes(config, c => c.EnumsValuesPath);
         TrimSlashes(config, c => c.ApiPath);
         TrimSlashes(config, c => c.ResourcesPath);
 
@@ -34,6 +40,7 @@ public class GeneratorRegistration : IGeneratorRegistration<JpaConfig>
         services.AddGenerator<JpaModelInterfaceGenerator, JpaConfig>(config, number);
         services.AddGenerator<JpaMapperGenerator, JpaConfig>(config, number);
         services.AddGenerator<JpaEnumGenerator, JpaConfig>(config, number);
+        services.AddGenerator<JpaEnumValuesGenerator, JpaConfig>(config, number);
         if (config.DaosPath != null)
         {
             services.AddGenerator<JpaDaoGenerator, JpaConfig>(config, number);

--- a/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
+++ b/TopModel.Generator.Jpa/ImportsJpaExtensions.cs
@@ -53,7 +53,13 @@ public static class ImportsJpaExtensions
         var imports = new List<string>();
 
         imports.AddRange(config.GetDomainImports(ap, config.GetBestClassTag(ap.Association, tag)));
-        if (!config.UseJdbc && ap.Class != null && ap.Association.IsPersistent)
+        if (config.CanClassUseEnums(ap.Association) && config.EnumsAsEnums)
+        {
+            imports.Add($"{config.GetEnumValuePackageName(ap.Association, config.GetBestClassTag(ap.Association, tag))}.{ap.Association.NamePascal}{config.EnumValueSuffix}");
+        }
+        else if (!config.UseJdbc
+            && ap.Class != null
+            && ap.Association.IsPersistent)
         {
             imports.Add(ap.Association.GetImport(config, config.GetBestClassTag(ap.Association, tag)));
         }

--- a/TopModel.Generator.Jpa/JavaConstructor.cs
+++ b/TopModel.Generator.Jpa/JavaConstructor.cs
@@ -1,0 +1,19 @@
+namespace TopModel.Generator.Jpa;
+
+public class JavaConstructor : JavaMethod
+{
+    public JavaConstructor(string returnType)
+        : base(returnType, string.Empty)
+    {
+    }
+
+    public override string Signature => $@"{(!string.IsNullOrEmpty(Visibility) ? $"{Visibility} " : string.Empty)}{(GenericTypes.Count() > 0 ? $"<{string.Join(", ", GenericTypes)}> " : string.Empty)}{ReturnType}({string.Join(", ", Parameters.Select(p => p.Declaration))})";
+
+    public override JavaMethod AddParameter(JavaMethodParameter parameter)
+    {
+        Imports.AddRange(parameter.Imports);
+        Parameters.Add(parameter);
+        AddBodyLine($@"this.{parameter.Name} = {parameter.Name};");
+        return this;
+    }
+}

--- a/TopModel.Generator.Jpa/JavaMethod.cs
+++ b/TopModel.Generator.Jpa/JavaMethod.cs
@@ -23,19 +23,19 @@ public class JavaMethod
 
     public List<string> Imports { get; } = new();
 
-    public string Signature => $@"{_visibility}{(GenericTypes.Count() > 0 ? $"<{string.Join(", ", GenericTypes)}> " : string.Empty)}{ReturnType} {Name}({string.Join(", ", Parameters.Select(p => p.Declaration))})";
+    public virtual string Signature => $@"{(!string.IsNullOrEmpty(Visibility) ? $"{Visibility} " : string.Empty)}{(Static ? "static " : string.Empty)}{(GenericTypes.Count() > 0 ? $"<{string.Join(", ", GenericTypes)}> " : string.Empty)}{ReturnType} {Name}({string.Join(", ", Parameters.Select(p => p.Declaration))})";
 
-    public string Visibility { get => this._visibility.Trim(); set => _visibility = string.IsNullOrEmpty(value) ? string.Empty : $"{value} "; }
+    public string Visibility { get; set; } = string.Empty;
 
-    private string _visibility { get; set; } = string.Empty;
+    public bool Static { get; set; }
 
-    private string Name { get; }
+    protected string Name { get; }
 
-    private string ReturnType { get; }
+    protected string ReturnType { get; }
 
-    private List<string> GenericTypes { get; } = new();
+    protected List<string> GenericTypes { get; } = new();
 
-    private List<JavaMethodParameter> Parameters { get; } = new();
+    protected List<JavaMethodParameter> Parameters { get; } = new();
 
     public JavaMethod AddAnnotation(JavaAnnotation annotation)
     {
@@ -62,10 +62,25 @@ public class JavaMethod
         return this;
     }
 
-    public JavaMethod AddParameter(JavaMethodParameter parameter)
+    public virtual JavaMethod AddParameter(JavaMethodParameter parameter)
     {
         Imports.AddRange(parameter.Imports);
         Parameters.Add(parameter);
         return this;
+    }
+
+    public JavaMethod AddParameters(IEnumerable<JavaMethodParameter> parameters)
+    {
+        foreach (var parameter in parameters)
+        {
+            AddParameter(parameter);
+        }
+
+        return this;
+    }
+
+    public string CallWith(params string[] parameters)
+    {
+        return $"{Name}{string.Join(", ", parameters)}";
     }
 }

--- a/TopModel.Generator.Jpa/JavaMethodParameter.cs
+++ b/TopModel.Generator.Jpa/JavaMethodParameter.cs
@@ -15,15 +15,17 @@ public class JavaMethodParameter
         Imports.Add(import);
     }
 
-    public string Declaration => $@"{string.Join(' ', Annotations)}{(Annotations.Count() > 0 ? ' ' : string.Empty)}{Type} {Name}";
+    public string Declaration => $@"{(Final ? "final " : string.Empty)}{string.Join(' ', Annotations)}{(Annotations.Count() > 0 ? ' ' : string.Empty)}{Type} {Name}";
 
     public List<string> Imports { get; } = new();
 
     public List<JavaAnnotation> Annotations { get; } = new();
 
-    private string Name { get; }
+    public bool Final { get; set; } = false;
 
-    private string Type { get; }
+    public string Name { get; }
+
+    private string Type { get; set; }
 
     public JavaMethodParameter AddAnnotation(JavaAnnotation annotation)
     {

--- a/TopModel.Generator.Jpa/JavaWriter.cs
+++ b/TopModel.Generator.Jpa/JavaWriter.cs
@@ -51,27 +51,6 @@ public class JavaWriter : IDisposable
     }
 
     /// <summary>
-    /// Ecrit l'annotation avec le niveau indenté.
-    /// </summary>
-    /// <param name="indentationLevel">Niveau d'indentation.</param>
-    /// <param name="javaAnnotation">Valeur à écrire dans le flux.</param>
-    public void WriteLine(int indentationLevel, JavaAnnotation javaAnnotation)
-    {
-        AddImports(javaAnnotation.Imports);
-        _toWrite.Add(new WriterLine() { Line = javaAnnotation.ToString(), Indent = indentationLevel });
-    }
-
-    /// <summary>
-    /// Ecrit l'annotation avec le niveau indenté.
-    /// </summary>
-    /// <param name="javaAnnotation">Valeur à écrire dans le flux.</param>
-    public void WriteLine(JavaAnnotation javaAnnotation)
-    {
-        AddImports(javaAnnotation.Imports);
-        _toWrite.Add(new WriterLine() { Line = javaAnnotation.ToString(), Indent = 0 });
-    }
-
-    /// <summary>
     /// Ecrit la signature de méthode avec le niveau indenté.
     /// </summary>
     /// <param name="indentationLevel">Niveau d'indentation.</param>
@@ -163,6 +142,27 @@ public class JavaWriter : IDisposable
         {
             WriteLine(indentationLevel, LoadDocStart(value));
         }
+    }
+
+    /// <summary>
+    /// Ecrit l'annotation avec le niveau indenté.
+    /// </summary>
+    /// <param name="indentationLevel">Niveau d'indentation.</param>
+    /// <param name="javaAnnotation">Valeur à écrire dans le flux.</param>
+    public void WriteLine(int indentationLevel, JavaAnnotation javaAnnotation)
+    {
+        AddImports(javaAnnotation.Imports);
+        _toWrite.Add(new WriterLine() { Line = javaAnnotation.ToString(), Indent = indentationLevel });
+    }
+
+    /// <summary>
+    /// Ecrit l'annotation avec le niveau indenté.
+    /// </summary>
+    /// <param name="javaAnnotation">Valeur à écrire dans le flux.</param>
+    public void WriteLine(JavaAnnotation javaAnnotation)
+    {
+        AddImports(javaAnnotation.Imports);
+        _toWrite.Add(new WriterLine() { Line = javaAnnotation.ToString(), Indent = 0 });
     }
 
     /// <summary>

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -189,7 +189,8 @@ public class JpaConfig : GeneratorConfigBase
 
     public override bool CanClassUseEnums(Class classe, IEnumerable<Class>? availableClasses = null, IProperty? prop = null)
     {
-        return !UseJdbc && base.CanClassUseEnums(classe, availableClasses, prop)
+        return !UseJdbc
+            && base.CanClassUseEnums(classe, availableClasses, prop)
             && !classe.Properties.OfType<AssociationProperty>().Any(a => a.Association != classe && !CanClassUseEnums(a.Association, availableClasses));
     }
 
@@ -264,7 +265,7 @@ public class JpaConfig : GeneratorConfigBase
         return GetPackageName(classe.Namespace, EnumsPath, tag);
     }
 
-    public string GetEnumValueFileName(IProperty property, Class classe, string tag)
+    public string GetEnumValueFileName(Class classe, string tag)
     {
         return Path.Combine(
             OutputDirectory,
@@ -361,7 +362,7 @@ public class JpaConfig : GeneratorConfigBase
 
     protected override string GetConstEnumName(string className, string refName)
     {
-        return $"{className.ToPascalCase()}.Values.{refName}";
+        return EnumsAsEnums ? refName : $"{className.ToPascalCase()}.Values.{refName}";
     }
 
     protected override string GetEnumType(string className, string propName, bool isPrimaryKeyDef = false)

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -91,6 +91,16 @@
       "description": "Localisation des enums du modèle, relative au répertoire de génération.",
       "default": "javagen:{app}/enums/{module}"
     },
+    "enumsValuesPath": {
+      "type": "string",
+      "description": "Localisation des enums de valeur du modèle, relative au répertoire de génération.",
+      "default": "javagen:{app}/enums/{module}"
+    },
+    "enumsAsEnums": {
+      "type": "boolean",
+      "description": "Transforme les classes contenant des values en enum. Par défaut, false",
+      "default": "false"
+    },
     "apiPath": {
       "type": "string",
       "description": "Localisation du l'API générée (client ou serveur), relative au répertoire de génération. Par défaut, 'javagen:{app}/api/{module}'.",

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Droit.java
@@ -21,6 +21,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
 import topmodel.jpa.sample.demo.enums.securite.profil.DroitCode;
+import topmodel.jpa.sample.demo.enums.securite.profil.DroitEnum;
+import topmodel.jpa.sample.demo.enums.securite.profil.TypeDroitEnum;
 
 /**
  * Droits de l'application.
@@ -33,13 +35,13 @@ import topmodel.jpa.sample.demo.enums.securite.profil.DroitCode;
 public class Droit {
 
 	@Transient
-	public static final Droit CREATE = new Droit(DroitCode.CREATE);
+	public static final Droit CREATE = new Droit(DroitEnum.CREATE);
 	@Transient
-	public static final Droit DELETE = new Droit(DroitCode.DELETE);
+	public static final Droit DELETE = new Droit(DroitEnum.DELETE);
 	@Transient
-	public static final Droit READ = new Droit(DroitCode.READ);
+	public static final Droit READ = new Droit(DroitEnum.READ);
 	@Transient
-	public static final Droit UPDATE = new Droit(DroitCode.UPDATE);
+	public static final Droit UPDATE = new Droit(DroitEnum.UPDATE);
 
 	/**
 	 * Code du droit.
@@ -70,28 +72,27 @@ public class Droit {
 	}
 
 	/**
-	 * Enum constructor.
+	 * Enum code finder.
 	 * @param code Code dont on veut obtenir l'instance.
 	 */
-	public Droit(DroitCode code) {
-		this.code = code;
-		switch(code) {
-		case CREATE :
-			this.libelle = "securite.profil.droit.values.Create";
-			this.typeDroit = TypeDroit.WRITE;
-			break;
-		case DELETE :
-			this.libelle = "securite.profil.droit.values.Delete";
-			this.typeDroit = TypeDroit.ADMIN;
-			break;
-		case READ :
-			this.libelle = "securite.profil.droit.values.Read";
-			this.typeDroit = TypeDroit.READ;
-			break;
-		case UPDATE :
-			this.libelle = "securite.profil.droit.values.Update";
-			this.typeDroit = TypeDroit.WRITE;
-			break;
+	public static Droit from(DroitCode code) {
+		return switch (code) {
+			case CREATE -> CREATE;
+			case DELETE -> DELETE;
+			case READ -> READ;
+			case UPDATE -> UPDATE;
+		};
+	}
+
+	/**
+	 * Enum constructor.
+	 * @param droitEnum Enum de valeur dont on veut obtenir l'entité.
+	 */
+	public Droit(DroitEnum droitEnum) {
+		this.code = droitEnum.getCode();
+		this.libelle = droitEnum.getLibelle();
+		if (droitEnum.getTypeDroitEnum() != null) {
+			this.typeDroit = new TypeDroit(droitEnum.getTypeDroitEnum());
 		}
 	}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/SecuriteProfilMappers.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/SecuriteProfilMappers.java
@@ -84,7 +84,7 @@ public class SecuriteProfilMappers {
 		}
 
 		target.setLibelle(source.getLibelle());
-		target.setDroits(source.getDroits().stream().map(Droit::new).collect(Collectors.toList()));
+		target.setDroits(source.getDroits().stream().map(Droit::from).collect(Collectors.toList()));
 		return target;
 	}
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/TypeDroit.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/TypeDroit.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
 import topmodel.jpa.sample.demo.enums.securite.profil.TypeDroitCode;
+import topmodel.jpa.sample.demo.enums.securite.profil.TypeDroitEnum;
 
 /**
  * Type de droit.
@@ -30,11 +31,11 @@ import topmodel.jpa.sample.demo.enums.securite.profil.TypeDroitCode;
 public class TypeDroit {
 
 	@Transient
-	public static final TypeDroit ADMIN = new TypeDroit(TypeDroitCode.ADMIN);
+	public static final TypeDroit ADMIN = new TypeDroit(TypeDroitEnum.ADMIN);
 	@Transient
-	public static final TypeDroit READ = new TypeDroit(TypeDroitCode.READ);
+	public static final TypeDroit READ = new TypeDroit(TypeDroitEnum.READ);
 	@Transient
-	public static final TypeDroit WRITE = new TypeDroit(TypeDroitCode.WRITE);
+	public static final TypeDroit WRITE = new TypeDroit(TypeDroitEnum.WRITE);
 
 	/**
 	 * Code du type de droit.
@@ -58,22 +59,24 @@ public class TypeDroit {
 	}
 
 	/**
-	 * Enum constructor.
+	 * Enum code finder.
 	 * @param code Code dont on veut obtenir l'instance.
 	 */
-	public TypeDroit(TypeDroitCode code) {
-		this.code = code;
-		switch(code) {
-		case ADMIN :
-			this.libelle = "securite.profil.typeDroit.values.Admin";
-			break;
-		case READ :
-			this.libelle = "securite.profil.typeDroit.values.Read";
-			break;
-		case WRITE :
-			this.libelle = "securite.profil.typeDroit.values.Write";
-			break;
-		}
+	public static TypeDroit from(TypeDroitCode code) {
+		return switch (code) {
+			case ADMIN -> ADMIN;
+			case READ -> READ;
+			case WRITE -> WRITE;
+		};
+	}
+
+	/**
+	 * Enum constructor.
+	 * @param typeDroitEnum Enum de valeur dont on veut obtenir l'entité.
+	 */
+	public TypeDroit(TypeDroitEnum typeDroitEnum) {
+		this.code = typeDroitEnum.getCode();
+		this.libelle = typeDroitEnum.getLibelle();
 	}
 
 	/**

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/SecuriteUtilisateurMappers.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/SecuriteUtilisateurMappers.java
@@ -75,7 +75,7 @@ public class SecuriteUtilisateurMappers {
 		target.setAdresse(source.getAdresse());
 		target.setActif(source.getActif());
 		if (source.getTypeUtilisateurCode() != null) {
-			target.setTypeUtilisateur(new TypeUtilisateur(source.getTypeUtilisateurCode()));
+			target.setTypeUtilisateur(TypeUtilisateur.from(source.getTypeUtilisateurCode()));
 		}
 
 		return target;

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
 import topmodel.jpa.sample.demo.enums.securite.utilisateur.TypeUtilisateurCode;
+import topmodel.jpa.sample.demo.enums.securite.utilisateur.TypeUtilisateurEnum;
 
 /**
  * Type d'utilisateur.
@@ -30,11 +31,11 @@ import topmodel.jpa.sample.demo.enums.securite.utilisateur.TypeUtilisateurCode;
 public class TypeUtilisateur {
 
 	@Transient
-	public static final TypeUtilisateur ADMIN = new TypeUtilisateur(TypeUtilisateurCode.ADMIN);
+	public static final TypeUtilisateur ADMIN = new TypeUtilisateur(TypeUtilisateurEnum.ADMIN);
 	@Transient
-	public static final TypeUtilisateur CLIENT = new TypeUtilisateur(TypeUtilisateurCode.CLIENT);
+	public static final TypeUtilisateur CLIENT = new TypeUtilisateur(TypeUtilisateurEnum.CLIENT);
 	@Transient
-	public static final TypeUtilisateur GEST = new TypeUtilisateur(TypeUtilisateurCode.GEST);
+	public static final TypeUtilisateur GESTIONNAIRE = new TypeUtilisateur(TypeUtilisateurEnum.GESTIONNAIRE);
 
 	/**
 	 * Code du type d'utilisateur.
@@ -58,22 +59,24 @@ public class TypeUtilisateur {
 	}
 
 	/**
-	 * Enum constructor.
+	 * Enum code finder.
 	 * @param code Code dont on veut obtenir l'instance.
 	 */
-	public TypeUtilisateur(TypeUtilisateurCode code) {
-		this.code = code;
-		switch(code) {
-		case ADMIN :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Admin";
-			break;
-		case CLIENT :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Client";
-			break;
-		case GEST :
-			this.libelle = "securite.utilisateur.typeUtilisateur.values.Gestionnaire";
-			break;
-		}
+	public static TypeUtilisateur from(TypeUtilisateurCode code) {
+		return switch (code) {
+			case ADMIN -> ADMIN;
+			case CLIENT -> CLIENT;
+			case GESTIONNAIRE -> GESTIONNAIRE;
+		};
+	}
+
+	/**
+	 * Enum constructor.
+	 * @param typeUtilisateurEnum Enum de valeur dont on veut obtenir l'entité.
+	 */
+	public TypeUtilisateur(TypeUtilisateurEnum typeUtilisateurEnum) {
+		this.code = typeUtilisateurEnum.getCode();
+		this.libelle = typeUtilisateurEnum.getLibelle();
 	}
 
 	/**

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
@@ -66,7 +66,7 @@ public class TypeUtilisateur {
 		return switch (code) {
 			case ADMIN -> ADMIN;
 			case CLIENT -> CLIENT;
-			case GESTIONNAIRE -> GESTIONNAIRE;
+			case GEST -> GESTIONNAIRE;
 		};
 	}
 

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/Utilisateur.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/Utilisateur.java
@@ -93,7 +93,7 @@ public class Utilisateur {
 	 */
 	@ManyToOne(fetch = FetchType.LAZY, optional = false, targetEntity = TypeUtilisateur.class)
 	@JoinColumn(name = "TUT_CODE", referencedColumnName = "TUT_CODE")
-	private TypeUtilisateur typeUtilisateur = new TypeUtilisateur(TypeUtilisateurCode.GEST);
+	private TypeUtilisateur typeUtilisateur = TypeUtilisateur.from(TypeUtilisateurCode.GEST);
 
 	/**
 	 * Date de création de l'utilisateur.

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitEnum.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitEnum.java
@@ -1,0 +1,85 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.securite.profil;
+
+import java.util.Arrays;
+
+/**
+ * Enumération des valeurs possibles de la classe Droit.
+ */
+public enum DroitEnum {
+	/**
+	 * Création.
+	 */
+	CREATE(DroitCode.CREATE, "securite.profil.droit.values.Create", TypeDroitEnum.WRITE), 
+
+	/**
+	 * Lecture.
+	 */
+	READ(DroitCode.READ, "securite.profil.droit.values.Read", TypeDroitEnum.READ), 
+
+	/**
+	 * Mise à jour.
+	 */
+	UPDATE(DroitCode.UPDATE, "securite.profil.droit.values.Update", TypeDroitEnum.WRITE), 
+
+	/**
+	 * Suppression.
+	 */
+	DELETE(DroitCode.DELETE, "securite.profil.droit.values.Delete", TypeDroitEnum.ADMIN); 
+
+	/**
+	 * Code.
+	 */
+	private final DroitCode code;
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+
+	/**
+	 * TypeDroit.
+	 */
+	private final TypeDroitEnum typeDroitEnum;
+
+	/**
+	 * Enum values constructor.
+	 */
+	private DroitEnum(final DroitCode code, final String libelle, final TypeDroitEnum typeDroitEnum) {
+		this.code = code;
+		this.libelle = libelle;
+		this.typeDroitEnum = typeDroitEnum;
+	}
+
+	/**
+	 * Getter for code.
+	 */
+	public DroitCode getCode() {
+		return this.code;
+	}
+
+	/**
+	 * Getter for libelle.
+	 */
+	public String getLibelle() {
+		return this.libelle;
+	}
+
+	/**
+	 * Getter for typeDroit.
+	 */
+	public TypeDroitEnum getTypeDroitEnum() {
+		return this.typeDroitEnum;
+	}
+
+
+	/**
+	 * Get Enum from pk.
+	 */
+	public static DroitEnum from(DroitCode code) {
+		return Arrays.stream(DroitEnum.values()).filter(t -> t.getCode() == code).findFirst().orElseThrow();
+	}
+}

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitEnum.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitEnum.java
@@ -1,0 +1,67 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.securite.profil;
+
+import java.util.Arrays;
+
+/**
+ * Enumération des valeurs possibles de la classe TypeDroit.
+ */
+public enum TypeDroitEnum {
+	/**
+	 * Lecture.
+	 */
+	READ(TypeDroitCode.READ, "securite.profil.typeDroit.values.Read"), 
+
+	/**
+	 * Ecriture.
+	 */
+	WRITE(TypeDroitCode.WRITE, "securite.profil.typeDroit.values.Write"), 
+
+	/**
+	 * Administration.
+	 */
+	ADMIN(TypeDroitCode.ADMIN, "securite.profil.typeDroit.values.Admin"); 
+
+	/**
+	 * Code.
+	 */
+	private final TypeDroitCode code;
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+
+	/**
+	 * Enum values constructor.
+	 */
+	private TypeDroitEnum(final TypeDroitCode code, final String libelle) {
+		this.code = code;
+		this.libelle = libelle;
+	}
+
+	/**
+	 * Getter for code.
+	 */
+	public TypeDroitCode getCode() {
+		return this.code;
+	}
+
+	/**
+	 * Getter for libelle.
+	 */
+	public String getLibelle() {
+		return this.libelle;
+	}
+
+
+	/**
+	 * Get Enum from pk.
+	 */
+	public static TypeDroitEnum from(TypeDroitCode code) {
+		return Arrays.stream(TypeDroitEnum.values()).filter(t -> t.getCode() == code).findFirst().orElseThrow();
+	}
+}

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurEnum.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurEnum.java
@@ -1,0 +1,67 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+package topmodel.jpa.sample.demo.enums.securite.utilisateur;
+
+import java.util.Arrays;
+
+/**
+ * Enumération des valeurs possibles de la classe TypeUtilisateur.
+ */
+public enum TypeUtilisateurEnum {
+	/**
+	 * Administrateur.
+	 */
+	ADMIN(TypeUtilisateurCode.ADMIN, "securite.utilisateur.typeUtilisateur.values.Admin"), 
+
+	/**
+	 * Gestionnaire.
+	 */
+	GESTIONNAIRE(TypeUtilisateurCode.GEST, "securite.utilisateur.typeUtilisateur.values.Gestionnaire"), 
+
+	/**
+	 * Client.
+	 */
+	CLIENT(TypeUtilisateurCode.CLIENT, "securite.utilisateur.typeUtilisateur.values.Client"); 
+
+	/**
+	 * Code.
+	 */
+	private final TypeUtilisateurCode code;
+
+	/**
+	 * Libelle.
+	 */
+	private final String libelle;
+
+	/**
+	 * Enum values constructor.
+	 */
+	private TypeUtilisateurEnum(final TypeUtilisateurCode code, final String libelle) {
+		this.code = code;
+		this.libelle = libelle;
+	}
+
+	/**
+	 * Getter for code.
+	 */
+	public TypeUtilisateurCode getCode() {
+		return this.code;
+	}
+
+	/**
+	 * Getter for libelle.
+	 */
+	public String getLibelle() {
+		return this.libelle;
+	}
+
+
+	/**
+	 * Get Enum from pk.
+	 */
+	public static TypeUtilisateurEnum from(TypeUtilisateurCode code) {
+		return Arrays.stream(TypeUtilisateurEnum.values()).filter(t -> t.getCode() == code).findFirst().orElseThrow();
+	}
+}

--- a/samples/generators/jpa/src/test/java/SecuriteUtilisateurMappersTest.java
+++ b/samples/generators/jpa/src/test/java/SecuriteUtilisateurMappersTest.java
@@ -32,7 +32,7 @@ public class SecuriteUtilisateurMappersTest {
         profil.setId(2);
         profil.setDroits(Arrays.asList(Droit.CREATE, Droit.DELETE));
         utilisateur.setProfil(profil);
-        utilisateur.setTypeUtilisateur(new TypeUtilisateur(TypeUtilisateurCode.ADMIN));
+        utilisateur.setTypeUtilisateur(TypeUtilisateur.from(TypeUtilisateurCode.ADMIN));
 
         // WHEN
         UtilisateurRead utilisateurRead = SecuriteUtilisateurMappers.createUtilisateurRead(utilisateur, null);
@@ -77,16 +77,12 @@ public class SecuriteUtilisateurMappersTest {
     @Test
     public void testToUtilisateurWithNullSource() {
         // WHEN & THEN
-        assertThatThrownBy(() -> {
-            SecuriteUtilisateurMappers.toUtilisateur(null, null);
-        }).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SecuriteUtilisateurMappers.toUtilisateur(null, null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testCreateUtilisateurReadWithNullUtilisateur() {
         // WHEN & THEN
-        assertThatThrownBy(() -> {
-            SecuriteUtilisateurMappers.createUtilisateurRead(null, null);
-        }).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SecuriteUtilisateurMappers.createUtilisateurRead(null, null)).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.3.5
 custom:
-  ../../../TopModel.Generator.Jpa: e30f09679b98ba42462f37bd353b6397
+  ../../../TopModel.Generator.Jpa: bca60d81f66e07cb329ee97b9d362041
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.3.5
 custom:
-  ../../../TopModel.Generator.Jpa: 11abe1baef01154b7cd55cc234b18171
+  ../../../TopModel.Generator.Jpa: c75b415ec6a725fa6430e7f26b9efa42
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java
@@ -26,7 +26,10 @@ generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/TypeUtilisateur.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/utilisateur/Utilisateur.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitEnum.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitCode.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitEnum.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurCode.java
+  - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurEnum.java
   - ../generators/jpa/src/main/resources/i18n/model/common.properties
   - ../generators/jpa/src/main/resources/i18n/model/securite.properties

--- a/samples/model/jpa.topmodel.lock
+++ b/samples/model/jpa.topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.3.5
 custom:
-  ../../../TopModel.Generator.Jpa: c75b415ec6a725fa6430e7f26b9efa42
+  ../../../TopModel.Generator.Jpa: e30f09679b98ba42462f37bd353b6397
 generatedFiles:
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ../generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
Cette PR est une première étape pour #373 
Il s'agit de générer une enum représentant totalement l'entité en dehors de l'entité. Ainsi toutes les valeurs statiques seront rendues disponibles hors du modèle pesisté.

Cette première étape a l'avantage de ne provoquer (presque) aucun breaking change. Excepté si les valeurs des PK sont différentes des clés des valeurs correspondantes (ce qui est une mauvaise pratique)

Ajoute le mode `enumsAsEnums` qui permet de transformer les classes qui contiennent des values statiques en enums représentant totalement l'entité

RaF : 
- Ajouter la documentation
- Générer les converters (ou constructeur) nécessaires 
