### PR TITLE
Décorateurs sur les décorateurs

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -42,6 +42,8 @@ public class ModelFile
         .Concat(Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object)))
         .Concat(Classes.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
         .Concat(Classes.SelectMany(c => c.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))
+        .Concat(Decorators.SelectMany(d => d.DecoratorReferences.Select(dr => (dr as Reference, d.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
+        .Concat(Decorators.SelectMany(d => d.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, d.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))
         .Concat(Endpoints.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
         .Concat(Endpoints.SelectMany(c => c.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))
         .Concat(Endpoints.SelectMany(e => e.RouteWithVariables.Variables.Select(pr => (pr as Reference, e.Params.FirstOrDefault(p => p.GetParamName() == pr.ReferenceName) as object))))

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -1,4 +1,5 @@
-﻿using TopModel.Core.Model.Implementation;
+﻿using TopModel.Core.FileModel;
+using TopModel.Core.Model.Implementation;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -25,6 +26,29 @@ public class DecoratorLoader(FileChecker fileChecker, PropertyLoader propertyLoa
                     break;
                 case "preservePropertyCasing":
                     decorator.PreservePropertyCasing = value!.Value == "true";
+                    break;
+                case "decorators":
+                    parser.ConsumeSequence(() =>
+                    {
+                        if (parser.Current is MappingStart)
+                        {
+                            parser.ConsumeMapping(prop =>
+                            {
+                                var decoratorRef = new DecoratorReference(prop);
+
+                                parser.ConsumeSequence(() =>
+                                {
+                                    decoratorRef.ParameterReferences.Add(new ParameterReference(parser.Consume<Scalar>()));
+                                });
+
+                                decorator.DecoratorReferences.Add(decoratorRef);
+                            });
+                        }
+                        else
+                        {
+                            decorator.DecoratorReferences.Add(new DecoratorReference(parser.Consume<Scalar>()));
+                        }
+                    });
                     break;
                 case "properties":
                     parser.ConsumeSequence(() =>

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -149,6 +149,8 @@ public class AliasProperty : IProperty
         set => _customProperties = value;
     }
 
+    public Decorator? SourceDecorator { get; set; }
+
     public IProperty? OriginalProperty => _property;
 
     public IProperty? PersistentProperty => (Class?.IsPersistent ?? false)
@@ -181,14 +183,15 @@ public class AliasProperty : IProperty
 
     internal AliasProperty? OriginalAliasProperty { get; private set; }
 
-    /// <inheritdoc cref="IProperty.CloneWithClassOrEndpoint" />
-    public IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null)
+    /// <inheritdoc cref="IProperty.CloneForDecorator" />
+    public IProperty CloneForDecorator(Class? classe = null, Endpoint? endpoint = null, Decorator? decorator = null)
     {
         var alp = new AliasProperty
         {
+            SourceDecorator = Decorator,
             Class = classe,
             Comment = _comment!,
-            Decorator = Decorator,
+            Decorator = decorator,
             DefaultValue = _defaultValue,
             Endpoint = endpoint,
             Label = _label,
@@ -239,6 +242,7 @@ public class AliasProperty : IProperty
             PropertyReference = includeReference,
             Class = Class,
             Decorator = Decorator,
+            SourceDecorator = SourceDecorator,
             DomainReference = DomainReference,
             Endpoint = Endpoint,
             PrimaryKey = PrimaryKey,

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -168,6 +168,8 @@ public class AssociationProperty : IProperty
 
     public bool PrimaryKey { get; set; }
 
+    public Decorator? SourceDecorator { get; set; }
+
     public Reference? PropertyReference { get; set; }
 
 #nullable disable
@@ -179,15 +181,16 @@ public class AssociationProperty : IProperty
 #nullable enable
 #pragma warning disable KTA1600
 
-    /// <inheritdoc cref="IProperty.CloneWithClassOrEndpoint" />
-    public IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null)
+    /// <inheritdoc cref="IProperty.CloneForDecorator" />
+    public IProperty CloneForDecorator(Class? classe = null, Endpoint? endpoint = null, Decorator? decorator = null)
     {
         return new AssociationProperty
         {
+            SourceDecorator = Decorator,
             Association = Association,
             Class = classe,
             Comment = Comment,
-            Decorator = Decorator,
+            Decorator = decorator,
             DefaultValue = DefaultValue,
             Endpoint = endpoint,
             Label = Label,

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -43,7 +43,7 @@ public class Class : IPropertyContainer
 
     public IList<IProperty> Properties { get; } = [];
 
-    public IList<IProperty> ExtendedProperties => Extends != null ? Properties.Concat(Extends.ExtendedProperties).ToList() : Properties;
+    public IList<IProperty> ExtendedProperties => Extends != null ? [.. Properties, .. Extends.ExtendedProperties] : Properties;
 
     public bool PreservePropertyCasing { get; set; }
 

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -66,6 +66,8 @@ public class CompositionProperty : IProperty
 
     public bool UseLegacyRoleName { get; init; }
 
+    public Decorator? SourceDecorator { get; set; }
+
 #nullable disable
     public ClassReference Reference { get; set; }
 
@@ -74,15 +76,16 @@ public class CompositionProperty : IProperty
 #nullable enable
     internal DomainReference? DomainReference { get; set; }
 
-    /// <inheritdoc cref="IProperty.CloneWithClassOrEndpoint" />
-    public IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null)
+    /// <inheritdoc cref="IProperty.CloneForDecorator" />
+    public IProperty CloneForDecorator(Class? classe = null, Endpoint? endpoint = null, Decorator? decorator = null)
     {
         return new CompositionProperty
         {
+            SourceDecorator = Decorator,
             Class = classe,
             Comment = Comment,
             Composition = Composition,
-            Decorator = Decorator,
+            Decorator = decorator,
             Domain = Domain,
             DomainParameters = DomainParameters,
             Endpoint = endpoint,

--- a/TopModel.Core/Model/Decorator.cs
+++ b/TopModel.Core/Model/Decorator.cs
@@ -23,6 +23,8 @@ public class Decorator : IPropertyContainer
 
     public Namespace Namespace { get; set; }
 
+    public List<(Decorator Decorator, string[] Parameters)> Decorators { get; } = [];
+
     public IList<IProperty> Properties { get; } = [];
 
     public bool PreservePropertyCasing { get; set; }
@@ -48,6 +50,8 @@ public class Decorator : IPropertyContainer
                 ..i.Imports.SelectMany(a => a.Transforms)
            ])
        .Where(pr => pr.ReferenceName.IsValidTransform());
+
+    public List<DecoratorReference> DecoratorReferences { get; } = [];
 
     internal Reference Location { get; set; }
 

--- a/TopModel.Core/Model/IProperty.cs
+++ b/TopModel.Core/Model/IProperty.cs
@@ -40,6 +40,8 @@ public interface IProperty
 
     Decorator Decorator { get; set; }
 
+    Decorator? SourceDecorator { get; set; }
+
     PropertyMapping PropertyMapping { get; set; }
 
     IPropertyContainer Parent => Class ?? (IPropertyContainer)Endpoint ?? (IPropertyContainer)Decorator ?? PropertyMapping;
@@ -69,16 +71,16 @@ public interface IProperty
         }
     }
 
-    IProperty ResourceProperty => Decorator != null && Parent != Decorator
-       ? Decorator.Properties.First(p => p.Name == Name).ResourceProperty
+    IProperty ResourceProperty => SourceDecorator != null
+       ? SourceDecorator.Properties.First(p => p.Name == Name).ResourceProperty
        : this is AliasProperty alp && alp.Label == alp.OriginalProperty?.Label
        ? alp.OriginalProperty!.ResourceProperty
        : this;
 
     string ResourceKey => $"{ResourceProperty.Parent.Namespace.ModuleCamel}.{ResourceProperty.Parent.NameCamel}.{ResourceProperty.NameCamel}";
 
-    IProperty CommentResourceProperty => Decorator != null && Parent != Decorator
-        ? Decorator.Properties.First(p => p.Name == Name).CommentResourceProperty
+    IProperty CommentResourceProperty => SourceDecorator != null
+        ? SourceDecorator.Properties.First(p => p.Name == Name).CommentResourceProperty
         : this is AliasProperty alp && alp.Comment == alp.OriginalProperty?.Comment
         ? alp.OriginalProperty!.CommentResourceProperty
         : this;
@@ -103,11 +105,11 @@ public interface IProperty
             return prop switch
             {
                 AssociationProperty or AliasProperty { Property: AssociationProperty } => apPk?.RawSqlName ?? string.Empty,
-                { Class.Extends: not null, PrimaryKey: true } => prop.Name[prop.Class.Name.Length..].ToConstantCase(),
+                { Class.Extends: not null, PrimaryKey: true } when prop.Name.StartsWith(prop.Class.Name) => prop.Name[prop.Class.Name.Length..].ToConstantCase(),
                 _ => prop.Name.ToConstantCase()
             };
         }
     }
 
-    IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null);
+    IProperty CloneForDecorator(Class? classe = null, Endpoint? endpoint = null, Decorator? decorator = null);
 }

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -53,19 +53,22 @@ public class RegularProperty : IProperty
 
     public bool UseLegacyRoleName { get; init; }
 
+    public Decorator? SourceDecorator { get; set; }
+
 #nullable disable
     internal Reference Location { get; set; }
 #nullable enable
 #pragma warning disable KTA1600
 
-    /// <inheritdoc cref="IProperty.CloneWithClassOrEndpoint" />
-    public IProperty CloneWithClassOrEndpoint(Class? classe = null, Endpoint? endpoint = null)
+    /// <inheritdoc cref="IProperty.CloneForDecorator" />
+    public IProperty CloneForDecorator(Class? classe = null, Endpoint? endpoint = null, Decorator? decorator = null)
     {
         return new RegularProperty
         {
+            SourceDecorator = Decorator,
             Class = classe,
             Comment = Comment,
-            Decorator = Decorator,
+            Decorator = decorator,
             DefaultValue = DefaultValue,
             Domain = Domain,
             DomainParameters = DomainParameters,

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -44,6 +44,11 @@ public static class ModelExtensions
             .Select(c => (
                 Reference: c.DecoratorReferences.First(dr => dr.ReferenceName == decorator.Name),
                 File: c.GetFile()))
+        .Concat(modelStore.Decorators
+            .Where(d => d.Decorators.Select(d => d.Decorator).Contains(decorator))
+            .Select(d => (
+                Reference: d.DecoratorReferences.First(dr => dr.ReferenceName == decorator.Name),
+                File: d.GetFile())))
         .Concat(modelStore.Endpoints
             .Where(e => e.Decorators.Select(d => d.Decorator).Contains(decorator))
             .Select(e => (

--- a/TopModel.Core/Resolvers/DecoratorResolver.cs
+++ b/TopModel.Core/Resolvers/DecoratorResolver.cs
@@ -10,18 +10,34 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
     /// </summary>
     public void CopyDecoratorProperties()
     {
+        foreach (var decorator in modelFile.Decorators)
+        {
+            if (decorator.Decorators.Count > 0)
+            {
+                foreach (var prop in decorator.Properties.Where(p => p.SourceDecorator is not null).ToList())
+                {
+                    decorator.Properties.Remove(prop);
+                }
+
+                foreach (var prop in decorator.Decorators.SelectMany(d => d.Decorator.Properties))
+                {
+                    decorator.Properties.Add(prop.CloneForDecorator(decorator: decorator));
+                }
+            }
+        }
+
         foreach (var classe in modelFile.Classes)
         {
             if (classe.Decorators.Count > 0)
             {
-                foreach (var prop in classe.Properties.Where(p => p.Decorator is not null).ToList())
+                foreach (var prop in classe.Properties.Where(p => p.SourceDecorator is not null).ToList())
                 {
                     classe.Properties.Remove(prop);
                 }
 
                 foreach (var prop in classe.Decorators.SelectMany(d => d.Decorator.Properties))
                 {
-                    classe.Properties.Add(prop.CloneWithClassOrEndpoint(classe: classe));
+                    classe.Properties.Add(prop.CloneForDecorator(classe: classe));
                 }
             }
         }
@@ -30,14 +46,14 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
         {
             if (endpoint.Decorators.Count > 0)
             {
-                foreach (var prop in endpoint.Params.Where(p => p.Decorator is not null).ToList())
+                foreach (var prop in endpoint.Params.Where(p => p.SourceDecorator is not null).ToList())
                 {
                     endpoint.Params.Remove(prop);
                 }
 
                 foreach (var prop in endpoint.Decorators.SelectMany(d => d.Decorator.Properties))
                 {
-                    endpoint.Params.Add(prop.CloneWithClassOrEndpoint(endpoint: endpoint));
+                    endpoint.Params.Add(prop.CloneForDecorator(endpoint: endpoint));
                 }
             }
         }
@@ -66,6 +82,49 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
             }
         }
 
+        foreach (var decorator in modelFile.Decorators.Where(c => c.DecoratorReferences.Count > 0))
+        {
+            decorator.Decorators.Clear();
+
+            var isError = false;
+            foreach (var decoratorRef in decorator.DecoratorReferences)
+            {
+                if (!referencedDecorators.TryGetValue(decoratorRef.ReferenceName, out var targetDecorator))
+                {
+                    isError = true;
+                    yield return new ModelError(decorator, $"Le décorateur '{decoratorRef.ReferenceName}' est introuvable dans le fichier ou l'une de ses dépendances.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1008 };
+                }
+                else
+                {
+                    if (decorator.Decorators.Any(d => d.Decorator == targetDecorator))
+                    {
+                        isError = true;
+                        yield return new ModelError(decorator, $"Le décorateur '{decoratorRef.ReferenceName}' est déjà présent dans la liste des décorateurs du décorateur '{decorator}'.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1009 };
+                    }
+                    else
+                    {
+                        if (targetDecorator.Implementations.Any(impl => impl.Value.Extends != null && decorator.Implementations.TryGetValue(impl.Key, out var dImpl) && dImpl.Extends != null))
+                        {
+                            isError = true;
+                            yield return new ModelError(decorator, $"Impossible d'appliquer le décorateur '{decoratorRef.ReferenceName}' au décorateur '{decorator}' : seul un 'extends' peut être spécifié.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1010 };
+                        }
+
+                        foreach (var error in CheckDecoratorParameters(decorator, decoratorRef, targetDecorator))
+                        {
+                            yield return error;
+                        }
+
+                        decorator.Decorators.Add((targetDecorator, decoratorRef.ParameterReferences.Select(p => p.ReferenceName).ToArray()));
+                    }
+                }
+            }
+
+            if (isError)
+            {
+                continue;
+            }
+        }
+
         foreach (var classe in modelFile.Classes.Where(c => c.DecoratorReferences.Count > 0))
         {
             classe.Decorators.Clear();
@@ -87,7 +146,7 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
                     }
                     else
                     {
-                        if (decorator.Implementations.Any(impl => impl.Value.Extends != null && (classe.Extends != null || classe.Decorators.Any(d => d.Decorator.Implementations.TryGetValue(impl.Key, out var dImpl) && dImpl.Extends != null))))
+                        if (decorator.Implementations.Concat(decorator.Decorators.SelectMany(d => d.Decorator.Implementations)).Any(impl => impl.Value.Extends != null && (classe.Extends != null || classe.Decorators.Any(d => d.Decorator.Implementations.TryGetValue(impl.Key, out var dImpl) && dImpl.Extends != null))))
                         {
                             isError = true;
                             yield return new ModelError(classe, $"Impossible d'appliquer le décorateur '{decoratorRef.ReferenceName}' à la classe '{classe}' : seul un 'extends' peut être spécifié.", decoratorRef) { ModelErrorType = ModelErrorType.TMD1010 };

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -737,6 +737,29 @@
               "type": "boolean",
               "description": "Garde les noms de propriétés tels quels lors de la génération, au lieu de les convertir dans le format du langage cible."
             },
+            "decorators": {
+              "type": "array",
+              "description": "Décorateurs du décorateur",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Nom du décorateur"
+                  },
+                  {
+                    "type": "object",
+                    "description": "Nom du décorateur",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "Paramètre du décorateur"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
             "properties": {
               "type": "array",
               "description": "Liste des propriétés du décorateur.",

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -130,26 +130,28 @@ public abstract class GeneratorConfigBase
     public IEnumerable<(string Annotation, List<string> Imports)> GetAnnotationsAndImports(Class classe, string tag)
     {
         return classe.Decorators
-            .Where(d => GetImplementation(d.Decorator) != null)
-             .SelectMany(d =>
-             {
-                 var decorator = d.Decorator;
-                 var imple = GetImplementation(decorator)!;
-                 return imple.Annotations.Select(a => (Annotation: a.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag),
-                 Imports: imple.Imports.Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)).ToList()));
-             });
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d =>
+            {
+                var (implementation, decorator, parameters) = d;
+                return implementation.Annotations.Select(a => (
+                    Annotation: a.ParseTemplate(decorator, classe, parameters, this, tag),
+                    Imports: implementation.Imports.Select(i => i.ParseTemplate(decorator, classe, parameters, this, tag)).ToList()));
+            });
     }
 
-    public string? GetClassExtends(Class item)
+    public string? GetClassExtends(Class classe)
     {
-        var extendsDecorator = item.Decorators.SingleOrDefault(d => GetImplementation(d.Decorator)?.Extends != null);
-        return item.Extends?.NamePascal ?? GetImplementation(extendsDecorator.Decorator)?.Extends!.ParseTemplate(extendsDecorator.Decorator, item, extendsDecorator.Parameters, this);
+        var extendsDecorator = classe.Decorators.SelectMany(GetDecoratorImplementations).SingleOrDefault(d => d.Implementation.Extends != null);
+        return classe.Extends?.NamePascal ?? GetImplementation(extendsDecorator.Decorator)?.Extends!.ParseTemplate(extendsDecorator.Decorator, classe, extendsDecorator.Parameters, this);
     }
 
     public IEnumerable<string> GetClassImplements(Class classe)
     {
-        return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Implements ?? [])
-            .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this)))
+        return classe.Decorators
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d => (d.Implementation.Implements ?? [])
+                .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this)))
             .Distinct();
     }
 
@@ -201,29 +203,37 @@ public abstract class GeneratorConfigBase
 
     public IEnumerable<string> GetDecoratorAnnotations(Class classe, string tag)
     {
-        return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Annotations ?? [])
-            .Select(a => a.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
+        return classe.Decorators
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d => (d.Implementation.Annotations ?? [])
+                .Select(a => a.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorAnnotations(Endpoint endpoint, string tag)
     {
-        return endpoint.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Annotations ?? [])
-            .Select(a => a.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
+        return endpoint.Decorators
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d => (d.Implementation.Annotations ?? [])
+                .Select(a => a.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorImports(Class classe, string tag)
     {
-        return classe.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Imports ?? [])
-            .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
+        return classe.Decorators
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d => (d.Implementation.Imports ?? [])
+                .Select(i => i.ParseTemplate(d.Decorator, classe, d.Parameters, this, tag)))
             .Distinct();
     }
 
     public IEnumerable<string> GetDecoratorImports(Endpoint endpoint, string tag)
     {
-        return endpoint.Decorators.SelectMany(d => (GetImplementation(d.Decorator)?.Imports ?? [])
-            .Select(i => i.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
+        return endpoint.Decorators
+            .SelectMany(GetDecoratorImplementations)
+            .SelectMany(d => (d.Implementation.Imports ?? [])
+                .Select(i => i.ParseTemplate(d.Decorator, endpoint, d.Parameters, this, tag)))
             .Distinct();
     }
 
@@ -659,6 +669,23 @@ public abstract class GeneratorConfigBase
             (annotation.Target & Target.Dto) > 0 && !IsPersistent(property.Class, tag)
             || (annotation.Target & Target.Persisted) > 0 && IsPersistent(property.Class, tag))
         || (annotation.Target & Target.Api) > 0 && property.Endpoint != null;
+    }
+
+    private IEnumerable<(DecoratorImplementation Implementation, Decorator Decorator, string[] Parameters)> GetDecoratorImplementations((Decorator Decorator, string[] Parameters) d)
+    {
+        var implementation = GetImplementation(d.Decorator);
+        if (implementation != null)
+        {
+            yield return (implementation, d.Decorator, d.Parameters);
+        }
+
+        foreach (var subD in d.Decorator.Decorators)
+        {
+            foreach (var subImplementation in GetDecoratorImplementations(subD))
+            {
+                yield return subImplementation;
+            }
+        }
     }
 
     /// <summary>

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaConstructorGenerator.cs
@@ -44,7 +44,7 @@ public class JavaConstructorGenerator(JpaConfig config)
                 constructor.AddParameter(parameter);
             }
 
-            if (classe.Extends != null || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+            if (Config.GetClassExtends(classe) != null)
             {
                 constructor.AddBodyLine("super();");
             }
@@ -66,7 +66,7 @@ public class JavaConstructorGenerator(JpaConfig config)
             Visibility = "public",
             Comment = "No arg constructor"
         };
-        if (classe.Extends != null || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+        if (Config.GetClassExtends(classe) != null)
         {
             constructor.AddBodyLine("super();");
         }

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaDtoGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaDtoGenerator.cs
@@ -71,9 +71,8 @@ public class JavaDtoGenerator(ILogger<JavaDtoGenerator> logger, IFileWriterProvi
     protected virtual void WriteConstuctors(JavaWriter fw, Class classe, string tag)
     {
         if (Config.MappersInClass && classe.FromMappers.Any(c => c.ClassParams.All(p => Classes.Contains(p.Class)))
-            || classe.Extends != null
             || Classes.Any(c => c.Extends == classe)
-            || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+            || Config.GetClassExtends(classe) != null)
         {
             ConstructorGenerator.WriteNoArgConstructor(fw, classe);
         }

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
@@ -24,7 +24,7 @@ public class JavaEnumConstructorGenerator(JpaConfig config)
         };
         constructor.AddParameter(parameter);
 
-        if (classe.Extends != null || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+        if (Config.GetClassExtends(classe) != null)
         {
             constructor.AddBodyLine("super();");
         }

--- a/TopModel.Generator.Jpa/ClassGeneration/JdbcEntityGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JdbcEntityGenerator.cs
@@ -95,9 +95,8 @@ public class JdbcEntityGenerator(ILogger<JdbcEntityGenerator> logger, IFileWrite
 
         if (Config.CanClassUseEnums(classe, Classes)
             || Config.MappersInClass && classe.FromMappers.Any(c => c.ClassParams.All(p => Classes.Contains(p.Class)))
-            || classe.Extends != null
             || Classes.Any(c => c.Extends == classe)
-            || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+            || Config.GetClassExtends(classe) != null)
         {
             ConstructorGenerator.WriteNoArgConstructor(fw, classe);
         }

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEntityGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEntityGenerator.cs
@@ -244,9 +244,8 @@ public class JpaEntityGenerator(ILogger<JpaEntityGenerator> logger, IFileWriterP
     protected virtual void WriteConstructors(Class classe, string tag, JavaWriter fw)
     {
         if (Config.MappersInClass && classe.FromMappers.Any(c => c.ClassParams.All(p => Classes.Contains(p.Class)))
-            || classe.Extends != null
             || Classes.Any(c => c.Extends == classe)
-            || classe.Decorators.Any(d => Config.GetImplementation(d.Decorator)?.Extends is not null))
+            || Config.GetClassExtends(classe) != null)
         {
             ConstructorGenerator.WriteNoArgConstructor(fw, classe);
         }

--- a/docs/model/decorators.md
+++ b/docs/model/decorators.md
@@ -2,15 +2,17 @@
 
 Afin d'enrichir de manière plus personnalisée le code généré (en Java et C#), il est possible de définir des décorateurs (`decorator`). On peut y déclarer un ensemble d'interfaces implémentées, une classe étendue (hors TopModel), des annotations à ajouter.
 
-Ces décorateurs s'ajoutent ensuite à la définition d'une classe ou d'un endpoint, sous forme de liste. Les décorateurs ne sont pas automatiquement disponibles dans tous les fichiers comme les domaines, donc il faudra qu'ils soient soit importés, soit définis dans le même fichier (comme une classe).
+Ces décorateurs s'ajoutent ensuite à la définition d'une classe, d'un endpoint ou d'un autre décorateur, sous forme de liste. Les décorateurs ne sont pas automatiquement disponibles dans tous les fichiers comme les domaines, donc il faudra qu'ils soient soit importés, soit définis dans le même fichier (comme une classe).
 
 ## Propriétés
 
 Il est également possible de renseigner des propriétés sur les décorateurs. Il n'y a aucune limitation sur les propriétés que l'on peut définir dans un décorateur (on peut mettre des alias, des compositions...).
 
-Ces propriétés sont ensuite recopiées sur les classes ou les endpoints (en tant que paramètres) décorés (littéralement recopiées, il n'y a pas d'alias vers la propriété du décorateur par exemple). Ce sont par la suite des propriétés à part entière de la classe ou du endpoint, qui peuvent être référencées par la suite sans problème (par exemple dans un alias). Leur "location" est en revanche bien dans le décorateur, donc le hover + la navigation dans l'IDE pointe bien vers la déclaration dans le décorateur.
+Ces propriétés sont ensuite recopiées sur les classes, les endpoints (en tant que paramètres) ou les autres décorateurs décorés (littéralement recopiées, il n'y a pas d'alias vers la propriété du décorateur par exemple). Ce sont par la suite des propriétés à part entière de la classe, de l'endpoint, ou du décorateur, qui peuvent être référencées par la suite sans problème (par exemple dans un alias). Leur "location" est en revanche bien dans le décorateur, donc le hover + la navigation dans l'IDE pointe bien vers la déclaration dans le décorateur.
 
-Elles sont ajoutées en dernier dans la liste des propriétés de la classe ou des paramètres du décorateur (attention du coup à l'erreur de doublon de nom de propriété qui s'affichera sur la propriété du décorateur...)
+Elles sont ajoutées en dernier dans la liste des propriétés de la classe ou du décorateur, et en dernier dans les paramètres de l'endpoint (attention du coup à l'erreur de doublon de nom de propriété qui s'affichera sur la propriété du décorateur...)
+
+Lorsqu'un décorateur avec d'autres décorateurs sera appliqué sur une classe ou un endpoint, l'ensemble des propriétés, des interfaces, des annotations et des imports de toute la "hiérarchie" de décorateur sera bien pris en compte.
 
 ## Exemple pour une classe
 

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.7.1
 custom:
-  ../../../TopModel.Generator.Jpa: 5e3441dff70c1f469c2b331e4fdda961
+  ../../../TopModel.Generator.Jpa: 284b9f6ce512a650a0ee493fb87cf629
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
C'est le vrai fix de #289 cette fois ci 😄 

On peut donc désormais faire des choses comme ça : 
```yaml
---
decorator:
  name: Audited
  description: Ajoute la date de création/modification et l'utilisateur lié sur la classe.
  csharp:
    implements:
      - IAudited
  decorators:
    - CreationAudited
    - ModificationAudited
---
decorator:
  name: CreationAudited
  description: Ajoute sur la classe la date de création et l'utilisateur lié à la création.
  csharp:
    implements:
      - ICreationAudited
  properties:
    - name: DateCreation
      label: Date de création
      domain: DO_DATETIME
      required: true
      comment: Date de création.

    - association: Utilisateur
      role: Creation
      comment: Utilisateur ayant créé la ligne.
---
decorator:
  name: ModificationAudited
  description: Ajoute sur la classe la date de modification et l'utilisateur lié à la modification.
  csharp:
    implements:
      - IModificationAudited
  properties:
    - name: DateModification
      label: Date de dernière modification
      domain: DO_DATETIME
      comment: Date de dernière modification.
      required: false

    - association: Utilisateur
      role: DerniereModification
      comment: Utilisateur ayant réalisé la dernière modification.
      required: false
 ```
 
 Toutes les annotations, interfaces... de la chaîne de décorateur est bien reportée sur la classe ou l'endpoint final. Les propriétés du décorateur "intermédiaire" sont bien référençable par des alias, et on ne peut bien avoir qu'un seul "extends" sur toute la chaine + la classe finale.