### PR TITLE
[Generator] Vide les buffers lors du build des générateurs custom

### DIFF
--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -306,7 +306,7 @@ for (var i = 0; i < configs.Count; i++)
             });
 
             await build!.StandardOutput.ReadToEndAsync();
-            await build!.StandardOutput.ReadToEndAsync();
+            await build!.StandardError.ReadToEndAsync();
             await build!.WaitForExitAsync();
 
             if (build.ExitCode != 0)

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -300,8 +300,13 @@ for (var i = 0; i < configs.Count; i++)
                 Arguments = "build -v q",
                 WorkingDirectory = customDir,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = Encoding.UTF8
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             });
+
+            await build!.StandardOutput.ReadToEndAsync();
+            await build!.StandardOutput.ReadToEndAsync();
             await build!.WaitForExitAsync();
 
             if (build.ExitCode != 0)


### PR DESCRIPTION
Fix #411 

Si la sortie standard est redirigée mais n’est pas lue activement, le processus peut se bloquer indéfiniment si le buffer de sortie se remplit, empêchant ainsi le processus de se terminer. Lire les sorties permet de résoudre ce problème.