### PR TITLE
Définitions de paramètres de domaines/décorateurs explicites

### DIFF
--- a/TopModel.Core/FileModel/DecoratorReference.cs
+++ b/TopModel.Core/FileModel/DecoratorReference.cs
@@ -9,5 +9,5 @@ public class DecoratorReference : Reference
     {
     }
 
-    public List<Reference> ParameterReferences { get; set; } = new();
+    public IList<ParameterReference> ParameterReferences { get; set; } = [];
 }

--- a/TopModel.Core/FileModel/DomainReference.cs
+++ b/TopModel.Core/FileModel/DomainReference.cs
@@ -9,5 +9,5 @@ public class DomainReference : Reference
     {
     }
 
-    public IList<Reference> ParameterReferences { get; set; } = [];
+    public IList<ParameterReference> ParameterReferences { get; set; } = [];
 }

--- a/TopModel.Core/FileModel/DomainReference.cs
+++ b/TopModel.Core/FileModel/DomainReference.cs
@@ -9,5 +9,5 @@ public class DomainReference : Reference
     {
     }
 
-    public List<Reference> ParameterReferences { get; set; } = new();
+    public IList<Reference> ParameterReferences { get; set; } = [];
 }

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -36,8 +36,11 @@ public class ModelFile
     public IDictionary<Reference, object> References => Domains.SelectMany(d => d.AsDomains.Keys.Select(adn => d.AsDomainReferences.TryGetValue(adn, out var adr) && d.AsDomains.TryGetValue(adn, out var ad) ? (adr as Reference, ad as object) : (null, null)))
         .Concat(Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object)))
         .Concat(Classes.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
+        .Concat(Classes.SelectMany(c => c.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))
         .Concat(Endpoints.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
+        .Concat(Endpoints.SelectMany(c => c.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))
         .Concat(Properties.OfType<RegularProperty>().Select(p => (p.DomainReference as Reference, p.Domain as object)))
+        .Concat(Properties.OfType<RegularProperty>().SelectMany(p => p.DomainReference?.ParameterReferences.Select((pr, i) => (pr as Reference, p.Domain?.TemplateParameters.ElementAtOrDefault(i) as object)) ?? []))
         .Concat(Properties.OfType<AssociationProperty>().SelectMany(p => new (Reference, object)[]
         {
             (p.Reference, p.Association),
@@ -48,6 +51,7 @@ public class ModelFile
             (p.Reference, p.Composition),
             (p.DomainReference, p.Domain)
         }))
+        .Concat(Properties.OfType<CompositionProperty>().SelectMany(p => p.DomainReference?.ParameterReferences.Select((pr, i) => (pr as Reference, p.Domain?.TemplateParameters.ElementAtOrDefault(i) as object)) ?? []))
         .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[]
         {
             (p.Reference, p.OriginalProperty?.Class),
@@ -58,6 +62,7 @@ public class ModelFile
             .SelectMany(p => p?.Reference?.ExcludeReferences?
                 .Select(er => (er, p?.OriginalProperty?.Class?.Properties?.FirstOrDefault(p => p?.Name == er?.ReferenceName) as object))
             ?? new List<(Reference, object)>()))
+        .Concat(Properties.OfType<AliasProperty>().SelectMany(p => p.DomainReference?.ParameterReferences.Select((pr, i) => (pr as Reference, p.Domain?.TemplateParameters.ElementAtOrDefault(i) as object)) ?? []))
         .Concat(Classes.SelectMany(c => new[] { c.DefaultPropertyReference, c.OrderPropertyReference, c.FlagPropertyReference }.Select(r => (r, (object)c.ExtendedProperties.FirstOrDefault(p => p.Name == r?.ReferenceName)))))
         .Concat(Classes.SelectMany(c => c.UniqueKeyReferences.SelectMany(uk => uk).Select(propRef => (propRef, (object)c.Properties.FirstOrDefault(p => p.Name == propRef.ReferenceName)))))
         .Concat(Classes.SelectMany(c => c.ValueReferences.SelectMany(rv => rv.Value).Select(prop => (prop.Key, (object)c.ExtendedProperties.FirstOrDefault(p => p.Name == prop.Key.ReferenceName)))))

--- a/TopModel.Core/FileModel/ParameterReference.cs
+++ b/TopModel.Core/FileModel/ParameterReference.cs
@@ -1,0 +1,11 @@
+﻿using YamlDotNet.Core.Events;
+
+namespace TopModel.Core.FileModel;
+
+public class ParameterReference : Reference
+{
+    internal ParameterReference(Scalar scalar)
+        : base(scalar)
+    {
+    }
+}

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -83,7 +83,7 @@ public class ClassLoader : ILoader<Class>
 
                                 parser.ConsumeSequence(() =>
                                 {
-                                    decorator.ParameterReferences.Add(new Reference(parser.Consume<Scalar>()));
+                                    decorator.ParameterReferences.Add(new ParameterReference(parser.Consume<Scalar>()));
                                 });
 
                                 classe.DecoratorReferences.Add(decorator);

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -43,6 +43,11 @@ public class DecoratorLoader : ILoader<Decorator>
                     break;
                 case "parameters":
                     decorator.TemplateParameters = _fileChecker.Deserialize<IList<TemplateParameter>>(parser);
+                    foreach (var param in decorator.TemplateParameters)
+                    {
+                        param.Decorator = decorator;
+                    }
+
                     break;
                 default:
                     decorator.Implementations[prop.Value] = _fileChecker.Deserialize<DecoratorImplementation>(parser);

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -41,6 +41,9 @@ public class DecoratorLoader : ILoader<Decorator>
                         decorator.Properties.Add(_propertyLoader.Load(parser));
                     });
                     break;
+                case "parameters":
+                    decorator.TemplateParameters = _fileChecker.Deserialize<IList<TemplateParameter>>(parser);
+                    break;
                 default:
                     decorator.Implementations[prop.Value] = _fileChecker.Deserialize<DecoratorImplementation>(parser);
                     break;

--- a/TopModel.Core/Loaders/DomainLoader.cs
+++ b/TopModel.Core/Loaders/DomainLoader.cs
@@ -55,6 +55,11 @@ public class DomainLoader : ILoader<Domain>
                     break;
                 case "parameters":
                     domain.TemplateParameters = _fileChecker.Deserialize<IList<TemplateParameter>>(parser);
+                    foreach (var param in domain.TemplateParameters)
+                    {
+                        param.Domain = domain;
+                    }
+
                     break;
                 default:
                     var implementation = new DomainImplementation();

--- a/TopModel.Core/Loaders/DomainLoader.cs
+++ b/TopModel.Core/Loaders/DomainLoader.cs
@@ -53,6 +53,9 @@ public class DomainLoader : ILoader<Domain>
                 case "mediaType":
                     domain.MediaType = value!.Value;
                     break;
+                case "parameters":
+                    domain.TemplateParameters = _fileChecker.Deserialize<IList<TemplateParameter>>(parser);
+                    break;
                 default:
                     var implementation = new DomainImplementation();
 

--- a/TopModel.Core/Loaders/EndpointLoader.cs
+++ b/TopModel.Core/Loaders/EndpointLoader.cs
@@ -65,7 +65,7 @@ public class EndpointLoader : ILoader<Endpoint>
 
                                 parser.ConsumeSequence(() =>
                                 {
-                                    decorator.ParameterReferences.Add(new Reference(parser.Consume<Scalar>()));
+                                    decorator.ParameterReferences.Add(new ParameterReference(parser.Consume<Scalar>()));
                                 });
 
                                 endpoint.DecoratorReferences.Add(decorator);

--- a/TopModel.Core/Loaders/FileChecker.cs
+++ b/TopModel.Core/Loaders/FileChecker.cs
@@ -29,6 +29,7 @@ public class FileChecker
         _deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .WithNodeTypeResolver(new InferTypeFromValueResolver())
+            .WithTypeConverter(new LocatedStringTypeConverter())
             .IgnoreUnmatchedProperties()
             .Build();
         _serializer = new SerializerBuilder()

--- a/TopModel.Core/Loaders/LoaderUtils.cs
+++ b/TopModel.Core/Loaders/LoaderUtils.cs
@@ -11,7 +11,7 @@ public static class LoaderUtils
         if (parser.Current is MappingStart)
         {
             Scalar? name = null;
-            var paramaters = new List<Reference>();
+            var paramaters = new List<ParameterReference>();
             parser.ConsumeMapping(prop =>
             {
                 switch (prop.Value)
@@ -20,7 +20,7 @@ public static class LoaderUtils
                         name = parser.Consume<Scalar>();
                         break;
                     case "parameters":
-                        parser.ConsumeSequence(() => paramaters.Add(new Reference(parser.Consume<Scalar>())));
+                        parser.ConsumeSequence(() => paramaters.Add(new ParameterReference(parser.Consume<Scalar>())));
                         break;
                 }
             });

--- a/TopModel.Core/Loaders/LoaderUtils.cs
+++ b/TopModel.Core/Loaders/LoaderUtils.cs
@@ -27,9 +27,7 @@ public static class LoaderUtils
 
             if (name != null)
             {
-                var domain = new DomainReference(name);
-                domain.ParameterReferences.AddRange(paramaters);
-                return domain;
+                return new DomainReference(name) { ParameterReferences = paramaters };
             }
             else
             {

--- a/TopModel.Core/Loaders/LocatedStringTypeConverter.cs
+++ b/TopModel.Core/Loaders/LocatedStringTypeConverter.cs
@@ -1,0 +1,26 @@
+﻿using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace TopModel.Core.Loaders;
+
+internal class LocatedStringTypeConverter : IYamlTypeConverter
+{
+    /// <inheritdoc cref="IYamlTypeConverter.Accepts" />
+    public bool Accepts(Type type)
+    {
+        return type == typeof(LocatedString);
+    }
+
+    /// <inheritdoc cref="IYamlTypeConverter.ReadYaml" />
+    public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+    {
+        return new LocatedString(parser.Consume<Scalar>());
+    }
+
+    /// <inheritdoc cref="IYamlTypeConverter.WriteYaml" />
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -9,7 +9,7 @@ public class AliasProperty : IProperty
     private Dictionary<string, string> _customProperties = [];
     private string? _defaultValue;
     private Domain? _domain;
-    private string[]? _domainParameters;
+    private IList<string>? _domainParameters;
     private string? _label;
     private string? _name;
 
@@ -112,7 +112,7 @@ public class AliasProperty : IProperty
     }
 #nullable enable
 
-    public string[] DomainParameters
+    public IList<string> DomainParameters
     {
         get => _domainParameters ?? _property?.DomainParameters ?? [];
         set => _domainParameters = value;

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -164,7 +164,7 @@ public class AssociationProperty : IProperty
 
     public Domain Domain => Type.IsToMany() && (Property?.Domain?.AsDomains.TryGetValue(As, out var ld) ?? false) ? ld : Property?.Domain!;
 
-    public string[] DomainParameters => Property?.DomainParameters ?? [];
+    public IList<string> DomainParameters => Property?.DomainParameters ?? [];
 
     public bool PrimaryKey { get; set; }
 

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -20,7 +20,7 @@ public class CompositionProperty : IProperty
 
     public Domain Domain { get; set; }
 
-    public string[] DomainParameters { get; set; } = [];
+    public IList<string> DomainParameters { get; set; } = [];
 
     public string Comment { get; set; }
 

--- a/TopModel.Core/Model/Decorator.cs
+++ b/TopModel.Core/Model/Decorator.cs
@@ -16,16 +16,18 @@ public class Decorator : IPropertyContainer
     public string Description { get; set; }
 #nullable enable
 
-    public Dictionary<string, DecoratorImplementation> Implementations { get; set; } = new();
+    public Dictionary<string, DecoratorImplementation> Implementations { get; set; } = [];
 
 #nullable disable
     public ModelFile ModelFile { get; set; }
 
     public Namespace Namespace { get; set; }
 
-    public IList<IProperty> Properties { get; } = new List<IProperty>();
+    public IList<IProperty> Properties { get; } = [];
 
     public bool PreservePropertyCasing { get; set; }
+
+    public IList<TemplateParameter> TemplateParameters { get; set; } = [];
 
     internal Reference Location { get; set; }
 

--- a/TopModel.Core/Model/Domain.cs
+++ b/TopModel.Core/Model/Domain.cs
@@ -26,11 +26,13 @@ public class Domain
 
     public bool BodyParam { get; set; }
 
-    public Dictionary<string, Domain> AsDomains { get; set; } = new();
+    public Dictionary<string, Domain> AsDomains { get; set; } = [];
 
-    public Dictionary<string, DomainReference> AsDomainReferences { get; set; } = new();
+    public Dictionary<string, DomainReference> AsDomainReferences { get; set; } = [];
 
-    public Dictionary<string, DomainImplementation> Implementations { get; set; } = new();
+    public Dictionary<string, DomainImplementation> Implementations { get; set; } = [];
+
+    public IList<TemplateParameter> TemplateParameters { get; set; } = [];
 
     public string? MediaType { get; set; }
 

--- a/TopModel.Core/Model/IProperty.cs
+++ b/TopModel.Core/Model/IProperty.cs
@@ -22,7 +22,7 @@ public interface IProperty
 
     Domain Domain { get; }
 
-    string[] DomainParameters { get; }
+    IList<string> DomainParameters { get; }
 
     string Comment { get; }
 

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -1,5 +1,4 @@
-﻿using NuGet.Packaging;
-using TopModel.Core.FileModel;
+﻿using TopModel.Core.FileModel;
 using TopModel.Utils;
 
 namespace TopModel.Core;
@@ -32,7 +31,7 @@ public class RegularProperty : IProperty
 #nullable disable
     public Domain Domain { get; set; }
 
-    public string[] DomainParameters { get; set; } = [];
+    public IList<string> DomainParameters { get; set; } = [];
 
     public string Comment { get; set; }
 

--- a/TopModel.Core/Model/TemplateParameter.cs
+++ b/TopModel.Core/Model/TemplateParameter.cs
@@ -1,0 +1,10 @@
+﻿namespace TopModel.Core;
+
+public class TemplateParameter
+{
+    public required string Name { get; set; }
+
+    public required string Comment { get; set; }
+
+    public string DefaultValue { get; set; } = string.Empty;
+}

--- a/TopModel.Core/Model/TemplateParameter.cs
+++ b/TopModel.Core/Model/TemplateParameter.cs
@@ -2,9 +2,11 @@
 
 public class TemplateParameter
 {
-    public required string Name { get; set; }
+    public required LocatedString Name { get; set; }
 
     public required string Comment { get; set; }
+
+    public bool Required { get; set; }
 
     public string DefaultValue { get; set; } = string.Empty;
 }

--- a/TopModel.Core/Model/TemplateParameter.cs
+++ b/TopModel.Core/Model/TemplateParameter.cs
@@ -9,4 +9,8 @@ public class TemplateParameter
     public bool Required { get; set; }
 
     public string DefaultValue { get; set; } = string.Empty;
+
+    public Decorator? Decorator { get; set; }
+
+    public Domain? Domain { get; set; }
 }

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -122,6 +122,7 @@ public static class ModelExtensions
             PropertyMapping p => p.Property.GetLocation(),
             OneOf<ClassMappings, PropertyMapping> p => p.Match(c => c.GetLocation(), p => p.GetLocation()),
             Converter c => c.Location,
+            TemplateParameter t => t.Name.Location,
             _ => null
         };
     }

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -97,6 +97,7 @@ public static class ModelExtensions
             (Decorator decorator, _) => decorator.ModelFile,
             Keyword keyword => keyword.ModelFile,
             ClassValue classValue => classValue.Class.ModelFile,
+            TemplateParameter templateParameter => templateParameter.Domain?.ModelFile ?? templateParameter.Decorator!.ModelFile,
             _ => throw new ArgumentException("Type d'objet non supporté.")
         };
     }

--- a/TopModel.Core/Resolvers/DecoratorResolver.cs
+++ b/TopModel.Core/Resolvers/DecoratorResolver.cs
@@ -76,6 +76,11 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
                             yield return new ModelError(classe, $"Impossible d'appliquer le décorateur '{decoratorRef.ReferenceName}' à la classe '{classe}' : seul un 'extends' peut être spécifié.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1010 };
                         }
 
+                        if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
+                        {
+                            yield return new ModelError(classe, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+                        }
+
                         classe.Decorators.Add((decorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
                     }
                 }
@@ -108,6 +113,11 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
                     }
                     else
                     {
+                        if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
+                        {
+                            yield return new ModelError(endpoint, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+                        }
+
                         endpoint.Decorators.Add((decorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
                     }
                 }

--- a/TopModel.Core/Resolvers/DecoratorResolver.cs
+++ b/TopModel.Core/Resolvers/DecoratorResolver.cs
@@ -49,6 +49,23 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
     /// <returns>Erreurs.</returns>
     public IEnumerable<ModelError> ResolveDecorators()
     {
+        foreach (var decorator in modelFile.Decorators)
+        {
+            foreach (var templateParam in decorator.TemplateParameters.Where((e, i) => decorator.TemplateParameters.Where((p, j) => p.Name == e.Name && j < i).Any()))
+            {
+                yield return new ModelError(decorator, $"Le nom '{templateParam.Name}' est déjà utilisé.", templateParam.GetLocation()) { ModelErrorType = ModelErrorType.TMD0003 };
+            }
+
+            foreach (var templateParam in decorator.TemplateParameters.Where(p => !p.Required))
+            {
+                var index = decorator.TemplateParameters.IndexOf(templateParam);
+                if (decorator.TemplateParameters.Any(param => param.Required && decorator.TemplateParameters.IndexOf(param) > index))
+                {
+                    yield return new ModelError(decorator, $"Le paramètre facultatif '{templateParam.Name}' doit être positionné après tous les paramètres obligatoires.", templateParam.GetLocation()) { ModelErrorType = ModelErrorType.TMD1037 };
+                }
+            }
+        }
+
         foreach (var classe in modelFile.Classes.Where(c => c.DecoratorReferences.Count > 0))
         {
             classe.Decorators.Clear();
@@ -76,9 +93,9 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
                             yield return new ModelError(classe, $"Impossible d'appliquer le décorateur '{decoratorRef.ReferenceName}' à la classe '{classe}' : seul un 'extends' peut être spécifié.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1010 };
                         }
 
-                        if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
+                        foreach (var error in CheckDecoratorParameters(classe, decoratorRef, decorator))
                         {
-                            yield return new ModelError(classe, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+                            yield return error;
                         }
 
                         classe.Decorators.Add((decorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
@@ -113,9 +130,9 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
                     }
                     else
                     {
-                        if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
+                        foreach (var error in CheckDecoratorParameters(endpoint, decoratorRef, decorator))
                         {
-                            yield return new ModelError(endpoint, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+                            yield return error;
                         }
 
                         endpoint.Decorators.Add((decorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
@@ -127,6 +144,19 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
             {
                 continue;
             }
+        }
+    }
+
+    private static IEnumerable<ModelError> CheckDecoratorParameters(IPropertyContainer container, DecoratorReference decoratorRef, Decorator decorator)
+    {
+        if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
+        {
+            yield return new ModelError(container, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+        }
+
+        if (decoratorRef.ParameterReferences.Count < decorator.TemplateParameters.Count(p => p.Required))
+        {
+            yield return new ModelError(container, $"Le décorateur '{decorator.Name}' n'est pas utilisé avec tous ses paramètres obligatoires ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count(p => p.Required)} minimum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1036 };
         }
     }
 }

--- a/TopModel.Core/Resolvers/DecoratorResolver.cs
+++ b/TopModel.Core/Resolvers/DecoratorResolver.cs
@@ -151,7 +151,10 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
     {
         if (decoratorRef.ParameterReferences.Count > decorator.TemplateParameters.Count)
         {
-            yield return new ModelError(container, $"Le décorateur '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).", decoratorRef) { ModelErrorType = ModelErrorType.TMD1035 };
+            foreach (var extraParameter in decoratorRef.ParameterReferences.Skip(decorator.TemplateParameters.Count))
+            {
+                yield return new ModelError(container, $"Le décorateur '{decorator.Name}' ne définit que {decorator.TemplateParameters.Count} paramètres.", extraParameter) { ModelErrorType = ModelErrorType.TMD1035 };
+            }
         }
 
         if (decoratorRef.ParameterReferences.Count < decorator.TemplateParameters.Count(p => p.Required))

--- a/TopModel.Core/Resolvers/DomainResolver.cs
+++ b/TopModel.Core/Resolvers/DomainResolver.cs
@@ -23,6 +23,20 @@ internal class DomainResolver(ModelFile modelFile, IDictionary<string, Domain> d
 
                 domain.AsDomains[asName] = asDomain;
             }
+
+            foreach (var templateParam in domain.TemplateParameters.Where((e, i) => domain.TemplateParameters.Where((p, j) => p.Name == e.Name && j < i).Any()))
+            {
+                yield return new ModelError(domain, $"Le nom '{templateParam.Name}' est déjà utilisé.", templateParam.GetLocation()) { ModelErrorType = ModelErrorType.TMD0003 };
+            }
+
+            foreach (var templateParam in domain.TemplateParameters.Where(p => !p.Required))
+            {
+                var index = domain.TemplateParameters.IndexOf(templateParam);
+                if (domain.TemplateParameters.Any(param => param.Required && domain.TemplateParameters.IndexOf(param) > index))
+                {
+                    yield return new ModelError(domain, $"Le paramètre facultatif '{templateParam.Name}' doit être positionné après tous les paramètres obligatoires.", templateParam.GetLocation()) { ModelErrorType = ModelErrorType.TMD1037 };
+                }
+            }
         }
     }
 

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -252,6 +252,11 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
                         break;
                     }
 
+                    foreach (var error in CheckDomainParameters(rp, rp.DomainReference, domain))
+                    {
+                        yield return error;
+                    }
+
                     rp.Domain = domain;
                     rp.DomainParameters = rp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     break;
@@ -295,6 +300,11 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
                             break;
                         }
 
+                        foreach (var error in CheckDomainParameters(cp, cp.DomainReference, cpDomain))
+                        {
+                            yield return error;
+                        }
+
                         cp.Domain = cpDomain;
                         cp.DomainParameters = cp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     }
@@ -308,10 +318,23 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
                         break;
                     }
 
+                    foreach (var error in CheckDomainParameters(alp, alp.DomainReference, aliasDomain))
+                    {
+                        yield return error;
+                    }
+
                     alp.Domain = aliasDomain;
                     alp.DomainParameters = alp.DomainReference.ParameterReferences.Select(p => p.ReferenceName).ToArray();
                     break;
             }
+        }
+    }
+
+    private static IEnumerable<ModelError> CheckDomainParameters(IProperty property, DomainReference domainRef, Domain domain)
+    {
+        if (domainRef.ParameterReferences.Count > domain.TemplateParameters.Count)
+        {
+            yield return new ModelError(property, $"Le domaine '{domain.Name}' est utilisé avec plus de paramètres qu'il ne définit ({domainRef.ParameterReferences.Count} au lieu de {domain.TemplateParameters.Count} maximum).", domainRef) { ModelErrorType = ModelErrorType.TMD1035 };
         }
     }
 }

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -336,5 +336,10 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
         {
             yield return new ModelError(property, $"Le domaine '{domain.Name}' est utilisé avec plus de paramètres qu'il ne définit ({domainRef.ParameterReferences.Count} au lieu de {domain.TemplateParameters.Count} maximum).", domainRef) { ModelErrorType = ModelErrorType.TMD1035 };
         }
+
+        if (domainRef.ParameterReferences.Count < domain.TemplateParameters.Count(p => p.Required))
+        {
+            yield return new ModelError(property, $"Le domaine '{domain.Name}' n'est pas utilisé avec tous ses paramètres obligatoires ({domainRef.ParameterReferences.Count} au lieu de {domain.TemplateParameters.Count(p => p.Required)} minimum).", domainRef) { ModelErrorType = ModelErrorType.TMD1036 };
+        }
     }
 }

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -334,7 +334,10 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
     {
         if (domainRef.ParameterReferences.Count > domain.TemplateParameters.Count)
         {
-            yield return new ModelError(property, $"Le domaine '{domain.Name}' est utilisé avec plus de paramètres qu'il ne définit ({domainRef.ParameterReferences.Count} au lieu de {domain.TemplateParameters.Count} maximum).", domainRef) { ModelErrorType = ModelErrorType.TMD1035 };
+            foreach (var extraParameter in domainRef.ParameterReferences.Skip(domain.TemplateParameters.Count))
+            {
+                yield return new ModelError(property, $"Le domaine '{domain.Name}' ne définit que {domain.TemplateParameters.Count} paramètres.", extraParameter) { ModelErrorType = ModelErrorType.TMD1035 };
+            }
         }
 
         if (domainRef.ParameterReferences.Count < domain.TemplateParameters.Count(p => p.Required))

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -38,7 +38,8 @@
               "type": "array",
               "description": "Paramètres du domaine.",
               "items": {
-                "type": "string"
+                "type": "string",
+                "description": "Paramètre de domaine."
               }
             }
           }
@@ -858,7 +859,7 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "description": "Paramètre du décorator"
+                        "description": "Paramètre du décorateur"
                       }
                     }
                   }
@@ -1116,7 +1117,7 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "description": "Paramètre du décorator"
+                        "description": "Paramètre du décorateur"
                       }
                     }
                   }

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -437,6 +437,10 @@
           "type": "string",
           "description": "Description du paramètre."
         },
+        "required": {
+          "type": "boolean",
+          "description": "Si le paramètre est obligatoire."
+        },
         "defaultValue": {
           "type": "string",
           "description": "Valeur par défaut du paramètre. Si non renseigné, la valeur sera une chaîne de caractères vide."

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -422,6 +422,26 @@
           }
         }
       ]
+    },
+    "parameter": {
+      "type": "object",
+      "description": "Paramètre à utiliser dans un template.",
+      "additionalProperties": false,
+      "required": [ "name", "comment" ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nom du paramètre."
+        },
+        "comment": {
+          "type": "string",
+          "description": "Description du paramètre."
+        },
+        "defaultValue": {
+          "type": "string",
+          "description": "Valeur par défaut du paramètre. Si non renseigné, la valeur sera une chaîne de caractères vide."
+        }
+      }
     }
   },
   "oneOf": [
@@ -527,6 +547,13 @@
             "mediaType": {
               "type": "string",
               "description": "Type de médias (utilisé si retourné par un endpoint)."
+            },
+            "parameters": {
+              "type": "array",
+              "description": "Définitions de paramètres, utilisables dans les templates pour les implémentations.",
+              "items": {
+                "$ref": "#/definitions/parameter"
+              }
             }
           },
           "additionalProperties": {
@@ -685,6 +712,13 @@
               "description": "Liste des propriétés du décorateur.",
               "items": {
                 "$ref": "#/definitions/property"
+              }
+            },
+            "parameters": {
+              "type": "array",
+              "description": "Définitions de paramètre, utilisables dans les templates pour les implémentations.",
+              "items": {
+                "$ref": "#/definitions/parameter"
               }
             }
           },

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -125,21 +125,21 @@ public abstract class GeneratorConfigBase
              {
                  var decorator = d.Decorator;
                  var imple = GetImplementation(decorator)!;
-                 return imple.Annotations.Select(a => (Annotation: a.ParseTemplate(classe, d.Parameters, this, tag),
-                 Imports: imple.Imports.Select(i => i.ParseTemplate(classe, d.Parameters, this, tag)).ToList()));
+                 return imple.Annotations.Select(a => (Annotation: a.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag),
+                 Imports: imple.Imports.Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)).ToList()));
              });
     }
 
     public string? GetClassExtends(Class item)
     {
         var extendsDecorator = item.Decorators.SingleOrDefault(d => GetImplementation(d.Decorator)?.Extends != null);
-        return item.Extends?.NamePascal ?? GetImplementation(extendsDecorator.Decorator)?.Extends!.ParseTemplate(item, extendsDecorator.Parameters, this);
+        return item.Extends?.NamePascal ?? GetImplementation(extendsDecorator.Decorator)?.Extends!.ParseTemplate(extendsDecorator.Decorator, item, extendsDecorator.Parameters, this);
     }
 
     public IEnumerable<string> GetClassImplements(Class classe)
     {
         return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Implements ?? [])
-            .Select(i => i.ParseTemplate(classe, d.Parameters, this)))
+            .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this)))
             .Distinct();
     }
 
@@ -192,28 +192,28 @@ public abstract class GeneratorConfigBase
     public IEnumerable<string> GetDecoratorAnnotations(Class classe, string tag)
     {
         return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Annotations ?? [])
-            .Select(a => a.ParseTemplate(classe, d.Parameters, this, tag)))
+            .Select(a => a.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorAnnotations(Endpoint endpoint, string tag)
     {
         return endpoint.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Annotations ?? [])
-            .Select(a => a.ParseTemplate(endpoint, d.Parameters, this, tag)))
+            .Select(a => a.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorImports(Class classe, string tag)
     {
         return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Imports ?? [])
-            .Select(i => i.ParseTemplate(classe, d.Parameters, this, tag)))
+            .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorImports(Endpoint endpoint, string tag)
     {
         return endpoint.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Imports ?? [])
-            .Select(i => i.ParseTemplate(endpoint, d.Parameters, this, tag)))
+            .Select(i => i.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
             .Distinct();
     }
 

--- a/TopModel.Generator.Core/TemplateExtensions.cs
+++ b/TopModel.Generator.Core/TemplateExtensions.cs
@@ -16,13 +16,13 @@ internal static class TemplateExtensions
         var result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), p, p.DomainParameters, config, tag));
+            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), p, p.Domain?.TemplateParameters ?? [], p.DomainParameters, config, tag));
         }
 
         return result;
     }
 
-    public static string ParseTemplate(this string template, Class c, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this string template, Decorator d, Class c, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -32,13 +32,13 @@ internal static class TemplateExtensions
         var result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), c, parameters, config, tag));
+            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), c, d.TemplateParameters, parameterValues, config, tag));
         }
 
         return result;
     }
 
-    public static string ParseTemplate(this string template, Endpoint e, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this string template, Decorator d, Endpoint e, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -48,7 +48,7 @@ internal static class TemplateExtensions
         var result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), e, parameters, config, tag));
+            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), e, d.TemplateParameters, parameterValues, config, tag));
         }
 
         return result;
@@ -155,41 +155,42 @@ internal static class TemplateExtensions
         }).Transform(input);
     }
 
-    private static string ResolveVariable(this string input, IPropertyContainer container, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, IPropertyContainer container, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         return container switch
         {
-            Endpoint e => ResolveVariable(input, e, parameters, config, tag),
-            Class c => ResolveVariable(input, c, parameters, config, tag),
+            Endpoint e => input.ResolveVariable(e, templateParameters, parameterValues, config, tag),
+            Class c => input.ResolveVariable(c, templateParameters, parameterValues, config, tag),
             _ => string.Empty,
         };
     }
 
-    private static string ResolveVariable(this string input, IProperty p, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, IProperty p, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
             return string.Empty;
         }
 
-        for (var i = 0; i < parameters.Length; i++)
+        for (var i = 0; i < templateParameters.Count; i++)
         {
-            input = input.Replace($"${i}", parameters[i]);
+            var param = templateParameters[i];
+            input = input.Replace($"{param.Name}", parameterValues.ElementAtOrDefault(i) ?? param.DefaultValue);
         }
 
         if (input.StartsWith("parent."))
         {
-            return ResolveVariable(input["parent.".Length..], p.Parent, parameters, config, tag);
+            return ResolveVariable(input["parent.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("class."))
         {
-            return ResolveVariable(input["class.".Length..], p.Parent, parameters, config, tag);
+            return ResolveVariable(input["class.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("endpoint."))
         {
-            return ResolveVariable(input["endpoint.".Length..], p.Parent, parameters, config, tag);
+            return ResolveVariable(input["endpoint.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("domain."))
@@ -213,7 +214,7 @@ internal static class TemplateExtensions
 
             if (association != null)
             {
-                return ResolveVariable(input["association.".Length..], association, parameters, config, tag);
+                return ResolveVariable(input["association.".Length..], association, templateParameters, parameterValues, config, tag);
             }
         }
 
@@ -228,7 +229,7 @@ internal static class TemplateExtensions
 
             if (composition != null)
             {
-                return ResolveVariable(input["composition.".Length..], composition, parameters, config, tag);
+                return ResolveVariable(input["composition.".Length..], composition, templateParameters, parameterValues, config, tag);
             }
         }
 
@@ -250,16 +251,17 @@ internal static class TemplateExtensions
         return result;
     }
 
-    private static string ResolveVariable(this string input, Class c, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Class c, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
             return string.Empty;
         }
 
-        for (var i = 0; i < parameters.Length; i++)
+        for (var i = 0; i < templateParameters.Count; i++)
         {
-            input = input.Replace($"${i}", parameters[i]);
+            var param = templateParameters[i];
+            input = input.Replace($"{param.Name}", parameterValues.ElementAtOrDefault(i) ?? param.DefaultValue);
         }
 
         if (input.StartsWith("primaryKey."))
@@ -269,7 +271,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["primaryKey.".Length..], c.PrimaryKey.FirstOrDefault()!, parameters, config, tag);
+            return ResolveVariable(input["primaryKey.".Length..], c.PrimaryKey.FirstOrDefault()!, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("extends."))
@@ -279,7 +281,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["extends.".Length..], c.Extends, parameters, config, tag);
+            return ResolveVariable(input["extends.".Length..], c.Extends, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith($"customProperties."))
@@ -299,7 +301,7 @@ internal static class TemplateExtensions
                     return string.Empty;
                 }
 
-                return ResolveVariable(nextInput, c.Properties[index], parameters, config, tag);
+                return ResolveVariable(nextInput, c.Properties[index], templateParameters, parameterValues, config, tag);
             }
             else
             {
@@ -322,16 +324,17 @@ internal static class TemplateExtensions
         return result;
     }
 
-    private static string ResolveVariable(this string input, Endpoint e, string[] parameters, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Endpoint e, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
             return string.Empty;
         }
 
-        for (var i = 0; i < parameters.Length; i++)
+        for (var i = 0; i < templateParameters.Count; i++)
         {
-            input = input.Replace($"${i}", parameters[i]);
+            var param = templateParameters[i];
+            input = input.Replace($"{param.Name}", parameterValues.ElementAtOrDefault(i) ?? param.DefaultValue);
         }
 
         if (input.StartsWith("returns."))
@@ -341,7 +344,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["returns.".Length..], e.Returns, parameters, config, tag);
+            return ResolveVariable(input["returns.".Length..], e.Returns, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith($"customProperties."))
@@ -361,7 +364,7 @@ internal static class TemplateExtensions
                     return string.Empty;
                 }
 
-                return ResolveVariable(nextInput, e.Params[index], parameters, config, tag);
+                return ResolveVariable(nextInput, e.Params[index], templateParameters, parameterValues, config, tag);
             }
             else
             {

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -46,6 +46,7 @@ public class HoverHandler : HoverHandlerBase
                         Decorator d => d.Description,
                         DataFlow d => $"Flux de données '{d.Name}'",
                         (Decorator d, _) => d.Description,
+                        TemplateParameter tp => $"**{tp.Name}** ({tp.Comment})",
                         _ => string.Empty
                     }))
                 });

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -64,6 +64,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
                     DataFlowReference => SemanticTokenType.Operator,
                     DomainReference => SemanticTokenType.EnumMember,
                     Reference r when r.ReferenceName == "false" => SemanticTokenType.Keyword,
+                    ParameterReference => SemanticTokenType.Parameter,
                     _ => SemanticTokenType.Function
                 };
 

--- a/TopModel.Utils/ModelErrorType.cs
+++ b/TopModel.Utils/ModelErrorType.cs
@@ -218,6 +218,11 @@ public enum ModelErrorType
     TMD1034,
 
     /// <summary>
+    /// Le décorateur/domaine '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).
+    /// </summary>
+    TMD1035,
+
+    /// <summary>
     /// Le flux de données est introuvable dans le fichier ou l'une de ses références.
     /// </summary>
     TMD2000,

--- a/TopModel.Utils/ModelErrorType.cs
+++ b/TopModel.Utils/ModelErrorType.cs
@@ -218,12 +218,12 @@ public enum ModelErrorType
     TMD1034,
 
     /// <summary>
-    /// Le décorateur/domaine '{decorator.Name}' est utilisé avec plus de paramètres qu'il ne définit ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count} maximum).
+    /// Le domaine/décorateur '{Name}' ne définit que {domain.TemplateParameters.Count} paramètres.
     /// </summary>
     TMD1035,
 
     /// <summary>
-    /// Le décorateur '{decorator.Name}' n'est pas utilisé avec tous ses paramètres obligatoires ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count(p => p.Required)} minimum).
+    /// Le domaine/décorateur '{Name}' n'est pas utilisé avec tous ses paramètres obligatoires ({ParameterReferences.Count} au lieu de {TemplateParameters.Count(p => p.Required)} minimum).
     /// </summary>
     TMD1036,
 

--- a/TopModel.Utils/ModelErrorType.cs
+++ b/TopModel.Utils/ModelErrorType.cs
@@ -223,6 +223,16 @@ public enum ModelErrorType
     TMD1035,
 
     /// <summary>
+    /// Le décorateur '{decorator.Name}' n'est pas utilisé avec tous ses paramètres obligatoires ({decoratorRef.ParameterReferences.Count} au lieu de {decorator.TemplateParameters.Count(p => p.Required)} minimum).
+    /// </summary>
+    TMD1036,
+
+    /// <summary>
+    /// Les paramètres obligatoires doivent précéder tous les paramètres faculatifs.
+    /// </summary>
+    TMD1037,
+
+    /// <summary>
     /// Le flux de données est introuvable dans le fichier ou l'une de ses références.
     /// </summary>
     TMD2000,

--- a/docs/generator/jpa.md
+++ b/docs/generator/jpa.md
@@ -292,14 +292,16 @@ Par ailleurs, elles implémentent toutes l'interface `java.io.Serializable`. Est
 
 De plus, toutes les propriétés `required: true` reçoivent l'annotation `javax.validation.constraints.NotNull` (ou `jakarata.validation.constraints.NotNull` selon la configuration choisie).
 Par ailleurs, si le domain a :
+
 - Le type java est `String`, `CharSequence`, `Set`,`Map`,`List`, ou `Collection`
 - `length` est défini
-Alors la propriété portera l'annotation `@Size(max = [length défini dans le domain])`
+  Alors la propriété portera l'annotation `@Size(max = [length défini dans le domain])`
 
 Egalement, si le domain a :
+
 - Le type java est `BigDecimal`, `BigInteger`, `byte`, `short`, `int`, `long`, `Byte`, `Short`, `Integer`, `Long`, `double` ou `Double`
 - `length` est défini ou `scale` est défini
-Alors la propriété portera l'annotation `@Digits(integer = [length défini dans le domain], fraction = [scale défini dans le domain])`
+  Alors la propriété portera l'annotation `@Digits(integer = [length défini dans le domain], fraction = [scale défini dans le domain])`
 
 Précautions d'emploi :
 
@@ -1057,11 +1059,18 @@ domain:
 domain:
   name: RESPONSE_ENTITY
   label: Response Entity
+  parameters:
+    - name: type
+      required: true
+      comment: Type de réponse
+    - name: import
+      required: true
+      comment: Import pour le type de la réponse
   java:
-    type: ResponseEntity<{$0}>
+    type: ResponseEntity<{type}>
     imports:
       - org.springframework.http.ResponseEntity
-      - "{$1}"
+      - "{import}"
 ---
 domain:
   name: LIST
@@ -1177,9 +1186,13 @@ decorator:
 decorator:
   name: HasAuthority
   description: Droit nécessaire pour pouvoir accéder au endpoint
+  parameters:
+    - name: authority
+      required: true
+      comment: Autorité a passer à `PreAuthorize`.
   java:
     annotations:
-      - '@PreAuthorize("hasAuthority(''{$0}'')")'
+      - '@PreAuthorize("hasAuthority(''{authority}'')")'
     imports:
       - org.springframework.security.access.prepost.PreAuthorize
 ```

--- a/docs/model/decorators.md
+++ b/docs/model/decorators.md
@@ -85,9 +85,13 @@ En C#, on pourrait définir un décorateur et son utilisation dans un endpoint c
 decorator:
   name: Authorize
   description: Authorize
+  parameters:
+    - name: policy
+      required: true
+      comment: Policy d'autorisation.
   csharp:
     annotations:
-      - Authorize("{$0}") # Le templating est décrit dans la section suivante.
+      - Authorize("{policy}") # Le templating est décrit dans la section suivante.
   properties:
     - name: AdditionalParam
       domain: DO_BOOLEEN
@@ -204,7 +208,24 @@ Vous pouvez également utiliser des [transformations](/model/templating.md#trans
 
 ### Paramètres
 
-Il est également possible de passer des paramètres lors de l'instanciation d'un décorateur :
+Il est également possible de définir des paramètres sur un décorateur, qui pourront être utilisés dans les templates :
+
+```yaml
+decorator:
+  name: MyDecorator
+  parameters:
+    - name: param1
+      required: true
+      comment: Premier paramètre.
+    - name: param2
+      defaultValue: Test
+      comment: Deuxième paramètre.
+  csharp:
+    annotations:
+      - text: MyAnnotation("{param1}", "{param2}"))
+```
+
+Ces paramètres pourront être passés lors de l'instanciation du décorateur :
 
 ```yaml
 class:
@@ -214,14 +235,4 @@ class:
     - OtherDecorator
 ```
 
-Les paramètres seront utilisés dans la résolution des variables `$0`, `$1`... Par exemple :
-
-```yaml
-decorator:
-  name: MyDecorator
-  csharp:
-    annotations:
-      - text: MyAnnotation("{$0}", "{$1}"))
-```
-
-Génèrera l'annotation `[MyAnnotation("Param1", "Param2")]` sur `MyClass`. Si les paramètres ne sont pas renseignés, les variables `$0`, `$1` ne seront simplement pas remplacées. Et bien entendu, rien ne se passera si on passe des paramètres alors que le décorateur ne les utilise pas.
+Tous les paramètres passés doivent être définis au prélable sur le décorateur. Les paramètres obligatoires doivent être renseignés avec le décorateur, et les paramètres non renseignés le seront avec leur `defaultValue` (qui vaut `""` si non renseignée).

--- a/docs/model/domains.md
+++ b/docs/model/domains.md
@@ -136,11 +136,28 @@ Le tout dans les propriétés d'implémentation :
 
 Les templates des domaines des propriétés sont également valorisés. Ces variables s'ajoutent à la variable `{T}` utilisée dans les types génériques.
 
-Vous pouvez également utiliser des [transformations](/model/templating.md#transformations) sur vos différentes variables, par exemple pour modifier la casse de leur valeur. 
+Vous pouvez également utiliser des [transformations](/model/templating.md#transformations) sur vos différentes variables, par exemple pour modifier la casse de leur valeur.
 
 ### Paramètres
 
-Il est également possible de passer des paramètres lorsqu'on associe un domaine à une propriété, en passant un objet `{name, parameters}` au lieu du nom du domaine :
+Il est également possible de définir des paramètres sur un domaine, qui pourront être utilisés dans les templates :
+
+```yaml
+domain:
+  name: DO_CODE
+  parameters:
+    - name: param1
+      required: true
+      comment: Premier paramètre.
+    - name: param2
+      defaultValue: Test
+      comment: Deuxième paramètre.
+  csharp:
+    annotations:
+      - text: MyAnnotation("{param1}", "{param2}"))
+```
+
+Ces paramètres pourront être passés lorsqu'on associe un domaine à une propriété, en passant un objet `{name, parameters}` au lieu du nom du domaine :
 
 ```yaml
 properties:
@@ -150,17 +167,7 @@ properties:
       parameters: ["Param1", "Param2"]
 ```
 
-Les paramètres seront utilisés dans la résolution des variables `$0`, `$1`... Par exemple :
-
-```yaml
-domain:
-  name: DO_CODE
-  csharp:
-    annotations:
-      - text: MyAnnotation("{$0}", "{$1}"))
-```
-
-Générera l'annotation `[MyAnnotation("Param1", "Param2")]` sur la propriété `MyProperty`. Si les paramètres ne sont pas renseignés, les variables `$0`, `$1` ne seront simplement pas remplacées. Et bien entendu, rien ne se passera si on passe des paramètres alors que le domaine ne les utilise pas.
+Tous les paramètres passés doivent être définis au prélable sur le domaine. Les paramètres obligatoires doivent être renseignés avec le domaine, et les paramètres non renseignés le seront avec leur `defaultValue` (qui vaut `""` si non renseignée).
 
 ## Spécialisation des annotations
 

--- a/samples/model/meta/decorators.tmd
+++ b/samples/model/meta/decorators.tmd
@@ -33,6 +33,7 @@ decorator:
   description: Ajoute une annotation de sécurité sur un endpoint.
   parameters:
     - name: permission
+      required: true
       comment: Permission demandée
   java:
     annotations:

--- a/samples/model/meta/decorators.tmd
+++ b/samples/model/meta/decorators.tmd
@@ -31,8 +31,11 @@ decorator:
 decorator:
   name: Security
   description: Ajoute une annotation de sécurité sur un endpoint.
+  parameters:
+    - name: permission
+      comment: Permission demandée
   java:
     annotations:
-      - PreAuthorize("{$0}")
+      - PreAuthorize("{permission}")
     imports:
       - org.springframework.security.access.prepost.PreAuthorize


### PR DESCRIPTION
Fix #372 

Cette PR introduit un  ⚡**breaking change**⚡qui oblige désormais les définitions de domaines et de décorateurs qui utilisent des paramètres pour les templates à **définir explicitement** leurs paramètres : 

```yaml
decorator:
  name: Security
  description: Ajoute une annotation de sécurité sur un endpoint.
  parameters:
    - name: permission
      required: true
      comment: Permission demandée
  java:
    annotations:
      - PreAuthorize("{permission}")
    imports:
      - org.springframework.security.access.prepost.PreAuthorize
 ```

Il faut donc utiliser le nom du paramètre dans le template au lieu de son index dans la liste passée. **Rien ne change à l'utilisation côté propriété ou classe/endpoint** en revanche.

Cela permet : 
- De définir des paramètres obligatoires
- De définir des valeurs par défaut (qui vaut `""` par défaut d'ailleurs)
- De vérifier que les paramètres sont bien renseignés lors de l'instanciation
- D'avoir de la doc/navigation sur les paramètres

![image](https://github.com/user-attachments/assets/2f89294a-59d4-4fba-badc-dac57b073f9a)

_Remarque : L'issue initiale proposait également de pouvoir renseigner les paramètres par leur nom dans l'instanciation, ce qui a été pour l'instant écarté car cela apporterait beaucoup de complexité pour gérer les deux syntaxes. En espérant que les features implémentés dans l'extension suffisent..._
