### PR TITLE
Implemente #438 : diminue les diffs dans les enums

### DIFF
--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
@@ -89,6 +89,8 @@ public class JpaEnumGenerator(ILogger<JpaEnumGenerator> logger, IFileWriterProvi
             fw.WriteLine(1, $"{value.Value[property]},");
         }
 
+        fw.WriteLine(1, ";");
+
         fw.WriteLine("}");
     }
 }

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
@@ -79,6 +79,11 @@ public class JpaEnumGenerator(ILogger<JpaEnumGenerator> logger, IFileWriterProvi
 
         foreach (var value in refs)
         {
+            if (i > 0)
+            {
+                fw.WriteLine();
+            }
+
             i++;
             if (classe.DefaultProperty != null)
             {
@@ -89,6 +94,7 @@ public class JpaEnumGenerator(ILogger<JpaEnumGenerator> logger, IFileWriterProvi
             fw.WriteLine(1, $"{value.Value[property]},");
         }
 
+        fw.WriteLine();
         fw.WriteLine(1, ";");
 
         fw.WriteLine("}");

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEnumGenerator.cs
@@ -80,14 +80,13 @@ public class JpaEnumGenerator(ILogger<JpaEnumGenerator> logger, IFileWriterProvi
         foreach (var value in refs)
         {
             i++;
-            var isLast = i == refs.Count;
             if (classe.DefaultProperty != null)
             {
                 fw.WriteDocStart(1, $"{value.Value[classe.DefaultProperty]}");
                 fw.WriteDocEnd(1);
             }
 
-            fw.WriteLine(1, $"{value.Value[property]}{(isLast ? string.Empty : ",")}");
+            fw.WriteLine(1, $"{value.Value[property]},");
         }
 
         fw.WriteLine("}");

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEnumValuesGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEnumValuesGenerator.cs
@@ -113,7 +113,6 @@ public class JpaEnumValuesGenerator(ILogger<JpaEnumValuesGenerator> logger, IFil
             }
 
             i++;
-            var isLast = i == refs.Count;
             if (classe.DefaultProperty != null)
             {
                 fw.WriteDocStart(1, $"{refValue.Value[classe.DefaultProperty]}");
@@ -149,9 +148,12 @@ public class JpaEnumValuesGenerator(ILogger<JpaEnumValuesGenerator> logger, IFil
                 enumAsString.Add($@"{val}{(prop == classe.Properties.Last() ? string.Empty : ", ")}");
             }
 
-            enumAsString.Add($"){(isLast ? ";" : ",")} ");
+            enumAsString.Add("),");
             fw.WriteLine(1, enumAsString.Aggregate(string.Empty, (acc, curr) => acc + curr));
         }
+
+        fw.WriteLine();
+        fw.WriteLine(1, ";"); // Separation entre valeurs et attributs
 
         foreach (var prop in classe.Properties.Where(p => p != classe.EnumKey))
         {

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/DroitCode.java
@@ -12,16 +12,21 @@ public enum DroitCode {
 	 * Création.
 	 */
 	CREATE,
+
 	/**
 	 * Suppression.
 	 */
 	DELETE,
+
 	/**
 	 * Lecture.
 	 */
 	READ,
+
 	/**
 	 * Mise à jour.
 	 */
-	UPDATE
+	UPDATE,
+
+	;
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/profil/TypeDroitCode.java
@@ -12,12 +12,16 @@ public enum TypeDroitCode {
 	 * Administration.
 	 */
 	ADMIN,
+
 	/**
 	 * Lecture.
 	 */
 	READ,
+
 	/**
 	 * Ecriture.
 	 */
-	WRITE
+	WRITE,
+
+	;
 }

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurCode.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/enums/securite/utilisateur/TypeUtilisateurCode.java
@@ -12,12 +12,16 @@ public enum TypeUtilisateurCode {
 	 * Administrateur.
 	 */
 	ADMIN,
+
 	/**
 	 * Client.
 	 */
 	CLIENT,
+
 	/**
 	 * Gestionnaire.
 	 */
-	GEST
+	GEST,
+
+	;
 }

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.5.3
 custom:
-  ../../../TopModel.Generator.Jpa: 883db930b2974b4dd794260f1c92041d
+  ../../../TopModel.Generator.Jpa: 6bc8e5553a3697688ed479b371e72520
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
Évite le bruit dans le VCS pour les valeurs qui existaient déjà.

Bonus : améliore la lisibilité en rajoutant des lignes d'espacement.