### PR TITLE
Alias de propriétés d'endpoint ou de décorateur

### DIFF
--- a/TopModel.Core/FileModel/AliasReference.cs
+++ b/TopModel.Core/FileModel/AliasReference.cs
@@ -2,11 +2,19 @@
 
 namespace TopModel.Core.FileModel;
 
-public class AliasReference : ClassReference
+public class AliasReference
 {
-    public List<Reference> IncludeReferences { get; } = new();
+    public ClassReference? ClassReference { get; set; }
 
-    public List<Reference> ExcludeReferences { get; } = new();
+    public EndpointReference? EndpointReference { get; set; }
+
+    public DecoratorReference? DecoratorReference { get; set; }
+
+    public Reference ContainerReference => ClassReference ?? (EndpointReference as Reference) ?? DecoratorReference!;
+
+    public List<Reference> IncludeReferences { get; } = [];
+
+    public List<Reference> ExcludeReferences { get; } = [];
 
     public void AddExclude(Scalar scalar)
     {

--- a/TopModel.Core/FileModel/EndpointReference.cs
+++ b/TopModel.Core/FileModel/EndpointReference.cs
@@ -1,0 +1,15 @@
+﻿using YamlDotNet.Core.Events;
+
+namespace TopModel.Core.FileModel;
+
+public class EndpointReference : Reference
+{
+    internal EndpointReference()
+    {
+    }
+
+    internal EndpointReference(Scalar scalar)
+        : base(scalar)
+    {
+    }
+}

--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -60,7 +60,9 @@ public class ModelFile
         .Concat(Properties.OfType<CompositionProperty>().SelectMany(p => p.DomainReference?.ParameterReferences.Select((pr, i) => (pr as Reference, p.Domain?.TemplateParameters.ElementAtOrDefault(i) as object)) ?? []))
         .Concat(Properties.OfType<AliasProperty>().SelectMany(p => new (Reference, object)[]
         {
-            (p.Reference, p.OriginalProperty?.Class),
+            (p.Reference?.ClassReference, p.OriginalProperty?.Class),
+            (p.Reference?.EndpointReference, p.OriginalProperty?.Endpoint),
+            (p.Reference?.DecoratorReference, p.OriginalProperty?.Decorator),
             (p.PropertyReference, p.OriginalProperty),
             (p.DomainReference, p.Domain)
         }))

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -204,9 +204,13 @@ public class PropertyLoader(ModelConfig modelConfig) : ILoader<IProperty>
                     switch (prop)
                     {
                         case "class":
-                            aliasReference.Start = ((Scalar)next).Start;
-                            aliasReference.End = ((Scalar)next).End;
-                            aliasReference.ReferenceName = ((Scalar)next).Value;
+                            aliasReference.ClassReference = new ClassReference((Scalar)next);
+                            break;
+                        case "endpoint":
+                            aliasReference.EndpointReference = new EndpointReference((Scalar)next);
+                            break;
+                        case "decorator":
+                            aliasReference.DecoratorReference = new DecoratorReference((Scalar)next);
                             break;
                         case "include" or "property" when next is Scalar pValue:
                             aliasReference.AddInclude(pValue);
@@ -251,10 +255,10 @@ public class PropertyLoader(ModelConfig modelConfig) : ILoader<IProperty>
                     switch (prop)
                     {
                         case "prefix":
-                            alp.Prefix = value!.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Prefix = value!.Value == "true" ? aliasReference.ContainerReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "suffix":
-                            alp.Suffix = value!.Value == "true" ? aliasReference.ReferenceName : value.Value == "false" ? null : value.Value;
+                            alp.Suffix = value!.Value == "true" ? aliasReference.ContainerReference.ReferenceName : value.Value == "false" ? null : value.Value;
                             break;
                         case "label":
                             alp.Label = value!.Value;

--- a/TopModel.Core/Model/DependenciesExtensions.cs
+++ b/TopModel.Core/Model/DependenciesExtensions.cs
@@ -6,7 +6,7 @@ internal static class DependenciesExtensions
     {
         return properties.OfType<AssociationProperty>().Select(p => new ClassDependency(p.Association, p))
             .Concat(properties.OfType<AliasProperty>().Select(p => p.Property is AssociationProperty ap ? new ClassDependency(ap.Association, p) : null))
-            .Concat(properties.OfType<AliasProperty>().Select(p => p.Property == p.Property.Class.EnumKey || p.Property.Class.UniqueKeys.Where(uk => uk.Count == 1).Select(uk => uk.Single()).Contains(p.Property) ? new ClassDependency(p.Property.Class, p) : null))
+            .Concat(properties.OfType<AliasProperty>().Select(p => p.Property.Class != null && (p.Property == p.Property.Class.EnumKey || p.Property.Class.UniqueKeys.Where(uk => uk.Count == 1).Select(uk => uk.Single()).Contains(p.Property)) ? new ClassDependency(p.Property.Class, p) : null))
             .Concat(properties.OfType<CompositionProperty>().Where(p => p.Composition != currentClass).Select(p => new ClassDependency(p.Composition, p)))
             .Concat(properties.OfType<AliasProperty>().Where(p => p.Property is CompositionProperty cp && cp.Composition != currentClass).Select(p => p is AliasProperty { Property: CompositionProperty cp } ? new ClassDependency(cp.Composition, p) : null))
             .Where(d => d != null)!;

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -7,10 +7,7 @@ public static class ModelExtensions
 {
     public static IEnumerable<(ClassReference Reference, ModelFile File)> GetClassReferences(this ModelStore modelStore, Class classe)
     {
-        return modelStore.Classes.SelectMany(c => c.Properties)
-            .Concat(modelStore.Classes.SelectMany(c => c.FromMapperProperties))
-            .Concat(modelStore.Endpoints.SelectMany(e => e.Properties))
-            .Concat(modelStore.Decorators.SelectMany(d => d.Properties))
+        return modelStore.Properties
             .Where(p =>
                 p is AliasProperty alp && alp.OriginalProperty?.Class == classe
                 || p is AssociationProperty ap && ap.Association == classe
@@ -21,7 +18,7 @@ public static class ModelExtensions
                 {
                     AssociationProperty ap => ap.Reference,
                     CompositionProperty cp => cp.Reference,
-                    AliasProperty alp => alp.Reference!,
+                    AliasProperty alp => alp.Reference!.ClassReference!,
                     _ => null! // Impossible
                 }, File: p.GetFile());
             })
@@ -42,23 +39,28 @@ public static class ModelExtensions
 
     public static IEnumerable<(DecoratorReference Reference, ModelFile File)> GetDecoratorReferences(this ModelStore modelStore, Decorator decorator)
     {
-        return modelStore.Classes.Where(c => c.Decorators.Select(d => d.Decorator).Contains(decorator))
+        return modelStore.Classes
+            .Where(c => c.Decorators.Select(d => d.Decorator).Contains(decorator))
             .Select(c => (
                 Reference: c.DecoratorReferences.First(dr => dr.ReferenceName == decorator.Name),
                 File: c.GetFile()))
-            .Concat(modelStore.Endpoints.Where(e => e.Decorators.Select(d => d.Decorator).Contains(decorator))
+        .Concat(modelStore.Endpoints
+            .Where(e => e.Decorators.Select(d => d.Decorator).Contains(decorator))
             .Select(e => (
                 Reference: e.DecoratorReferences.First(dr => dr.ReferenceName == decorator.Name),
                 File: e.GetFile())))
-            .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
+        .Concat(modelStore.Properties.OfType<AliasProperty>()
+            .Where(alp => alp.OriginalProperty?.Decorator == decorator)
+            .Select(alp => (
+                Reference: alp.Reference?.DecoratorReference!,
+                File: alp.GetFile())))
+        .Where(r => r.Reference is not null)
+        .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
     }
 
     public static IEnumerable<(DomainReference Reference, ModelFile File)> GetDomainReferences(this ModelStore modelStore, Domain domain)
     {
-        return modelStore.Classes.SelectMany(c => c.Properties)
-            .Concat(modelStore.Classes.SelectMany(c => c.FromMapperProperties))
-            .Concat(modelStore.Decorators.SelectMany(c => c.Properties))
-            .Concat(modelStore.Endpoints.SelectMany(e => e.Properties))
+        return modelStore.Properties
             .Where(p =>
                 p is RegularProperty rp && rp.Domain == domain
                 || p is AliasProperty alp && alp.DomainReference != null && alp.Domain == domain
@@ -77,6 +79,17 @@ public static class ModelExtensions
             .Concat(modelStore.Domains.Values.SelectMany(d => d.AsDomainReferences.Values.Select(adr => (Reference: adr, File: d.GetFile()))).Where(r => r.Reference.ReferenceName == domain.Name))
             .Where(l => l.Reference is not null)
             .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
+    }
+
+    public static IEnumerable<(EndpointReference Reference, ModelFile File)> GetEndpointReferences(this ModelStore modelStore, Endpoint endpoint)
+    {
+        return modelStore.Properties.OfType<AliasProperty>()
+            .Where(alp => alp.OriginalProperty?.Endpoint == endpoint)
+            .Select(alp => (
+                Reference: alp.Reference?.EndpointReference!,
+                File: alp.GetFile()))
+        .Where(r => r.Reference is not null)
+        .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
     }
 
     public static ModelFile GetFile(this object? objet)
@@ -161,7 +174,7 @@ public static class ModelExtensions
         {
             if (alp.OriginalProperty == property)
             {
-                var reference = alp.PropertyReference ?? alp.Reference;
+                var reference = alp.PropertyReference ?? alp.Reference?.ContainerReference;
                 if (reference != null)
                 {
                     yield return (reference, alp.GetFile());

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -54,6 +54,11 @@ public class ModelStore
 
     public IEnumerable<Decorator> Decorators => _modelFiles.SelectMany(mf => mf.Value.Decorators).Distinct();
 
+    public IEnumerable<IProperty> Properties => Classes.SelectMany(c => c.Properties)
+        .Concat(Classes.SelectMany(c => c.FromMapperProperties))
+        .Concat(Decorators.SelectMany(c => c.Properties))
+        .Concat(Endpoints.SelectMany(e => e.Properties));
+
     public IEnumerable<ModelFile> Files => _modelFiles.Values;
 
     public IEnumerable<Class> GetAvailableClasses(ModelFile file)
@@ -72,12 +77,36 @@ public class ModelStore
         return GetDependencies(file).SelectMany(m => m.Decorators).Concat(file.Decorators);
     }
 
+    public IEnumerable<Endpoint> GetAvailableEndpoints(ModelFile file)
+    {
+        return GetDependencies(file).SelectMany(m => m.Endpoints).Concat(file.Endpoints);
+    }
+
     public Dictionary<string, Class> GetReferencedClasses(ModelFile modelFile)
     {
-        var dependencies = GetDependencies(modelFile).ToList();
-        return dependencies
+        return GetDependencies(modelFile)
             .SelectMany(m => m.Classes)
             .Concat(modelFile.Classes)
+            .Distinct()
+            .GroupBy(c => c.Name.Value)
+            .ToDictionary(c => c.Key, c => c.First());
+    }
+
+    public Dictionary<string, Decorator> GetReferencedDecorators(ModelFile modelFile)
+    {
+        return GetDependencies(modelFile)
+            .SelectMany(m => m.Decorators)
+            .Concat(modelFile.Decorators)
+            .Distinct()
+            .GroupBy(c => c.Name.Value)
+            .ToDictionary(c => c.Key, c => c.First());
+    }
+
+    public Dictionary<string, Endpoint> GetReferencedEndpoints(ModelFile modelFile)
+    {
+        return GetDependencies(modelFile)
+            .SelectMany(m => m.Endpoints)
+            .Concat(modelFile.Endpoints)
             .Distinct()
             .GroupBy(c => c.Name.Value)
             .ToDictionary(c => c.Key, c => c.First());
@@ -91,7 +120,7 @@ public class ModelStore
         using var scope = _logger.BeginScope(_storeConfig!);
 
         var watchers = _modelWatchers.Select(mw => mw.FullName.Split("@")).GroupBy(split => split[0]).Select(grp => $"{grp.Key}@{{{string.Join(",", grp.Select(split => split[1]))}}}");
-        if (watchers.Count() > 0)
+        if (watchers.Any())
         {
             _logger.LogInformation($"Watchers enregistrés : \n                          - {string.Join("\n                          - ", watchers.OrderBy(x => x))}");
         }
@@ -437,6 +466,12 @@ public class ModelStore
             .Where(c => !duplicateClasses.Select(c => c.Name.Value).Contains(c.Name.Value))
             .ToDictionary(c => c.Name.Value, c => c);
 
+        var referencedEndpoints = dependencies
+            .SelectMany(m => m.Endpoints)
+            .Concat(modelFile.Endpoints)
+            .Distinct()
+            .ToDictionary(d => (string)d.Name, c => c);
+
         var referencedDecorators = dependencies
             .SelectMany(m => m.Decorators)
             .Concat(modelFile.Decorators)
@@ -468,7 +503,7 @@ public class ModelStore
         var domainResolver = new DomainResolver(modelFile, Domains, Converters);
         var endpointResolver = new EndpointResolver(modelFile);
         var mapperResolver = new MapperResolver(modelFile, referencedClasses, Converters, _config.UseLegacyAssociationCompositionMappers);
-        var propertyResolver = new PropertyResolver(modelFile, Domains, referencedClasses);
+        var propertyResolver = new PropertyResolver(modelFile, Domains, referencedClasses, referencedEndpoints, referencedDecorators);
 
         foreach (var error in domainResolver.ResolveAsDomains())
         {

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -3,7 +3,7 @@ using TopModel.Utils;
 
 namespace TopModel.Core.Resolvers;
 
-internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain> domains, IDictionary<string, Class> referencedClasses)
+internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain> domains, IDictionary<string, Class> referencedClasses, IDictionary<string, Endpoint> referencedEndpoints, IDictionary<string, Decorator> referencedDecorators)
 {
     /// <summary>
     /// Réinitialise les alias déjà résolus sur les classes/endpoints/décorateurs/mappers (pour le watch).
@@ -92,19 +92,51 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
     {
         foreach (var alp in modelFile.Properties.OfType<AliasProperty>().Where(filter))
         {
-            if (!referencedClasses!.TryGetValue(alp.Reference!.ReferenceName, out var aliasedClass))
+            IPropertyContainer propertyContainer;
+
+            if (alp.Reference?.ClassReference != null)
             {
-                yield return new ModelError(alp, "La classe '{0}' est introuvable dans le fichier ou l'une de ses dépendances.", alp.Reference) { ModelErrorType = ModelErrorType.TMD1002 };
+                if (!referencedClasses!.TryGetValue(alp.Reference.ClassReference.ReferenceName, out var aliasedClass))
+                {
+                    yield return new ModelError(alp, "La classe '{0}' est introuvable dans le fichier ou l'une de ses dépendances.", alp.Reference.ClassReference) { ModelErrorType = ModelErrorType.TMD1002 };
+                    continue;
+                }
+
+                propertyContainer = aliasedClass;
+            }
+            else if (alp.Reference?.EndpointReference != null)
+            {
+                if (!referencedEndpoints!.TryGetValue(alp.Reference.EndpointReference.ReferenceName, out var aliasedEndpoint))
+                {
+                    yield return new ModelError(alp, "L'endpoint '{0}' est introuvable dans le fichier ou l'une de ses dépendances.", alp.Reference.EndpointReference) { ModelErrorType = ModelErrorType.TMD1006 };
+                    continue;
+                }
+
+                propertyContainer = aliasedEndpoint;
+            }
+            else if (alp.Reference?.DecoratorReference != null)
+            {
+                if (!referencedDecorators!.TryGetValue(alp.Reference.DecoratorReference.ReferenceName, out var aliasedDecorator))
+                {
+                    yield return new ModelError(alp, "Le décorateur '{0}' est introuvable dans le fichier ou l'une de ses dépendances.", alp.Reference.DecoratorReference) { ModelErrorType = ModelErrorType.TMD1008 };
+                    continue;
+                }
+
+                propertyContainer = aliasedDecorator;
+            }
+            else
+            {
+                // Impossible
                 continue;
             }
 
             var shouldBreak = false;
             foreach (var propReference in alp.Reference.IncludeReferences.Concat(alp.Reference.ExcludeReferences))
             {
-                var aliasedProperty = aliasedClass.Properties.FirstOrDefault(p => p.Name == propReference.ReferenceName);
+                var aliasedProperty = propertyContainer.Properties.FirstOrDefault(p => p.Name == propReference.ReferenceName);
                 if (aliasedProperty == null)
                 {
-                    yield return new ModelError(alp, $"La propriété '{{0}}' est introuvable sur la classe '{aliasedClass}'.", propReference) { ModelErrorType = ModelErrorType.TMD1004 };
+                    yield return new ModelError(alp, $"La propriété '{{0}}' est introuvable sur la classe '{propertyContainer}'.", propReference) { ModelErrorType = ModelErrorType.TMD1004 };
                     shouldBreak = true;
                 }
             }
@@ -128,8 +160,8 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
 
             var propertiesToAlias =
                 (alp.Reference.IncludeReferences.Count > 0
-                    ? alp.Reference.IncludeReferences.Select(p => aliasedClass.Properties.First(prop => prop.Name == p.ReferenceName))
-                    : aliasedClass.Properties.Where(prop => !alp.Reference.ExcludeReferences.Select(p => p.ReferenceName).Contains(prop.Name)))
+                    ? alp.Reference.IncludeReferences.Select(p => propertyContainer.Properties.First(prop => prop.Name == p.ReferenceName))
+                    : propertyContainer.Properties.Where(prop => !alp.Reference.ExcludeReferences.Select(p => p.ReferenceName).Contains(prop.Name)))
                 .Reverse();
 
             foreach (var property in propertiesToAlias)
@@ -138,7 +170,7 @@ internal class PropertyResolver(ModelFile modelFile, IDictionary<string, Domain>
 
                 if (prop.As != null && prop.Domain == null)
                 {
-                    yield return new ModelError(modelFile, $"Le domaine '{prop.OriginalProperty?.Domain}' doit définir un domaine 'as' pour '{prop.As}' pour définir un alias '{prop.As}' sur la propriété '{prop.OriginalProperty}' de la classe '{prop.OriginalProperty?.Class}'", prop.PropertyReference ?? prop.Reference) { IsError = true, ModelErrorType = ModelErrorType.TMD1023 };
+                    yield return new ModelError(modelFile, $"Le domaine '{prop.OriginalProperty?.Domain}' doit définir un domaine 'as' pour '{prop.As}' pour définir un alias '{prop.As}' sur la propriété '{prop.OriginalProperty}' de la classe '{prop.OriginalProperty?.Class}'", prop.PropertyReference ?? prop.Reference?.ContainerReference) { IsError = true, ModelErrorType = ModelErrorType.TMD1023 };
                 }
 
                 if (alp.Class != null)

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -187,10 +187,27 @@
             "alias": {
               "type": "object",
               "description": "Définition de propriété(s) à recopier d'une autre classe. Cette propriété DOIT être en PREMIER.",
-              "required": [
-                "class"
+              "oneOf": [
+                {
+                  "required": [ "class" ]
+                },
+                {
+                  "required": [ "endpoint" ]
+                },
+                {
+                  "required": [ "decorator" ]
+                }
               ],
               "allOf": [
+                {
+                  "not": {
+                    "required": [
+                      "class",
+                      "endpoint",
+                      "decorator"
+                    ]
+                  }
+                },
                 {
                   "not": {
                     "required": [
@@ -221,6 +238,14 @@
                 "class": {
                   "type": "string",
                   "description": "Nom de la classe depuis laquelle on veut recopier des propriétés. Doit être référencée dans ce fichier, soit en y étant déclarée, soit en étant listée dans la section 'uses' du fichier."
+                },
+                "endpoint": {
+                  "type": "string",
+                  "description": "Nom de l'endpoint depuis lequel on veut recopier des propriétés. Doit être référencé dans ce fichier, soit en y étant déclarée, soit en étant listée dans la section 'uses' du fichier."
+                },
+                "decorator": {
+                  "type": "string",
+                  "description": "Nom du décorateur depuis lequel on veut recopier des propriétés. Doit être référencé dans ce fichier, soit en y étant déclarée, soit en étant listée dans la section 'uses' du fichier."
                 },
                 "property": {
                   "oneOf": [

--- a/TopModel.Generator.Csharp/DbContextGenerator.cs
+++ b/TopModel.Generator.Csharp/DbContextGenerator.cs
@@ -228,13 +228,10 @@ public class DbContextGenerator(ILogger<DbContextGenerator> logger, IFileWriterP
                     foreach (var refProp in refValue.Value.ToList())
                     {
                         var prop = refProp.Key is AliasProperty alp ? alp.Property : refProp.Key;
-                        var ap = prop as AssociationProperty;
-
-                        var targetClass = ap != null ? ap.Association : prop.Class;
-                        var targetProp = ap != null ? ap.Property : prop;
+                        var targetClass = prop is AssociationProperty ap ? ap.Association : prop.Class;
 
                         var value = Config.GetValue(refProp.Key, Classes, refProp.Value);
-                        if (value.StartsWith(targetClass.PluralNamePascal))
+                        if (targetClass != null && value.StartsWith(targetClass.PluralNamePascal))
                         {
                             var targetNs = Config.GetNamespace(targetClass, tag);
                             var contextNsSplit = contextNs.Split('.');

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -10,21 +10,8 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace TopModel.LanguageServer;
 
-public class CodeActionHandler : CodeActionHandlerBase
+public class CodeActionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache modelFileCache, ModelConfig config) : CodeActionHandlerBase
 {
-    private readonly ModelConfig _config;
-    private readonly ILanguageServerFacade _facade;
-    private readonly ModelFileCache _fileCache;
-    private readonly ModelStore _modelStore;
-
-    public CodeActionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache modelFileCache, ModelConfig config)
-    {
-        _config = config;
-        _facade = facade;
-        _fileCache = modelFileCache;
-        _modelStore = modelStore;
-    }
-
     public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
     {
         return Task.FromResult(request);
@@ -32,7 +19,7 @@ public class CodeActionHandler : CodeActionHandlerBase
 
     public override Task<CommandOrCodeActionContainer?> Handle(CodeActionParams request, CancellationToken cancellationToken)
     {
-        var modelFile = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
+        var modelFile = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
         var codeActions = new List<CommandOrCodeAction>();
         if (modelFile != null)
         {
@@ -52,6 +39,9 @@ public class CodeActionHandler : CodeActionHandlerBase
                     case ModelErrorType.TMD1002:
                         codeActions.AddRange(GetCodeActionMissingClassImport(request, diagnostic, modelFile));
                         codeActions.AddRange(GetCodeActionAddClass(request, diagnostic, modelFile));
+                        break;
+                    case ModelErrorType.TMD1006:
+                        codeActions.AddRange(GetCodeActionMissingEndpointImport(request, diagnostic, modelFile));
                         break;
                     case ModelErrorType.TMD1008:
                         codeActions.AddRange(GetCodeActionMissingDecoratorImport(request, diagnostic, modelFile));
@@ -83,9 +73,9 @@ public class CodeActionHandler : CodeActionHandlerBase
                 Changes =
                     new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [request.TextDocument.Uri] = new List<TextEdit>
-                        {
-                            new TextEdit
+                        [request.TextDocument.Uri] =
+                        [
+                            new()
                             {
                                 NewText = string.Join(
                                     "\n  - ",
@@ -96,7 +86,7 @@ public class CodeActionHandler : CodeActionHandlerBase
                                         .Select(u => u.ReferenceName)),
                                 Range = new Range(start, end)
                             }
-                        }
+                        ]
                     }
             }
         };
@@ -106,7 +96,7 @@ public class CodeActionHandler : CodeActionHandlerBase
     {
         return new()
         {
-            DocumentSelector = _config.GetDocumentSelector(),
+            DocumentSelector = config.GetDocumentSelector(),
             ResolveProvider = true,
             CodeActionKinds = new List<CodeActionKind>
             {
@@ -118,11 +108,11 @@ public class CodeActionHandler : CodeActionHandlerBase
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionAddClass(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = modelFileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var line = text.ElementAt(diagnostic.Range.Start.Line);
         var className = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
-        return new List<CommandOrCodeAction>
-        {
+        return
+        [
             new CodeAction
             {
                 Title = $"TopModel : Créer la classe {className} dans ce fichier",
@@ -137,9 +127,9 @@ public class CodeActionHandler : CodeActionHandlerBase
                     Changes =
                         new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                         {
-                            [new Uri(_facade.GetFilePath(modelFile))] = new List<TextEdit>()
-                            {
-                                new TextEdit()
+                            [new Uri(facade.GetFilePath(modelFile))] =
+                            [
+                                new()
                                 {
                                     NewText = @$"
 ---
@@ -151,23 +141,23 @@ class:
 ",
                                     Range = new Range(text.Length, 0, text.Length, 0)
                                 }
-                            }
+                            ]
                         }
                 }
             }
-        };
+        ];
     }
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionCreateDomain(CodeActionParams request, Diagnostic diagnostic)
     {
         var fs = request.TextDocument.Uri.GetFileSystemPath();
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = modelFileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var line = text.ElementAt(diagnostic.Range.Start.Line);
         var domainName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
 
-        return _modelStore.Files.Where(f => f.Domains.Any()).Select(f =>
+        return modelStore.Files.Where(f => f.Domains.Count > 0).Select(f =>
         {
-            var lastLine = File.ReadAllLines(_facade.GetFilePath(f)).Length;
+            var lastLine = File.ReadAllLines(facade.GetFilePath(f)).Length;
             return (CommandOrCodeAction)new CodeAction
             {
                 Title = $"TopModel : Ajouter le domain au fichier {f.Path}",
@@ -182,9 +172,9 @@ class:
                     Changes =
                         new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                         {
-                            [new Uri(_facade.GetFilePath(f))] = new List<TextEdit>()
-                            {
-                                new TextEdit()
+                            [new Uri(facade.GetFilePath(f))] =
+                            [
+                                new()
                                 {
                                     Range = new Range(new Position(lastLine, 0), new Position(lastLine, 0)),
                                     NewText = $@"
@@ -194,7 +184,7 @@ domain:
   label: 
 "
                                 }
-                            }
+                            ]
                         }
                 }
             };
@@ -203,50 +193,30 @@ domain:
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingClassImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
     {
-        var fs = request.TextDocument.Uri.GetFileSystemPath();
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
-        var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var className = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
-        var useIndex = modelFile!.Uses.Any()
-            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
-            : text.First().StartsWith("-")
-                ? 1
-                : 0;
-
-        return _modelStore.Classes.Where(c => c.Name == className)
+        var (className, useIndex) = GetImport(request, diagnostic, modelFile);
+        return modelStore.Classes.Where(c => c.Name == className)
             .Select(classToImport => GetFileImportAction(diagnostic, modelFile, classToImport.ModelFile, useIndex));
     }
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDataFlowImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
     {
-        var fs = request.TextDocument.Uri.GetFileSystemPath();
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
-        var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var dataFlowName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
-        var useIndex = modelFile!.Uses.Any()
-            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
-            : text.First().StartsWith("-")
-                ? 1
-                : 0;
-
-        return _modelStore.DataFlows.Where(c => c.Name == dataFlowName)
+        var (dataFlowName, useIndex) = GetImport(request, diagnostic, modelFile);
+        return modelStore.DataFlows.Where(c => c.Name == dataFlowName)
             .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
     }
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDecoratorImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
     {
-        var fs = request.TextDocument.Uri.GetFileSystemPath();
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
-        var line = text.ElementAt(diagnostic.Range.Start.Line);
-        var decoratorName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
-        var useIndex = modelFile!.Uses.Any()
-            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
-            : text.First().StartsWith("-")
-                ? 1
-                : 0;
-
-        return _modelStore.Decorators.Where(c => c.Name == decoratorName)
+        var (decoratorName, useIndex) = GetImport(request, diagnostic, modelFile);
+        return modelStore.Decorators.Where(c => c.Name == decoratorName)
             .Select(decoratorToImport => GetFileImportAction(diagnostic, modelFile, decoratorToImport.ModelFile, useIndex));
+    }
+
+    protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingEndpointImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
+    {
+        var (endpointName, useIndex) = GetImport(request, diagnostic, modelFile);
+        return modelStore.Endpoints.Where(c => c.Name == endpointName)
+            .Select(endpointToImport => GetFileImportAction(diagnostic, modelFile, endpointToImport.ModelFile, useIndex));
     }
 
     private CommandOrCodeAction GetFileImportAction(Diagnostic diagnostic, ModelFile targetFile, ModelFile sourceFile, int useIndex)
@@ -262,16 +232,30 @@ domain:
                 Changes =
                     new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [new Uri(_facade.GetFilePath(targetFile))] = new List<TextEdit>()
-                        {
-                            new TextEdit()
+                        [new Uri(facade.GetFilePath(targetFile))] =
+                        [
+                            new()
                             {
-                                NewText = targetFile.Uses.Any() ? $"  - {sourceFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {sourceFile.Name}{Environment.NewLine}",
+                                NewText = targetFile.Uses.Count > 0 ? $"  - {sourceFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {sourceFile.Name}{Environment.NewLine}",
                                 Range = new Range(useIndex, 0, useIndex, 0)
                             }
-                        }
+                        ]
                     }
             }
         };
+    }
+
+    private (string ImportName, int UseIndex) GetImport(CodeActionParams request, Diagnostic diagnostic, ModelFile modelFile)
+    {
+        var text = modelFileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var line = text.ElementAt(diagnostic.Range.Start.Line);
+        var importName = line[diagnostic.Range.Start.Character..Math.Min(diagnostic.Range.End.Character, line.Length)];
+        var useIndex = modelFile!.Uses.Count != 0
+            ? modelFile.Uses.Last().ToRange()!.Start.Line + 1
+            : text.First().StartsWith('-')
+                ? 1
+                : 0;
+
+        return (importName, useIndex);
     }
 }

--- a/TopModel.LanguageServer/CodeLensHandler.cs
+++ b/TopModel.LanguageServer/CodeLensHandler.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -7,19 +6,8 @@ using TopModel.Core;
 
 namespace TopModel.LanguageServer;
 
-public class CodeLensHandler : CodeLensHandlerBase
+public class CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config) : CodeLensHandlerBase
 {
-    private readonly ModelConfig _config;
-    private readonly ILanguageServerFacade _facade;
-    private readonly ModelStore _modelStore;
-
-    public CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    {
-        _config = config;
-        _facade = facade;
-        _modelStore = modelStore;
-    }
-
     public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
     {
         return Task.FromResult(request);
@@ -27,21 +15,21 @@ public class CodeLensHandler : CodeLensHandlerBase
 
     public override Task<CodeLensContainer?> Handle(CodeLensParams request, CancellationToken cancellationToken)
     {
-        var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
         if (file != null)
         {
-            return Task.FromResult<CodeLensContainer?>(new CodeLensContainer(file.Classes.Select(clazz =>
+            return Task.FromResult<CodeLensContainer?>(new(file.Classes.Select(clazz =>
                 new CodeLens
                 {
                     Range = clazz.GetLocation().ToRange()!,
                     Command = new Command()
                     {
-                        Title = $"{_modelStore.GetClassReferences(clazz).Count()} references",
+                        Title = $"{modelStore.GetClassReferences(clazz).Count()} references",
                         Name = "topmodel.findRef",
-                        Arguments = new JArray
-                        {
+                        Arguments =
+                        [
                             clazz.GetLocation()!.Start.Line - 1
-                        }
+                        ]
                     }
                 })
                 .Concat(file.Domains.Select(domain => new CodeLens
@@ -49,12 +37,12 @@ public class CodeLensHandler : CodeLensHandlerBase
                     Range = domain.GetLocation().ToRange()!,
                     Command = new Command()
                     {
-                        Title = $"{_modelStore.GetDomainReferences(domain).Count()} references",
+                        Title = $"{modelStore.GetDomainReferences(domain).Count()} references",
                         Name = "topmodel.findRef",
-                        Arguments = new JArray
-                        {
+                        Arguments =
+                        [
                             domain.GetLocation()!.Start.Line - 1
-                        }
+                        ]
                     }
                 }))
                 .Concat(file.Decorators.Select(decorator => new CodeLens
@@ -62,12 +50,12 @@ public class CodeLensHandler : CodeLensHandlerBase
                     Range = decorator.GetLocation().ToRange()!,
                     Command = new Command()
                     {
-                        Title = $"{_modelStore.GetDecoratorReferences(decorator).Count()} references",
+                        Title = $"{modelStore.GetDecoratorReferences(decorator).Count()} references",
                         Name = "topmodel.findRef",
-                        Arguments = new JArray
-                        {
+                        Arguments =
+                        [
                             decorator.GetLocation()!.Start.Line - 1
-                        }
+                        ]
                     }
                 })
                 .Concat(file.DataFlows.Select(dataFlow => new CodeLens
@@ -75,14 +63,27 @@ public class CodeLensHandler : CodeLensHandlerBase
                     Range = dataFlow.GetLocation().ToRange()!,
                     Command = new Command()
                     {
-                        Title = $"{_modelStore.GetDataFlowReferences(dataFlow).Count()} references",
+                        Title = $"{modelStore.GetDataFlowReferences(dataFlow).Count()} references",
                         Name = "topmodel.findRef",
-                        Arguments = new JArray
-                        {
+                        Arguments =
+                        [
                             dataFlow.GetLocation()!.Start.Line - 1
-                        }
+                        ]
                     }
-                })))));
+                })))
+                .Concat(file.Endpoints.Select(endpoint => new CodeLens
+                {
+                    Range = endpoint.GetLocation().ToRange()!,
+                    Command = new()
+                    {
+                        Title = $"{modelStore.GetEndpointReferences(endpoint).Count()} references",
+                        Name = "topmodel.findRef",
+                        Arguments =
+                        [
+                            endpoint.GetLocation()!.Start.Line - 1
+                        ]
+                    }
+                }))));
         }
 
         return Task.FromResult<CodeLensContainer?>(new());
@@ -92,7 +93,7 @@ public class CodeLensHandler : CodeLensHandlerBase
     {
         return new CodeLensRegistrationOptions
         {
-            DocumentSelector = _config.GetDocumentSelector()
+            DocumentSelector = config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -8,10 +8,10 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class CompletionHandler : CompletionHandlerBase
+public class CompletionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache fileCache, ModelConfig config) : CompletionHandlerBase
 {
-    private static readonly List<char> Separators = new()
-        {
+    private static readonly char[] Separators =
+        [
             ':',
             ',',
             '{',
@@ -28,20 +28,7 @@ public class CompletionHandler : CompletionHandlerBase
             '\n',
             '.',
             '"'
-        };
-
-    private readonly ModelConfig _config;
-    private readonly ILanguageServerFacade _facade;
-    private readonly ModelFileCache _fileCache;
-    private readonly ModelStore _modelStore;
-
-    public CompletionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelFileCache fileCache, ModelConfig config)
-    {
-        _config = config;
-        _facade = facade;
-        _fileCache = fileCache;
-        _modelStore = modelStore;
-    }
+        ];
 
     public override Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
     {
@@ -50,7 +37,7 @@ public class CompletionHandler : CompletionHandlerBase
 
     public override Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var currentLine = text.ElementAtOrDefault(request.Position.Line);
 
         if (currentLine == null)
@@ -58,7 +45,7 @@ public class CompletionHandler : CompletionHandlerBase
             return Task.FromResult(new CompletionList());
         }
 
-        var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
         if (file == null || currentLine == string.Empty)
         {
             return Task.FromResult(new CompletionList());
@@ -83,16 +70,22 @@ public class CompletionHandler : CompletionHandlerBase
             return Task.FromResult(CompleteDomain(request));
         }
 
-        List<string> classCompleteKeys = new()
-        {
+        List<string> classCompleteKeys =
+        [
             "association",
             "composition",
             "class",
             "extends"
-        };
+        ];
+
         if (classCompleteKeys.Contains(currentKey) && parentKey != currentKey)
         {
             return Task.FromResult(CompleteClass(request, file, useIndex));
+        }
+
+        if (currentKey == "endpoint")
+        {
+            return Task.FromResult(CompleteEndpoint(request, file, useIndex));
         }
 
         // Tags
@@ -108,7 +101,7 @@ public class CompletionHandler : CompletionHandlerBase
         }
 
         // Décorateur
-        else if (currentKey == "decorators")
+        else if (currentKey.Contains("decorator"))
         {
             return Task.FromResult(CompleteDecorator(request, file, useIndex));
         }
@@ -128,17 +121,31 @@ public class CompletionHandler : CompletionHandlerBase
     {
         return new CompletionRegistrationOptions
         {
-            DocumentSelector = _config.GetDocumentSelector()
+            DocumentSelector = config.GetDocumentSelector()
         };
+    }
+
+    private static int GetUseIndex(ModelFile file, string[] text)
+    {
+        if (file.Uses.Count > 0)
+        {
+            return file.Uses.Last().ToRange()!.Start.Line + 1;
+        }
+        else if (text.First().StartsWith('-'))
+        {
+            return 1;
+        }
+
+        return 0;
     }
 
     private CompletionList CompleteClass(CompletionParams request, ModelFile file, int useIndex)
     {
         var searchText = GetSearchText(request);
-        var availableClasses = new HashSet<Class>(_modelStore.GetAvailableClasses(file));
+        var availableClasses = new HashSet<Class>(modelStore.GetAvailableClasses(file));
 
-        return new CompletionList(
-            _modelStore.Classes
+        return new(
+            modelStore.Classes
                 .Where(classe => classe.Name.ToLower().ShouldMatch(searchText))
                 .Select(classe => new CompletionItem
                 {
@@ -150,15 +157,15 @@ public class CompletionHandler : CompletionHandlerBase
                     },
                     InsertText = classe.Name,
                     SortText = availableClasses.Contains(classe) ? "0000" + classe.Name : classe.Name,
-                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+                    TextEdit = new(new TextEdit
                     {
                         NewText = classe.Name,
                         Range = GetCompleteRange(searchText, request)
                     }),
                     AdditionalTextEdits = !availableClasses.Contains(classe) ?
-                        new TextEditContainer(new TextEdit
+                        new(new TextEdit
                         {
-                            NewText = file.Uses.Any() ? $"  - {classe.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {classe.ModelFile.Name}{Environment.NewLine}",
+                            NewText = file.Uses.Count > 0 ? $"  - {classe.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {classe.ModelFile.Name}{Environment.NewLine}",
                             Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(useIndex, 0, useIndex, 0)
                         })
                         : null
@@ -168,10 +175,10 @@ public class CompletionHandler : CompletionHandlerBase
     private CompletionList CompleteDataFlow(CompletionParams request, ModelFile file, int useIndex)
     {
         var searchText = GetSearchText(request);
-        var availableDataFlows = new HashSet<DataFlow>(_modelStore.GetAvailableDataFlows(file));
+        var availableDataFlows = new HashSet<DataFlow>(modelStore.GetAvailableDataFlows(file));
 
-        return new CompletionList(
-            _modelStore.DataFlows
+        return new(
+            modelStore.DataFlows
                 .Where(dataFlow => dataFlow.Name.ToLower().ShouldMatch(searchText))
                 .OrderBy(dataFlow => dataFlow.Name)
                 .Select(dataFlow => new CompletionItem
@@ -180,15 +187,15 @@ public class CompletionHandler : CompletionHandlerBase
                     Label = availableDataFlows.Contains(dataFlow) ? dataFlow.Name : $"{dataFlow.Name} - ({dataFlow.ModelFile.Name})",
                     InsertText = dataFlow.Name,
                     SortText = availableDataFlows.Contains(dataFlow) ? "0000" + dataFlow.Name : dataFlow.Name,
-                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+                    TextEdit = new(new TextEdit
                     {
                         NewText = dataFlow.Name,
                         Range = GetCompleteRange(searchText, request)
                     }),
                     AdditionalTextEdits = !availableDataFlows.Contains(dataFlow) ?
-                        new TextEditContainer(new TextEdit
+                        new(new TextEdit
                         {
-                            NewText = file.Uses.Any() ? $"  - {dataFlow.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {dataFlow.ModelFile.Name}{Environment.NewLine}",
+                            NewText = file.Uses.Count > 0 ? $"  - {dataFlow.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {dataFlow.ModelFile.Name}{Environment.NewLine}",
                             Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(useIndex, 0, useIndex, 0)
                         })
                         : null
@@ -198,10 +205,10 @@ public class CompletionHandler : CompletionHandlerBase
     private CompletionList CompleteDecorator(CompletionParams request, ModelFile file, int useIndex)
     {
         var searchText = GetSearchText(request);
-        var availableDecorators = new HashSet<Decorator>(_modelStore.GetAvailableDecorators(file));
+        var availableDecorators = new HashSet<Decorator>(modelStore.GetAvailableDecorators(file));
 
-        return new CompletionList(
-            _modelStore.Decorators
+        return new(
+            modelStore.Decorators
                 .Where(decorator => decorator.Name.ToLower().ShouldMatch(searchText))
                 .OrderBy(decorator => decorator.Name)
                 .Select(decorator => new CompletionItem
@@ -214,15 +221,15 @@ public class CompletionHandler : CompletionHandlerBase
                     },
                     InsertText = decorator.Name,
                     SortText = availableDecorators.Contains(decorator) ? "0000" + decorator.Name : decorator.Name,
-                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+                    TextEdit = new(new TextEdit
                     {
                         NewText = decorator.Name,
                         Range = GetCompleteRange(searchText, request)
                     }),
                     AdditionalTextEdits = !availableDecorators.Contains(decorator) ?
-                        new TextEditContainer(new TextEdit
+                        new(new TextEdit
                         {
-                            NewText = file.Uses.Any() ? $"  - {decorator.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {decorator.ModelFile.Name}{Environment.NewLine}",
+                            NewText = file.Uses.Count > 0 ? $"  - {decorator.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {decorator.ModelFile.Name}{Environment.NewLine}",
                             Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(useIndex, 0, useIndex, 0)
                         })
                         : null
@@ -232,15 +239,15 @@ public class CompletionHandler : CompletionHandlerBase
     private CompletionList CompleteDomain(CompletionParams request)
     {
         var searchText = GetSearchText(request);
-        return new CompletionList(
-            _modelStore.Domains
+        return new(
+            modelStore.Domains
                 .Where(domain => domain.Key.ToLower().ShouldMatch(searchText))
                 .OrderBy(domain => domain.Key)
                 .Select(domain => new CompletionItem
                 {
                     Kind = CompletionItemKind.EnumMember,
                     Label = domain.Key,
-                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+                    TextEdit = new(new TextEdit
                     {
                         NewText = domain.Key,
                         Range = GetCompleteRange(searchText, request)
@@ -248,11 +255,44 @@ public class CompletionHandler : CompletionHandlerBase
                 }));
     }
 
+    private CompletionList CompleteEndpoint(CompletionParams request, ModelFile file, int useIndex)
+    {
+        var searchText = GetSearchText(request);
+        var availableEndpoints = new HashSet<Endpoint>(modelStore.GetAvailableEndpoints(file));
+
+        return new(
+            modelStore.Endpoints
+                .Where(endpoint => endpoint.Name.ToLower().ShouldMatch(searchText))
+                .Select(endpoint => new CompletionItem
+                {
+                    Kind = CompletionItemKind.Class,
+                    Label = availableEndpoints.Contains(endpoint) ? endpoint.Name : $"{endpoint.Name} - ({endpoint.ModelFile.Name})",
+                    LabelDetails = new()
+                    {
+                        Description = $"{endpoint.Description}"
+                    },
+                    InsertText = endpoint.Name,
+                    SortText = availableEndpoints.Contains(endpoint) ? "0000" + endpoint.Name : endpoint.Name,
+                    TextEdit = new(new TextEdit
+                    {
+                        NewText = endpoint.Name,
+                        Range = GetCompleteRange(searchText, request)
+                    }),
+                    AdditionalTextEdits = !availableEndpoints.Contains(endpoint) ?
+                        new(new TextEdit
+                        {
+                            NewText = file.Uses.Count > 0 ? $"  - {endpoint.ModelFile.Name}{Environment.NewLine}" : $"uses:{Environment.NewLine}  - {endpoint.ModelFile.Name}{Environment.NewLine}",
+                            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(useIndex, 0, useIndex, 0)
+                        })
+                        : null
+                }));
+    }
+
     private CompletionList CompleteFile(CompletionParams request, ModelFile file)
     {
         var searchText = GetSearchText(request);
-        return new CompletionList(
-            _modelStore.Files.Select(f => f.Name)
+        return new(
+            modelStore.Files.Select(f => f.Name)
                 .Except(file.Uses.Select(u => u.ReferenceName))
                 .Where(name => name != file.Name && name.ToLower().ShouldMatch(searchText))
                 .Select(name => new CompletionItem
@@ -271,16 +311,30 @@ public class CompletionHandler : CompletionHandlerBase
     {
         // Alias, propriété d'association ou propriété de flux de données
         string? className = null;
+        string? endpointName = null;
+        string? decoratorName = null;
         var requestLine = request.Position.Line;
         var isListElement = currentLine.TrimStart().StartsWith('-');
         var isInlineList = currentLine.Contains(':') && currentLine.Split(':')[1].TrimStart().StartsWith('[');
-        var objectRange = isListElement ? GetParentRange(text, requestLine) : GetObjectRange(text, requestLine);
-        var objectLines = text[objectRange.Start..objectRange.End];
+        var (start, end) = isListElement ? GetParentRange(text, requestLine) : GetObjectRange(text, requestLine);
+        var objectLines = text[start..end];
         var searchText = GetSearchText(request);
-        var cl = objectLines.ToList().Find(o => o.Contains("class: ") || o.Contains("association: "));
+        var cl = objectLines.FirstOrDefault(o => o.Contains("class: ") || o.Contains("association: "));
         if (cl != null)
         {
             className = cl.Split(": ")[1].Trim();
+        }
+
+        var ep = objectLines.FirstOrDefault(o => o.Contains("endpoint: "));
+        if (ep != null)
+        {
+            endpointName = ep.Split(": ")[1].Trim();
+        }
+
+        var dc = objectLines.FirstOrDefault(o => o.Contains("decorator: "));
+        if (dc != null)
+        {
+            decoratorName = dc.Split(": ")[1].Trim();
         }
 
         var currentKey = GetCurrentKey(request);
@@ -292,13 +346,34 @@ public class CompletionHandler : CompletionHandlerBase
         {
             "include", "exclude", "property", "activeProperty"
         };
+
         if (!string.IsNullOrEmpty(className) && ((isListElement || isInlineList) && propertyListKeyWords.Contains(currentKey.Key)
-                                || propertyKeyWords.Contains(currentKey.Key)))
+            || propertyKeyWords.Contains(currentKey.Key)))
         {
-            var referencedClasses = _modelStore.GetReferencedClasses(file);
-            if (referencedClasses.TryGetValue(className, out var aliasedClass))
+            var referencedClasses = modelStore.GetReferencedClasses(file);
+            if (referencedClasses.TryGetValue(className, out var referencedClass))
             {
-                return CompleteProperty(request, aliasedClass, false);
+                return CompleteProperty(request, referencedClass, false);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(endpointName) && ((isListElement || isInlineList) && propertyListKeyWords.Contains(currentKey.Key)
+            || propertyKeyWords.Contains(currentKey.Key)))
+        {
+            var referencedEndpoints = modelStore.GetReferencedEndpoints(file);
+            if (referencedEndpoints.TryGetValue(endpointName, out var referencedEndpoint))
+            {
+                return CompleteProperty(request, referencedEndpoint, false);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(decoratorName) && ((isListElement || isInlineList) && propertyListKeyWords.Contains(currentKey.Key)
+            || propertyKeyWords.Contains(currentKey.Key)))
+        {
+            var referencedDecorators = modelStore.GetReferencedDecorators(file);
+            if (referencedDecorators.TryGetValue(decoratorName, out var referencedDecorator))
+            {
+                return CompleteProperty(request, referencedDecorator, false);
             }
         }
 
@@ -345,12 +420,12 @@ public class CompletionHandler : CompletionHandlerBase
                         var isKey = textBefore.LastIndexOf(':') == -1 || textBefore.LastIndexOf(':') < Math.Max(textBefore.LastIndexOf(','), textBefore.LastIndexOf('{'));
                         if (!isKey)
                         {
-                            var parentObjectRange = GetObjectRange(text, parentKey.Line);
-                            var parentObjectLines = text[parentObjectRange.Start..(parentObjectRange.End + 1)];
+                            var (startP, endP) = GetObjectRange(text, parentKey.Line);
+                            var parentObjectLines = text[startP..(endP + 1)];
                             className = parentObjectLines.First(l => l.Contains("class: ")).TrimStart().Split(':')[1].Trim();
                         }
 
-                        var referencedClasses = _modelStore.GetReferencedClasses(file);
+                        var referencedClasses = modelStore.GetReferencedClasses(file);
                         if (referencedClasses.TryGetValue(className, out var aliasedClass))
                         {
                             classe = aliasedClass;
@@ -378,11 +453,11 @@ public class CompletionHandler : CompletionHandlerBase
         return new CompletionList();
     }
 
-    private CompletionList CompleteProperty(CompletionParams request, Class classe, bool includeExtends)
+    private CompletionList CompleteProperty(CompletionParams request, IPropertyContainer container, bool includeExtends)
     {
-        var properties = includeExtends ? classe.ExtendedProperties : classe.Properties;
+        var properties = includeExtends && container is Class classe ? classe.ExtendedProperties : container.Properties;
         var searchText = GetSearchText(request);
-        return new CompletionList(properties
+        return new(properties
             .Where(f => f.Name.ShouldMatch(searchText))
             .Select(f => new CompletionItem
             {
@@ -403,36 +478,36 @@ public class CompletionHandler : CompletionHandlerBase
     private CompletionList CompleteTag(CompletionParams request, ModelFile file)
     {
         var searchText = GetSearchText(request);
-        return new CompletionList(
-            _modelStore.Files.SelectMany(f => f.Tags)
-            .Distinct()
-            .Where(t => !file.Tags.Contains(t))
-            .Where(tag => tag.ShouldMatch(searchText))
-            .Select(tag => new CompletionItem
-            {
-                Kind = CompletionItemKind.Keyword,
-                Label = tag,
-                TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+        return new(
+            modelStore.Files.SelectMany(f => f.Tags)
+                .Distinct()
+                .Where(t => !file.Tags.Contains(t))
+                .Where(tag => tag.ShouldMatch(searchText))
+                .Select(tag => new CompletionItem
                 {
-                    NewText = tag,
-                    Range = GetCompleteRange(searchText, request)
-                })
-            }));
+                    Kind = CompletionItemKind.Keyword,
+                    Label = tag,
+                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit
+                    {
+                        NewText = tag,
+                        Range = GetCompleteRange(searchText, request)
+                    })
+                }));
     }
 
     private OmniSharp.Extensions.LanguageServer.Protocol.Models.Range GetCompleteRange(string searchText, CompletionParams request)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var currentLine = text.ElementAtOrDefault(request.Position.Line)!;
         int start, end = currentLine.Length;
-        if (currentLine.Length > 0 && Separators.Exists(currentLine.Contains))
+        if (currentLine.Length > 0 && Array.Exists(Separators, currentLine.Contains))
         {
             var left = currentLine[..request.Position.Character];
-            start = left.LastIndexOfAny(Separators.ToArray()) + 1;
+            start = left.LastIndexOfAny(Separators) + 1;
             var right = currentLine[request.Position.Character..];
-            if (right.IndexOfAny(Separators.ToArray()) >= 0)
+            if (right.IndexOfAny(Separators) >= 0)
             {
-                end = request.Position.Character + right.IndexOfAny(Separators.ToArray());
+                end = request.Position.Character + right.IndexOfAny(Separators);
             }
         }
         else
@@ -441,15 +516,15 @@ public class CompletionHandler : CompletionHandlerBase
         }
 
         return new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-                            request.Position.Line,
-                            start,
-                            request.Position.Line,
-                            end);
+            request.Position.Line,
+            start,
+            request.Position.Line,
+            end);
     }
 
     private (string Key, int Line, int End, bool IsKey) GetCurrentKey(CompletionParams request)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         return GetCurrentKey(text, request.Position.Line, request.Position.Character);
     }
 
@@ -553,7 +628,7 @@ public class CompletionHandler : CompletionHandlerBase
 
     private (string Key, int Line, int End, bool IsKey) GetParentKey(CompletionParams request)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         return GetParentKey(text, request.Position.Line, request.Position.Character);
     }
 
@@ -602,7 +677,7 @@ public class CompletionHandler : CompletionHandlerBase
 
     private (string Object, int Line) GetRootObject(CompletionParams request)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var currentLine = text.ElementAtOrDefault(request.Position.Line);
         var requestLine = request.Position.Line;
         var rootLine = currentLine ?? string.Empty;
@@ -628,29 +703,15 @@ public class CompletionHandler : CompletionHandlerBase
 
     private string GetSearchText(CompletionParams request)
     {
-        var text = _fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
         var currentLine = text.ElementAtOrDefault(request.Position.Line)!;
         int start = 0, end = request.Position.Character;
         var left = currentLine[..end];
-        if (currentLine.Length > 0 && Separators.Exists(currentLine.Contains))
+        if (currentLine.Length > 0 && Array.Exists(Separators, currentLine.Contains))
         {
-            start = Math.Min(left.LastIndexOfAny(Separators.ToArray()) + 1, end);
+            start = Math.Min(left.LastIndexOfAny(Separators) + 1, end);
         }
 
         return currentLine[start..end].Trim();
-    }
-
-    private int GetUseIndex(ModelFile file, string[] text)
-    {
-        if (file.Uses.Any())
-        {
-            return file.Uses.Last().ToRange()!.Start.Line + 1;
-        }
-        else if (text.First().StartsWith('-'))
-        {
-            return 1;
-        }
-
-        return 0;
     }
 }

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -20,6 +20,7 @@ public static class OmnisharpExtensions
             Domain domain => domain.Name,
             Decorator decorator => decorator.Name,
             DataFlow dataFlow => dataFlow.Name,
+            Endpoint endpoint => endpoint.Name,
             AliasProperty property => property.OriginalProperty?.Name ?? property.Name,
             IProperty property => property.Name,
             _ => null
@@ -43,6 +44,7 @@ public static class OmnisharpExtensions
             .Concat(file.Domains.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
             .Concat(file.Decorators.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
             .Concat(file.DataFlows.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
+            .Concat(file.Endpoints.Where(d => d.Name.GetLocation()!.Start.Line - 1 == position.Line || d.GetLocation()!.Start.Line - 1 == position.Line).Cast<object>())
             .Concat(file.Properties.Where(p => p.GetLocation()!.Start.Line - 1 == position.Line));
 
         var definedObject = definedObjects.Count() == 1 ? definedObjects.Single() : null;
@@ -59,6 +61,8 @@ public static class OmnisharpExtensions
                     .Concat(modelStore.GetDecoratorReferences(decorator).Select(d => (Reference: (Reference)d.Reference, d.File))),
                 DataFlow dataFlow => new[] { (Reference: dataFlow.Name.GetLocation()!, File: dataFlow.GetFile()!) }
                     .Concat(modelStore.GetDataFlowReferences(dataFlow).Select(d => (Reference: (Reference)d.Reference, d.File))),
+                Endpoint endpoint => new[] { (Reference: endpoint.Name.GetLocation()!, File: endpoint.GetFile()!) }
+                   .Concat(modelStore.GetEndpointReferences(endpoint).Select(d => (Reference: (Reference)d.Reference, d.File))),
                 IProperty property => new[] { (Reference: property.GetLocation()!, File: property.GetFile()!) }
                     .Concat(modelStore.GetPropertyReferences(property, includeTransitive).Select(d => (d.Reference, d.File))),
                 _ => null!

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -7,32 +7,21 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class RenameHandler : RenameHandlerBase
+public class RenameHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config) : RenameHandlerBase
 {
-    private readonly ModelConfig _config;
-    private readonly ILanguageServerFacade _facade;
-    private readonly ModelStore _modelStore;
-
-    public RenameHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    {
-        _config = config;
-        _facade = facade;
-        _modelStore = modelStore;
-    }
-
     public override Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
     {
-        var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath());
         if (file != null)
         {
-            var references = _modelStore.GetReferencesForPositionInFile(request.Position, file, true);
-            if (references != null && references.All(r => r.Reference.ReferenceName == references.Objet.GetName() || r.Reference is ClassReference))
+            var references = modelStore.GetReferencesForPositionInFile(request.Position, file, true);
+            if (references != null && references.All(r => r.Reference.ReferenceName == references.Objet.GetName() || r.Reference is ClassReference || r.Reference is EndpointReference))
             {
                 return Task.FromResult<WorkspaceEdit?>(new WorkspaceEdit
                 {
                     Changes = references
                         .Where(r => r.Reference.ReferenceName == references.Objet.GetName())
-                        .Select(r => new Location { Uri = new Uri(_facade.GetFilePath(r.File)), Range = r.Reference.ToRange()! })
+                        .Select(r => new Location { Uri = new Uri(facade.GetFilePath(r.File)), Range = r.Reference.ToRange()! })
                         .Select(c => new
                         {
                             c.Uri,
@@ -55,7 +44,7 @@ public class RenameHandler : RenameHandlerBase
     {
         return new RenameRegistrationOptions
         {
-            DocumentSelector = _config.GetDocumentSelector()
+            DocumentSelector = config.GetDocumentSelector()
         };
     }
 }

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -7,24 +7,13 @@ using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class SemanticTokensHandler : SemanticTokensHandlerBase
+public class SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config) : SemanticTokensHandlerBase
 {
-    private readonly ModelConfig _config;
-    private readonly ILanguageServerFacade _facade;
-    private readonly ModelStore _modelStore;
-
-    public SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    {
-        _config = config;
-        _facade = facade;
-        _modelStore = modelStore;
-    }
-
     protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(SemanticTokensCapability capability, ClientCapabilities clientCapabilities)
     {
         return new SemanticTokensRegistrationOptions
         {
-            DocumentSelector = _config.GetDocumentSelector(),
+            DocumentSelector = config.GetDocumentSelector(),
             Legend = new()
             {
                 TokenModifiers = capability.TokenModifiers,
@@ -45,12 +34,12 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
 
     protected override Task Tokenize(SemanticTokensBuilder builder, ITextDocumentIdentifierParams identifier, CancellationToken cancellationToken)
     {
-        var file = _modelStore.Files.SingleOrDefault(f => _facade.GetFilePath(f) == identifier.TextDocument.Uri.GetFileSystemPath());
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == identifier.TextDocument.Uri.GetFileSystemPath());
         if (file != null)
         {
             foreach (var reference in file.Uses)
             {
-                if (_modelStore.Files.Any(f => f.Name == reference.ReferenceName))
+                if (modelStore.Files.Any(f => f.Name == reference.ReferenceName))
                 {
                     builder.Push(reference.ToRange()!, SemanticTokenType.Parameter, SemanticTokenModifier.Definition);
                 }
@@ -60,7 +49,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
             {
                 var type = reference switch
                 {
-                    ClassReference or DecoratorReference => SemanticTokenType.Class,
+                    ClassReference or DecoratorReference or EndpointReference => SemanticTokenType.Class,
                     DataFlowReference => SemanticTokenType.Operator,
                     DomainReference => SemanticTokenType.EnumMember,
                     Reference r when r.ReferenceName == "false" => SemanticTokenType.Keyword,

--- a/docs/model/properties.md
+++ b/docs/model/properties.md
@@ -99,7 +99,7 @@ La classe référencée par la composition doit être connue du fichier de modè
 
 Dans le modèle d'une application, il est très courant d'avoir besoin de référencer des propriétés définies dans d'autres objets lorsqu'on construit un nouvel objet. L'exemple le plus courant est le cas des DTOs, qui sont des objets qui vont être utilisés dans l'API publique d'une application et qui sont bien souvent presque identiques à des objets persistés, plutôt réservés à une API "interne".
 
-TopModel permet donc de définir des **alias** de propriétés, qui pourront être utilisés pour **recopier** des définitions déjà écrites par ailleurs dans une une autre classe (ou dans la définition d'un endpoint).
+TopModel permet donc de définir des **alias** de propriétés, qui pourront être utilisés pour **recopier** des définitions déjà écrites par ailleurs dans une autre classe, un autre endpoint, ou un autre décorateur.
 
 Pour se faire, il est possible de définir un `alias` à la place d'une définition de propriété, par exemple :
 
@@ -108,6 +108,14 @@ alias:
   class: MyClass
   property: MyProperty1
 prefix: true
+
+alias:
+  endpoint: MyEndpoint
+  property: MyParameter # Vous pouvez référencer à la fois les paramètres comme la propriété de retour.
+
+alias:
+  decorator: MyDecorator
+  property: MyProperty
 ```
 
 Il est possible de préfixer ou suffixer le nom de la propriété recopiée (`true` est une valeur spéciale qui correspond au nom de la classe), et même de surcharger son libellé, commentaire, caractère obligatoire, domaine, valeur par défaut, caractère readonly...

--- a/samples/generators/csharp/topmodel.lock
+++ b/samples/generators/csharp/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.7.0
 custom:
-  ../../../TopModel.Generator.Csharp: 28f3f1b37f54b2b34e2099808b8780fd
+  ../../../TopModel.Generator.Csharp: ac1547bf8a1e1b0ed7d6b9a6d4392ee8
 generatedFiles:
   - ./src/Clients/TopModel.Sample.Clients.Db/generated/TopModelSampleDbContext.comments.cs
   - ./src/Clients/TopModel.Sample.Clients.Db/generated/TopModelSampleDbContext.cs


### PR DESCRIPTION
Avec cette PR, il est désormais possible de spécifier des alias qui référencent des propriétés d'endpoint ou de décorateur, par exemple : 

```yaml
alias:
  endpoint: MyEndpoint
  property: MyParameter # Vous pouvez référencer à la fois les paramètres comme la propriété de retour.

alias:
  decorator: MyDecorator
  property: MyProperty
```

Ils se comportent exactement de la même façon que les alias de propriétés de classes et obéissent au même fonctionnement. Il s'agit de la première fonctionnalité qui utilise des références d'endpoint, donc elles existent maintenant dans l'extension VSCode également.

Il n'est pas impossible de rencontrer une incompatibilité avec un générateur si celui-ci suppose que la propriété référencée dans un alias est forcément issue d'une classe, dans ce cas un fix devra être réalisé sur ce dernier pour utiliser la fonctionnalité. Cette PR corrige donc également une incompatibilité potentielle sur le générateur C#.

Cette PR servira de correction indirecte à #289, puisque la demande pourra être implémentée avec un alias de propriétés de décorateur dans le second décorateur.