### PR TITLE
Améliorations identification des variables dans les templates

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -35,10 +35,10 @@ public class ModelFile
 
     public IDictionary<Reference, object> References =>
         Domains.SelectMany(d => d.AsDomains.Keys.Select(adn => d.AsDomainReferences.TryGetValue(adn, out var adr) && d.AsDomains.TryGetValue(adn, out var ad) ? (adr as Reference, ad as object) : (null, null)))
-        .Concat(Domains.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, d.TemplateParameters.FirstOrDefault(tp => tp.Name == pr.ReferenceName) as object ?? Variable.Property))))
-        .Concat(Decorators.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, d.TemplateParameters.FirstOrDefault(tp => tp.Name == pr.ReferenceName) as object ?? Variable.PropertyContainer))))
-        .Concat(Converters.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, Variable.Converter as object))))
-        .Concat(Domains.SelectMany(d => d.TransformReferences).Concat(Decorators.SelectMany(d => d.TransformReferences)).Concat(Converters.SelectMany(d => d.TransformReferences)).Select(tr => (tr as Reference, Variable.Transform as object)))
+        .Concat(Domains.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, d.Variables.TryGetValue(pr.ReferenceName, out var variable) ? variable as object : null))))
+        .Concat(Decorators.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, d.Variables.TryGetValue(pr.ReferenceName, out var variable) ? variable as object : null))))
+        .Concat(Converters.SelectMany(d => d.VariableReferences.Select(pr => (pr as Reference, d.Variables.TryGetValue(pr.ReferenceName, out var variable) ? variable as object : null))))
+        .Concat(Domains.SelectMany(d => d.TransformReferences).Concat(Decorators.SelectMany(d => d.TransformReferences)).Concat(Converters.SelectMany(d => d.TransformReferences)).Select(tr => (tr as Reference, new Variable { Description = "Transformation de variable" } as object)))
         .Concat(Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object)))
         .Concat(Classes.SelectMany(c => c.DecoratorReferences.Select(dr => (dr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName) as object))))
         .Concat(Classes.SelectMany(c => c.DecoratorReferences.SelectMany(dr => dr.ParameterReferences.Select((pr, i) => (pr as Reference, c.Decorators.FirstOrDefault(d => d.Decorator.Name == dr.ReferenceName).Decorator?.TemplateParameters.ElementAtOrDefault(i) as object)))))

--- a/TopModel.Core/Loaders/FileChecker.cs
+++ b/TopModel.Core/Loaders/FileChecker.cs
@@ -137,6 +137,11 @@ public class FileChecker
         return _deserializer.Deserialize(_serializer.Serialize(genConfigMap), configType)!;
     }
 
+    public WatcherConfigBase GetWatcherConfigBase(IDictionary<string, object> genConfigMap)
+    {
+        return _deserializer.Deserialize<WatcherConfigBase>(_serializer.Serialize(genConfigMap))!;
+    }
+
     private static void Validate(string fileName, JsonSchema schema, string json)
     {
         var errors = schema.Validate(json);

--- a/TopModel.Core/Model/Converter.cs
+++ b/TopModel.Core/Model/Converter.cs
@@ -33,8 +33,9 @@ public class Converter
     public Dictionary<string, ConverterImplementation> Implementations { get; set; } = [];
 
     public IEnumerable<ParameterReference> VariableReferences => Implementations.Values
-        .SelectMany(i => i.TextWithVariables.Variables)
-        .Where(pr => pr.ReferenceName.IsValidConverterVariable());
+        .SelectMany(i => i.TextWithVariables.Variables);
+
+    public Dictionary<string, Variable> Variables { get; } = [];
 
     public IEnumerable<TransformReference> TransformReferences => Implementations.Values
          .SelectMany(i => i.TextWithVariables.Transforms)

--- a/TopModel.Core/Model/Decorator.cs
+++ b/TopModel.Core/Model/Decorator.cs
@@ -38,8 +38,9 @@ public class Decorator : IPropertyContainer
                 ..i.Implements.SelectMany(a => a.Variables),
                 ..i.Annotations.SelectMany(a => a.Variables),
                 ..i.Imports.SelectMany(a => a.Variables)
-            ])
-        .Where(pr => pr.ReferenceName.IsValidClassVariable(TemplateParameters) || pr.ReferenceName.IsValidEndpointVariable(TemplateParameters));
+            ]);
+
+    public Dictionary<string, Variable> Variables { get; } = [];
 
     public IEnumerable<TransformReference> TransformReferences => Implementations.Values
        .SelectMany(i =>

--- a/TopModel.Core/Model/Domain.cs
+++ b/TopModel.Core/Model/Domain.cs
@@ -50,8 +50,9 @@ public class Domain
                 ..i.Imports.SelectMany(a => a.Variables),
                 ..i.ValueTemplates.Values.SelectMany(a => a.Value.Variables),
                 ..i.ValueTemplates.Values.SelectMany(a => a.Imports.SelectMany(vi => vi.Variables))
-            ])
-        .Where(pr => pr.ReferenceName.IsValidPropertyVariable(TemplateParameters));
+            ]);
+
+    public Dictionary<string, Variable> Variables { get; } = [];
 
     public IEnumerable<TransformReference> TransformReferences => Implementations.Values
         .SelectMany(i =>

--- a/TopModel.Core/Model/Implementation/VariableUtils.cs
+++ b/TopModel.Core/Model/Implementation/VariableUtils.cs
@@ -1,134 +1,254 @@
-﻿namespace TopModel.Core.Model.Implementation;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace TopModel.Core.Model.Implementation;
 
 internal static class VariableUtils
 {
-    internal static readonly string[] ClassProperties = ["trigram", "name", "sqlName", "comment", "label", "pluralName", "module"];
-    internal static readonly string[] DomainProperties = ["mediaType", "length", "scale", "name", "type"];
-    internal static readonly string[] EndpointProperties = ["name", "method", "route", "description", "module"];
-    internal static readonly string[] PropertyProperties = ["T", "value", "name", "sqlName", "paramName", "trigram", "label", "comment", "required", "resourceKey", "commentResourceKey", "defaultValue"];
+    internal static readonly Dictionary<string, string> ClassProperties = new()
+    {
+        ["trigram"] = "Trigramme de la classe",
+        ["name"] = "Nom de la classe",
+        ["sqlName"] = "Nom de la table SQL de la classe",
+        ["comment"] = "Commentaire de la classe",
+        ["label"] = "Libellé de la classe",
+        ["pluralName"] = "Nom au pluriel de la classe",
+        ["module"] = "Module du fichier contenant la classe"
+    };
+
+    internal static readonly Dictionary<string, string> DomainProperties = new()
+    {
+        ["mediaType"] = "Media type d'une proprieté du domaine",
+        ["length"] = "Longueur d'une proprieté du domaine",
+        ["scale"] = "Nombre de chiffres après la virgule pour une propriété du domaine",
+        ["name"] = "Nom du domaine",
+        ["type"] = "Type d'implémentation du domaine"
+    };
+
+    internal static readonly Dictionary<string, string> EndpointProperties = new()
+    {
+        ["name"] = "Nom de l'endpoint",
+        ["method"] = "Méthode HTTP de l'endpoint",
+        ["route"] = "Route de l'endpoint",
+        ["description"] = "Description de l'endpoint",
+        ["module"] = "Module du fichier contenant l'endpoint"
+    };
+
+    internal static readonly Dictionary<string, string> PropertyProperties = new()
+    {
+        ["T"] = "Type sur lequel s'applique le type générique",
+        ["value"] = "Valeur de la propriété",
+        ["name"] = "Nom de la propriété",
+        ["sqlName"] = "Nom de la colonne SQL de la propriété",
+        ["paramName"] = "Nom de la propriété en tant que paramètre d'endpoint",
+        ["trigram"] = "Trigramme de la propriété",
+        ["label"] = "Libellé de la propriété",
+        ["comment"] = "Commentaire de la propriété",
+        ["required"] = "Si la propriété est obligatoire",
+        ["resourceKey"] = "Clé de traduction de la propriété",
+        ["commentResourceKey"] = "Clé de traduction pour le commentaire de la propriété",
+        ["defaultValue"] = "Valeur par défaut de la propriété"
+    };
+
     internal static readonly string[] Transforms = ["camel", "constant", "kebab", "lower", "pascal", "snake", "upper", "flat", "path", "head", "last", "tail"];
 
-    public static bool IsValidClassVariable(this string input, IList<TemplateParameter> templateParameters)
+    public static bool IsValidTransform(this string input)
+    {
+        return Transforms.Contains(input);
+    }
+
+    public static bool TryGetClassVariable(this string input, ModelConfig config, IList<TemplateParameter> templateParameters, [MaybeNullWhen(false)] out Variable variable)
     {
         if (input.StartsWith("primaryKey."))
         {
-            return input["primaryKey.".Length..].IsValidPropertyVariable(templateParameters);
+            return input["primaryKey.".Length..].TryGetPropertyVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("extends."))
         {
-            return input["extends.".Length..].IsValidClassVariable(templateParameters);
+            return input["extends.".Length..].TryGetClassVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith($"customProperties."))
         {
+            variable = new Variable { Description = "Propriété personnalisée" };
             return true;
         }
 
         if (input.StartsWith("properties["))
         {
-            return input[(input.IndexOf(']') + 2)..].IsValidPropertyVariable(templateParameters);
+            return input[(input.IndexOf(']') + 2)..].TryGetPropertyVariable(config, templateParameters, out variable);
         }
 
         if (templateParameters.Any(tp => tp.Name == input))
         {
+            variable = new Variable { TemplateParameter = templateParameters.First(tp => tp.Name == input) };
             return true;
         }
 
-        return ClassProperties.Contains(input);
+        if (ClassProperties.TryGetValue(input, out var description))
+        {
+            variable = new Variable { Description = description };
+            return true;
+        }
+
+        if (config.GlobalVariables.TryGetValue(input, out var gVariable))
+        {
+            variable = gVariable;
+            return true;
+        }
+
+        if (config.TagVariables.TryGetValue(input, out var tVariable))
+        {
+            variable = tVariable;
+            return true;
+        }
+
+        variable = null;
+        return false;
     }
 
-    public static bool IsValidConverterVariable(this string input)
+    public static bool TryGetConverterVariable(this string input, [MaybeNullWhen(false)] out Variable variable)
     {
         if (input.StartsWith("from."))
         {
-            return input["from.".Length..].IsValidDomainVariable();
+            return input["from.".Length..].TryGetDomainVariable(out variable);
         }
         else if (input.StartsWith("to."))
         {
-            return input["to.".Length..].IsValidDomainVariable();
+            return input["to.".Length..].TryGetDomainVariable(out variable);
         }
 
-        return input == "value";
+        if (input == "value")
+        {
+            variable = new Variable { Description = "Valeur de la propriété à convertir" };
+            return true;
+        }
+
+        variable = null;
+        return false;
     }
 
-    public static bool IsValidDomainVariable(this string input)
+    public static bool TryGetDomainVariable(this string input, [MaybeNullWhen(false)] out Variable variable)
     {
-        return DomainProperties.Contains(input);
+        if (DomainProperties.TryGetValue(input, out var description))
+        {
+            variable = new Variable { Description = description };
+            return true;
+        }
+
+        variable = null;
+        return false;
     }
 
-    public static bool IsValidEndpointVariable(this string input, IList<TemplateParameter> templateParameters)
+    public static bool TryGetEndpointVariable(this string input, ModelConfig config, IList<TemplateParameter> templateParameters, [MaybeNullWhen(false)] out Variable variable)
     {
         if (input.StartsWith("returns."))
         {
-            return input["returns.".Length..].IsValidClassVariable(templateParameters);
+            return input["returns.".Length..].TryGetClassVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("customProperties."))
         {
+            variable = new Variable { Description = "Propriété personnalisée" };
             return true;
         }
 
         if (input.StartsWith("params["))
         {
-            return input[(input.IndexOf(']') + 2)..].IsValidPropertyVariable(templateParameters);
+            return input[(input.IndexOf(']') + 2)..].TryGetPropertyVariable(config, templateParameters, out variable);
         }
 
         if (templateParameters.Any(tp => tp.Name == input))
         {
+            variable = new Variable { TemplateParameter = templateParameters.First(tp => tp.Name == input) };
             return true;
         }
 
-        return EndpointProperties.Contains(input);
+        if (EndpointProperties.TryGetValue(input, out var description))
+        {
+            variable = new Variable { Description = description };
+            return true;
+        }
+
+        if (config.GlobalVariables.TryGetValue(input, out var gVariable))
+        {
+            variable = gVariable;
+            return true;
+        }
+
+        if (config.TagVariables.TryGetValue(input, out var tVariable))
+        {
+            variable = tVariable;
+            return true;
+        }
+
+        variable = null;
+        return false;
     }
 
-    public static bool IsValidPropertyVariable(this string input, IList<TemplateParameter> templateParameters)
+    public static bool TryGetPropertyVariable(this string input, ModelConfig config, IList<TemplateParameter> templateParameters, [MaybeNullWhen(false)] out Variable variable)
     {
         if (input.StartsWith("parent."))
         {
-            return input["parent.".Length..].IsValidClassVariable(templateParameters) || input["parent.".Length..].IsValidEndpointVariable(templateParameters);
+            return input["parent.".Length..].TryGetClassVariable(config, templateParameters, out variable) || input["parent.".Length..].TryGetEndpointVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("class."))
         {
-            return input["class.".Length..].IsValidClassVariable(templateParameters);
+            return input["class.".Length..].TryGetClassVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("endpoint."))
         {
-            return input["endpoint.".Length..].IsValidEndpointVariable(templateParameters);
+            return input["endpoint.".Length..].TryGetEndpointVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("domain."))
         {
-            return input["domain.".Length..].IsValidDomainVariable();
+            return input["domain.".Length..].TryGetDomainVariable(out variable);
         }
 
         if (input.StartsWith($"customProperties."))
         {
+            variable = new Variable { Description = "Propriété personnalisée" };
             return true;
         }
 
         if (input.StartsWith("association."))
         {
-            return input["association.".Length..].IsValidClassVariable(templateParameters);
+            return input["association.".Length..].TryGetClassVariable(config, templateParameters, out variable);
         }
 
         if (input.StartsWith("composition."))
         {
-            return input["composition.".Length..].IsValidClassVariable(templateParameters);
+            return input["composition.".Length..].TryGetClassVariable(config, templateParameters, out variable);
         }
 
         if (templateParameters.Any(tp => tp.Name == input))
         {
+            variable = new Variable { TemplateParameter = templateParameters.First(tp => tp.Name == input) };
             return true;
         }
 
-        return PropertyProperties.Contains(input);
-    }
+        if (PropertyProperties.TryGetValue(input, out var description))
+        {
+            variable = new Variable { Description = description };
+            return true;
+        }
 
-    public static bool IsValidTransform(this string input)
-    {
-        return Transforms.Contains(input);
+        if (config.GlobalVariables.TryGetValue(input, out var gVariable))
+        {
+            variable = gVariable;
+            return true;
+        }
+
+        if (config.TagVariables.TryGetValue(input, out var tVariable))
+        {
+            variable = tVariable;
+            return true;
+        }
+
+        variable = null;
+        return false;
     }
 }

--- a/TopModel.Core/Model/TemplateParameter.cs
+++ b/TopModel.Core/Model/TemplateParameter.cs
@@ -13,4 +13,6 @@ public class TemplateParameter
     public Decorator? Decorator { get; set; }
 
     public Domain? Domain { get; set; }
+
+    public string Description => $"**{Name}** ({Comment})";
 }

--- a/TopModel.Core/Model/Variable.cs
+++ b/TopModel.Core/Model/Variable.cs
@@ -2,11 +2,34 @@
 
 public class Variable
 {
-    public static Variable Property { get; } = new();
+    private readonly string? _description = null;
 
-    public static Variable PropertyContainer { get; } = new();
+    public List<string> Configs { get; init; } = [];
 
-    public static Variable Converter { get; } = new();
+    public List<string> Tags { get; init; } = [];
 
-    public static Variable Transform { get; } = new();
+    public List<string> Languages { get; init; } = [];
+
+    public bool ByTag { get; init; }
+
+    public TemplateParameter? TemplateParameter { get; init; }
+
+    public string Description
+    {
+        get
+        {
+            if (_description != null)
+            {
+                return _description;
+            }
+
+            if (TemplateParameter != null)
+            {
+                return TemplateParameter.Description;
+            }
+
+            return $"Variable de configuration ({(ByTag ? "par tag" : "globale")}) pour les modules : \n- {string.Join("\n- ", Configs)}";
+        }
+        init => _description = value;
+    }
 }

--- a/TopModel.Core/ModelConfig.cs
+++ b/TopModel.Core/ModelConfig.cs
@@ -20,6 +20,31 @@ public class ModelConfig : ConfigBase
 
     public List<string> CustomGenerators { get; set; } = [];
 
+    public Dictionary<string, WatcherConfigBase> Configs { get; } = [];
+
+    public Dictionary<string, Variable> GlobalVariables => Configs
+        .SelectMany(c => c.Value.GlobalVariableNames
+            .Select(v => new { Name = v, ConfigName = c.Key, c.Value.Tags, c.Value.Languages }))
+        .GroupBy(v => v.Name)
+        .ToDictionary(g => g.Key, g => new Variable
+        {
+            Configs = g.Select(g => g.ConfigName).ToList(),
+            Tags = g.SelectMany(g => g.Tags).Distinct().ToList(),
+            Languages = g.SelectMany(g => g.Languages).Distinct().ToList()
+        });
+
+    public Dictionary<string, Variable> TagVariables => Configs
+        .SelectMany(c => c.Value.TagVariableNames
+            .Select(v => new { Name = v, ConfigName = c.Key, c.Value.Tags, c.Value.Languages }))
+        .GroupBy(v => v.Name)
+        .ToDictionary(g => g.Key, g => new Variable
+        {
+            ByTag = true,
+            Configs = g.Select(g => g.ConfigName).ToList(),
+            Tags = g.SelectMany(g => g.Tags).Distinct().ToList(),
+            Languages = g.SelectMany(g => g.Languages).Distinct().ToList()
+        });
+
     public string GetFileName(string filePath)
     {
         return Path.GetRelativePath(Path.Combine(Directory.GetCurrentDirectory(), ModelRoot), filePath)

--- a/TopModel.Core/ModelExtensions.cs
+++ b/TopModel.Core/ModelExtensions.cs
@@ -116,6 +116,7 @@ public static class ModelExtensions
             Keyword keyword => keyword.ModelFile,
             ClassValue classValue => classValue.Class.ModelFile,
             TemplateParameter templateParameter => templateParameter.Domain?.ModelFile ?? templateParameter.Decorator!.ModelFile,
+            Variable { TemplateParameter: TemplateParameter templateParameter } => templateParameter.Domain?.ModelFile ?? templateParameter.Decorator!.ModelFile,
             Variable => new ModelFile { Name = string.Empty },
             _ => throw new ArgumentException("Type d'objet non supporté.")
         };
@@ -143,6 +144,7 @@ public static class ModelExtensions
             OneOf<ClassMappings, PropertyMapping> p => p.Match(c => c.GetLocation(), p => p.GetLocation()),
             Converter c => c.Location,
             TemplateParameter t => t.Name.Location,
+            Variable { TemplateParameter: TemplateParameter t } => t.Name.Location,
             _ => null
         };
     }

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -513,6 +513,8 @@ public class ModelStore
         var mapperResolver = new MapperResolver(modelFile, referencedClasses, Converters, _config.UseLegacyAssociationCompositionMappers);
         var propertyResolver = new PropertyResolver(modelFile, Domains, referencedClasses, referencedEndpoints, referencedDecorators);
 
+        domainResolver.ResolveDomainVariables(_config);
+
         foreach (var error in domainResolver.ResolveAsDomains())
         {
             yield return error;
@@ -523,7 +525,7 @@ public class ModelStore
             yield return error;
         }
 
-        foreach (var error in decoratorResolver.ResolveDecorators())
+        foreach (var error in decoratorResolver.ResolveDecorators(_config))
         {
             yield return error;
         }

--- a/TopModel.Core/Resolvers/DecoratorResolver.cs
+++ b/TopModel.Core/Resolvers/DecoratorResolver.cs
@@ -1,4 +1,5 @@
 ﻿using TopModel.Core.FileModel;
+using TopModel.Core.Model.Implementation;
 using TopModel.Utils;
 
 namespace TopModel.Core.Resolvers;
@@ -62,11 +63,27 @@ internal class DecoratorResolver(ModelFile modelFile, IDictionary<string, Decora
     /// <summary>
     /// Résout les décorateurs sur les classes et les endpoints.
     /// </summary>
+    /// <param name="config">La config.</param>
     /// <returns>Erreurs.</returns>
-    public IEnumerable<ModelError> ResolveDecorators()
+    public IEnumerable<ModelError> ResolveDecorators(ModelConfig config)
     {
         foreach (var decorator in modelFile.Decorators)
         {
+            decorator.Variables.Clear();
+
+            foreach (var varName in decorator.VariableReferences)
+            {
+                if (varName.ReferenceName.TryGetClassVariable(config, decorator.TemplateParameters, out var cVariable))
+                {
+                    decorator.Variables.TryAdd(varName.ReferenceName, cVariable);
+                }
+
+                if (varName.ReferenceName.TryGetEndpointVariable(config, decorator.TemplateParameters, out var eVariable))
+                {
+                    decorator.Variables.TryAdd(varName.ReferenceName, eVariable);
+                }
+            }
+
             foreach (var templateParam in decorator.TemplateParameters.Where((e, i) => decorator.TemplateParameters.Where((p, j) => p.Name == e.Name && j < i).Any()))
             {
                 yield return new ModelError(decorator, $"Le nom '{templateParam.Name}' est déjà utilisé.", templateParam.GetLocation()) { ModelErrorType = ModelErrorType.TMD0003 };

--- a/TopModel.Core/Resolvers/DomainResolver.cs
+++ b/TopModel.Core/Resolvers/DomainResolver.cs
@@ -1,4 +1,5 @@
 ﻿using TopModel.Core.FileModel;
+using TopModel.Core.Model.Implementation;
 using TopModel.Utils;
 
 namespace TopModel.Core.Resolvers;
@@ -48,6 +49,16 @@ internal class DomainResolver(ModelFile modelFile, IDictionary<string, Domain> d
     {
         foreach (var converter in converters)
         {
+            converter.Variables.Clear();
+
+            foreach (var varName in converter.VariableReferences)
+            {
+                if (varName.ReferenceName.TryGetConverterVariable(out var variable))
+                {
+                    converter.Variables.TryAdd(varName.ReferenceName, variable);
+                }
+            }
+
             converter.From.Clear();
             converter.To.Clear();
 
@@ -87,6 +98,26 @@ internal class DomainResolver(ModelFile modelFile, IDictionary<string, Domain> d
             foreach (var f in converter.To)
             {
                 f.ConvertersTo.Add(converter);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Résout les variables dans les domaines.
+    /// </summary>
+    /// <param name="config">Config.</param>
+    public void ResolveDomainVariables(ModelConfig config)
+    {
+        foreach (var domain in modelFile.Domains)
+        {
+            domain.Variables.Clear();
+
+            foreach (var varName in domain.VariableReferences)
+            {
+                if (varName.ReferenceName.TryGetPropertyVariable(config, domain.TemplateParameters, out var variable))
+                {
+                    domain.Variables.TryAdd(varName.ReferenceName, variable);
+                }
             }
         }
     }

--- a/TopModel.Core/Templating/TemplateExtensions.cs
+++ b/TopModel.Core/Templating/TemplateExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using System.Text.RegularExpressions;
-using TopModel.Core;
 using TopModel.Utils;
 
-namespace TopModel.Generator.Core;
+namespace TopModel.Core.Templating;
 
-internal static class TemplateExtensions
+public static class TemplateExtensions
 {
-    public static string ParseTemplate(this string template, IProperty p, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this string template, IProperty p, WatcherConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -16,18 +15,18 @@ internal static class TemplateExtensions
         var result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), p, p.Domain?.TemplateParameters ?? [], p.DomainParameters, config, tag));
+            result = result.Replace(t.Value, t.Value.Trim('{', '}').ResolveVariable(p, p.Domain?.TemplateParameters ?? [], p.DomainParameters, config, tag));
         }
 
         return result;
     }
 
-    public static string ParseTemplate(this StringWithVariables template, IProperty p, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this StringWithVariables template, IProperty p, WatcherConfigBase config, string? tag = null)
     {
         return template.Value.ParseTemplate(p, config, tag);
     }
 
-    public static string ParseTemplate(this string template, Decorator d, Class c, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this string template, Decorator d, Class c, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -37,18 +36,18 @@ internal static class TemplateExtensions
         string result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), c, d.TemplateParameters, parameterValues, config, tag));
+            result = result.Replace(t.Value, t.Value.Trim('{', '}').ResolveVariable(c, d.TemplateParameters, parameterValues, config, tag));
         }
 
         return result;
     }
 
-    public static string ParseTemplate(this StringWithVariables template, Decorator d, Class c, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this StringWithVariables template, Decorator d, Class c, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         return template.Value.ParseTemplate(d, c, parameterValues, config, tag);
     }
 
-    public static string ParseTemplate(this StringWithVariables template, Decorator d, Endpoint e, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this StringWithVariables template, Decorator d, Endpoint e, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -58,13 +57,13 @@ internal static class TemplateExtensions
         string result = template;
         foreach (var t in template.Value.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), e, d.TemplateParameters, parameterValues, config, tag));
+            result = result.Replace(t.Value, t.Value.Trim('{', '}').ResolveVariable(e, d.TemplateParameters, parameterValues, config, tag));
         }
 
         return result;
     }
 
-    public static string ParseTemplate(this string template, Domain domainFrom, Domain domainTo, GeneratorConfigBase config, string? tag = null)
+    public static string ParseTemplate(this string template, Domain domainFrom, Domain domainTo, WatcherConfigBase config, string? tag = null)
     {
         if (string.IsNullOrEmpty(template) || !template.Contains('{'))
         {
@@ -74,7 +73,7 @@ internal static class TemplateExtensions
         var result = template;
         foreach (var t in template.ExtractVariables())
         {
-            result = result.Replace(t.Value, ResolveVariable(t.Value.Trim('{', '}'), domainFrom, domainTo, config, tag));
+            result = result.Replace(t.Value, t.Value.Trim('{', '}').ResolveVariable(domainFrom, domainTo, config, tag));
         }
 
         return result;
@@ -152,7 +151,7 @@ internal static class TemplateExtensions
         return string.Empty;
     }
 
-    private static string ResolveVariable(this string input, Domain domain, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Domain domain, WatcherConfigBase config, string? tag = null)
     {
         return (input.Split(':').First() switch
         {
@@ -165,7 +164,7 @@ internal static class TemplateExtensions
         }).Transform(input);
     }
 
-    private static string ResolveVariable(this string input, IPropertyContainer container, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, IPropertyContainer container, IList<TemplateParameter> templateParameters, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         return container switch
         {
@@ -175,7 +174,7 @@ internal static class TemplateExtensions
         };
     }
 
-    private static string ResolveVariable(this string input, IProperty p, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, IProperty p, IList<TemplateParameter> templateParameters, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
@@ -184,22 +183,22 @@ internal static class TemplateExtensions
 
         if (input.StartsWith("parent."))
         {
-            return ResolveVariable(input["parent.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
+            return input["parent.".Length..].ResolveVariable(p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("class."))
         {
-            return ResolveVariable(input["class.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
+            return input["class.".Length..].ResolveVariable(p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("endpoint."))
         {
-            return ResolveVariable(input["endpoint.".Length..], p.Parent, templateParameters, parameterValues, config, tag);
+            return input["endpoint.".Length..].ResolveVariable(p.Parent, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("domain."))
         {
-            return ResolveVariable(input["domain.".Length..], p.Domain, config, tag);
+            return input["domain.".Length..].ResolveVariable(p.Domain, config, tag);
         }
 
         if (input.StartsWith($"customProperties."))
@@ -218,7 +217,7 @@ internal static class TemplateExtensions
 
             if (association != null)
             {
-                return ResolveVariable(input["association.".Length..], association, templateParameters, parameterValues, config, tag);
+                return input["association.".Length..].ResolveVariable(association, templateParameters, parameterValues, config, tag);
             }
         }
 
@@ -233,7 +232,7 @@ internal static class TemplateExtensions
 
             if (composition != null)
             {
-                return ResolveVariable(input["composition.".Length..], composition, templateParameters, parameterValues, config, tag);
+                return input["composition.".Length..].ResolveVariable(composition, templateParameters, parameterValues, config, tag);
             }
         }
 
@@ -255,7 +254,7 @@ internal static class TemplateExtensions
         return result;
     }
 
-    private static string ResolveVariable(this string input, Class c, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Class c, IList<TemplateParameter> templateParameters, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
@@ -269,7 +268,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["primaryKey.".Length..], c.PrimaryKey.FirstOrDefault()!, templateParameters, parameterValues, config, tag);
+            return input["primaryKey.".Length..].ResolveVariable(c.PrimaryKey.FirstOrDefault()!, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith("extends."))
@@ -279,7 +278,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["extends.".Length..], c.Extends, templateParameters, parameterValues, config, tag);
+            return input["extends.".Length..].ResolveVariable(c.Extends, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith($"customProperties."))
@@ -299,7 +298,7 @@ internal static class TemplateExtensions
                     return string.Empty;
                 }
 
-                return ResolveVariable(nextInput, c.Properties[index], templateParameters, parameterValues, config, tag);
+                return nextInput.ResolveVariable(c.Properties[index], templateParameters, parameterValues, config, tag);
             }
             else
             {
@@ -322,7 +321,7 @@ internal static class TemplateExtensions
         return result;
     }
 
-    private static string ResolveVariable(this string input, Endpoint e, IList<TemplateParameter> templateParameters, IList<string> parameterValues, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Endpoint e, IList<TemplateParameter> templateParameters, IList<string> parameterValues, WatcherConfigBase config, string? tag = null)
     {
         if (input == null || input.Length == 0)
         {
@@ -336,7 +335,7 @@ internal static class TemplateExtensions
                 return string.Empty;
             }
 
-            return ResolveVariable(input["returns.".Length..], e.Returns, templateParameters, parameterValues, config, tag);
+            return input["returns.".Length..].ResolveVariable(e.Returns, templateParameters, parameterValues, config, tag);
         }
 
         if (input.StartsWith($"customProperties."))
@@ -356,7 +355,7 @@ internal static class TemplateExtensions
                     return string.Empty;
                 }
 
-                return ResolveVariable(nextInput, e.Params[index], templateParameters, parameterValues, config, tag);
+                return nextInput.ResolveVariable(e.Params[index], templateParameters, parameterValues, config, tag);
             }
             else
             {
@@ -377,15 +376,15 @@ internal static class TemplateExtensions
         return result;
     }
 
-    private static string ResolveVariable(this string input, Domain domainFrom, Domain domainTo, GeneratorConfigBase config, string? tag = null)
+    private static string ResolveVariable(this string input, Domain domainFrom, Domain domainTo, WatcherConfigBase config, string? tag = null)
     {
         if (input.StartsWith("from."))
         {
-            return ResolveVariable(input["from.".Length..], domainFrom, config, tag);
+            return input["from.".Length..].ResolveVariable(domainFrom, config, tag);
         }
         else
         {
-            return ResolveVariable(input["to.".Length..], domainTo, config, tag);
+            return input["to.".Length..].ResolveVariable(domainTo, config, tag);
         }
     }
 

--- a/TopModel.Core/WatcherConfigBase.cs
+++ b/TopModel.Core/WatcherConfigBase.cs
@@ -1,0 +1,293 @@
+﻿using System.Text.RegularExpressions;
+using Spectre.Console;
+using TopModel.Core.Loaders;
+using TopModel.Core.Model.Implementation;
+using TopModel.Core.Templating;
+using YamlDotNet.Serialization;
+
+namespace TopModel.Core;
+
+public class WatcherConfigBase
+{
+    /// <summary>
+    /// Tags du module.
+    /// </summary>
+    public required IList<string> Tags { get; set; }
+
+    /// <summary>
+    /// Langage du module, utilisé pour choisir l'implémentation correspondante des domaines, décorateurs et convertisseurs.
+    /// </summary>
+    [YamlIgnore]
+    public string Language { get => Languages.FirstOrDefault()!; set => Languages = [value]; }
+
+    /// <summary>
+    /// Langages du module, utilisé en cascade pour choisir l'implémentation correspondante des domaines, décorateurs et convertisseurs.
+    /// </summary>
+    [YamlMember(Alias = "language")]
+    [YamlConverter(typeof(StringListTypeConverter))]
+    public IList<string> Languages { get; set; } = [];
+
+    /// <summary>
+    /// Variables globales du module.
+    /// </summary>
+    public Dictionary<string, string> Variables { get; set; } = [];
+
+    /// <summary>
+    /// Variables par tag du module.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, string>> TagVariables { get; set; } = [];
+
+    /// <summary>
+    /// Noms de toutes les variables par tag du module.
+    /// </summary>
+    public IEnumerable<string> TagVariableNames => TagVariables.Values.SelectMany(v => v.Keys).Distinct();
+
+    /// <summary>
+    /// Noms de toutes les variables  globales du module.
+    /// </summary>
+    public IEnumerable<string> GlobalVariableNames => Variables.Select(v => v.Key).Except(TagVariableNames).Distinct();
+
+    /// <summary>
+    /// Propriétés qui supportent la variable "module".
+    /// </summary>
+    public virtual string[] PropertiesWithModuleVariableSupport => [];
+
+    /// <summary>
+    /// Propriétés qui supportent la variable "module".
+    /// </summary>
+    public virtual string[] PropertiesWithFileNameVariableSupport => [];
+
+    /// <summary>
+    /// Propriétés qui supportent la variable "lang".
+    /// </summary>
+    public virtual string[] PropertiesWithLangVariableSupport => [];
+
+    /// <summary>
+    /// Propriétés qui peuvent contenir des templates à ne pas interprêter dans la résolution des variables globales ou par tag.
+    /// </summary>
+    public virtual Dictionary<string, List<string>> TemplateAttributes => [];
+
+    /// <summary>
+    /// Propriétés qui supportent les variables par tag de la configuration courante.
+    /// </summary>
+    public virtual string[] PropertiesWithTagVariableSupport => [];
+
+    /// <summary>
+    /// Récupère l'implémentation du domaine pour la config.
+    /// </summary>
+    /// <param name="domain">Décorateur.</param>
+    /// <returns>Implémentation.</returns>
+    public DomainImplementation? GetImplementation(Domain? domain)
+    {
+        return GetImplementation(domain?.Implementations);
+    }
+
+    /// <summary>
+    /// Récupère l'implémentation du décorateur pour la config.
+    /// </summary>
+    /// <param name="decorator">Décorateur.</param>
+    /// <returns>Implémentation.</returns>
+    public DecoratorImplementation? GetImplementation(Decorator? decorator)
+    {
+        return GetImplementation(decorator?.Implementations);
+    }
+
+    /// <summary>
+    /// Récupère l'implémentation du convertisseur pour la config.
+    /// </summary>
+    /// <param name="converter">Convertisseur.</param>
+    /// <returns>Implémentation.</returns>
+    public ConverterImplementation? GetImplementation(Converter? converter)
+    {
+        return GetImplementation(converter?.Implementations);
+    }
+
+    /// <summary>
+    /// Initialise les variables globales, et par tag manquantes.
+    /// </summary>
+    /// <param name="app">Valeur de la variable 'app'.</param>
+    /// <param name="number">Numéro du générateur.</param>
+    public void InitVariables(string app, int number)
+    {
+        if (!Variables.ContainsKey("app"))
+        {
+            Variables["app"] = app;
+        }
+
+        // Si on a défini au moins une variable par tag, alors on s'assure qu'elle est définie pour tous les tags (et on y met "" si ce n'est pas une variable globale).
+        if (TagVariableNames.Any())
+        {
+            foreach (var tag in Tags)
+            {
+                if (!TagVariables.ContainsKey(tag))
+                {
+                    TagVariables[tag] = [];
+                }
+            }
+
+            foreach (var variables in TagVariables.Values)
+            {
+                foreach (var varName in TagVariableNames)
+                {
+                    if (!variables.ContainsKey(varName))
+                    {
+                        Variables.TryGetValue(varName, out var globalVariable);
+                        variables[varName] = globalVariable ?? string.Empty;
+                    }
+                }
+            }
+        }
+
+        var hasMissingVar = false;
+        foreach (var property in GetType().GetProperties().Where(p => p.PropertyType == typeof(string) && p.CanWrite && p.Name != nameof(Language)))
+        {
+            var value = (string?)property.GetValue(this);
+            if (value != null)
+            {
+                value = ResolveGlobalVariables(value);
+                property.SetValue(this, value);
+
+                foreach (var match in Regex.Matches(value, @"\{([$a-zA-Z0-9_-]+)(:\w+)?\}").Cast<Match>())
+                {
+                    var varName = match.Groups[1].Value;
+                    if (TemplateAttributes.TryGetValue(property.Name, out var ta) && ta.Contains(varName))
+                    {
+                        continue;
+                    }
+
+                    if (varName == "module" || varName == "lang" || varName == "fileName")
+                    {
+                        var supportedProperties = varName switch
+                        {
+                            "module" => PropertiesWithModuleVariableSupport,
+                            "lang" => PropertiesWithLangVariableSupport,
+                            "fileName" => PropertiesWithFileNameVariableSupport,
+                            _ => null!
+                        };
+
+                        if (!supportedProperties.Contains(property.Name))
+                        {
+                            hasMissingVar = true;
+                            AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning} {{{GetType().Name}[[{number}]].{property.Name}}} - La variable '{{{varName}}}' n'est pas supportée par cette propriété.[/]");
+                        }
+
+                        continue;
+                    }
+
+                    var hasTagSupport = PropertiesWithTagVariableSupport.Contains(property.Name);
+
+                    if (!hasTagSupport)
+                    {
+                        hasMissingVar = true;
+                        AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning} {{{GetType().Name}[[{number}]].{property.Name}}} - La variable globale '{{{varName}}}' n'est pas définie pour ce générateur.[/]");
+                    }
+                    else if (!TagVariableNames.Contains(varName))
+                    {
+                        hasMissingVar = true;
+                        AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning}  {{{GetType().Name}[[{number}]].{property.Name}}} - La variable '{{{varName}}}' n'est pas définie pour ce générateur.[/]");
+                    }
+                }
+            }
+        }
+
+        foreach (var tagVariables in TagVariables.Values)
+        {
+            foreach (var tagVarName in tagVariables.Keys)
+            {
+                foreach (var varName in GlobalVariableNames)
+                {
+                    tagVariables[tagVarName] = ReplaceVariable(tagVariables[tagVarName], varName, Variables[varName]);
+                }
+            }
+        }
+
+        if (hasMissingVar)
+        {
+            AnsiConsole.WriteLine();
+        }
+    }
+
+    /// <summary>
+    /// Résout toutes les variables pour une valeur donnée.
+    /// </summary>
+    /// <param name="value">Valeur.</param>
+    /// <param name="tag">Tag.</param>
+    /// <param name="module">Module.</param>
+    /// <param name="lang">Lang.</param>
+    /// <returns>La valeur avec les variables résolues.</returns>
+    public virtual string ResolveVariables(string value, string? tag = null, string? module = null, string? lang = null)
+    {
+        var result = value;
+
+        if (tag != null)
+        {
+            result = ResolveTagVariables(result, tag);
+        }
+
+        if (module != null)
+        {
+            result = ReplaceVariable(result, "module", module);
+        }
+
+        if (lang != null)
+        {
+            result = ReplaceVariable(result, "lang", lang);
+        }
+
+        return result;
+    }
+
+    internal string ResolveGlobalVariables(string input)
+    {
+        foreach (var varName in GlobalVariableNames)
+        {
+            input = ReplaceVariable(input, varName, Variables[varName]);
+        }
+
+        return input;
+    }
+
+    /// <summary>
+    /// Résout les variables de tag dans une chaîne de caractère.
+    /// </summary>
+    /// <param name="value">Chaîne de caractères.</param>
+    /// <param name="tag">Nom du tag.</param>
+    /// <returns>Value avec les variables remplacées..</returns>
+    protected virtual string ResolveTagVariables(string value, string tag)
+    {
+        if (TagVariables.TryGetValue(tag, out var tagVariables))
+        {
+            foreach (var (varName, varValue) in tagVariables)
+            {
+                value = ReplaceVariable(value, varName, varValue);
+            }
+        }
+
+        return value;
+    }
+
+    private static string ReplaceVariable(string value, string varName, string varValue)
+    {
+        string MatchEvaluator(Match m) => varValue.Transform(m.Value.Trim('{', '}'));
+        return Regex.Replace(value, $"\\{{{varName}(:\\w+)*\\}}", MatchEvaluator);
+    }
+
+    /// <summary>
+    /// Pour un dictionnaire d'implémentations, retourne la première valeur qui match avec un langages
+    /// </summary>
+    /// <typeparam name="T">Type d'implémentation</typeparam>
+    /// <param name="implementations">Dictionnaire de toutes les implémentations</param>
+    /// <returns>L'implémentation sélectionnée si elle existe</returns>
+    private T? GetImplementation<T>(IDictionary<string, T>? implementations)
+    {
+        foreach (var language in Languages)
+        {
+            if (implementations?.ContainsKey(language) ?? false)
+            {
+                return implementations[language];
+            }
+        }
+
+        return default;
+    }
+}

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -1,24 +1,18 @@
 ﻿using System.Text.RegularExpressions;
 using Spectre.Console;
 using TopModel.Core;
-using TopModel.Core.Loaders;
 using TopModel.Core.Model.Implementation;
+using TopModel.Core.Templating;
 using TopModel.Utils;
-using YamlDotNet.Serialization;
 
 namespace TopModel.Generator.Core;
 
-public abstract class GeneratorConfigBase
+public abstract class GeneratorConfigBase : WatcherConfigBase
 {
     /// <summary>
     /// Racine du répertoire de génération.
     /// </summary>
     public required string OutputDirectory { get; set; }
-
-    /// <summary>
-    /// Tags du générateur.
-    /// </summary>
-    public required IList<string> Tags { get; set; }
 
     /// <summary>
     /// Tags pour lesquels il ne faut pas générer les fichiers (surchage en CLI).
@@ -29,20 +23,6 @@ public abstract class GeneratorConfigBase
     /// Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration.
     /// </summary>
     public virtual bool IgnoreDefaultValues { get; set; }
-
-    /// <summary>
-    /// Langage du générateur, utilisé pour choisir l'implémentation correspondante des domaines, décorateurs et convertisseurs.
-    /// </summary>
-    [YamlIgnore]
-    public string Language { get => Languages.FirstOrDefault()!; set => Languages = [value]; }
-
-    /// <summary>
-    /// Langages du générateur, utilisé en cascade pour choisir l'implémentation correspondante des domaines, décorateurs et convertisseurs.
-    /// </summary>
-    [YamlMember(Alias = "language")]
-    [YamlConverter(typeof(StringListTypeConverter))]
-    public IList<string> Languages { get; set; } = [];
-#nullable enable
 
     /// <summary>
     /// Si les libellés des listes de références doivent être traduits.
@@ -58,45 +38,6 @@ public abstract class GeneratorConfigBase
     /// Générateurs désactivés.
     /// </summary>
     public IList<string>? Disable { get; set; }
-
-    /// <summary>
-    /// Variables globales du générateur.
-    /// </summary>
-    public Dictionary<string, string> Variables { get; set; } = [];
-
-    /// <summary>
-    /// Variables par tag du générateur.
-    /// </summary>
-    public Dictionary<string, Dictionary<string, string>> TagVariables { get; set; } = [];
-
-    public IEnumerable<string> TagVariableNames => TagVariables.Values.SelectMany(v => v.Keys).Distinct();
-
-    public IEnumerable<string> GlobalVariableNames => Variables.Select(v => v.Key).Except(TagVariableNames).Distinct();
-
-    /// <summary>
-    /// Propriétés qui supportent la variable "module".
-    /// </summary>
-    public virtual string[] PropertiesWithModuleVariableSupport => [];
-
-    /// <summary>
-    /// Propriétés qui supportent la variable "module".
-    /// </summary>
-    public virtual string[] PropertiesWithFileNameVariableSupport => [];
-
-    /// <summary>
-    /// Propriétés qui supportent la variable "lang".
-    /// </summary>
-    public virtual string[] PropertiesWithLangVariableSupport => [];
-
-    /// <summary>
-    /// Propriétés qui peuvent contenir des templates à ne pas interprêter dans la résolution des variables globales ou par tag.
-    /// </summary>
-    public virtual Dictionary<string, List<string>> TemplateAttributes => [];
-
-    /// <summary>
-    /// Propriétés qui supportent les variables par tag de la configuration courante.
-    /// </summary>
-    public virtual string[] PropertiesWithTagVariableSupport => [];
 
     protected virtual bool UseNamedEnums => true;
 
@@ -288,36 +229,6 @@ public abstract class GeneratorConfigBase
     }
 
     /// <summary>
-    /// Récupère l'implémentation du domaine pour la config.
-    /// </summary>
-    /// <param name="domain">Décorateur.</param>
-    /// <returns>Implémentation.</returns>
-    public DomainImplementation? GetImplementation(Domain? domain)
-    {
-        return GetImplementation(domain?.Implementations);
-    }
-
-    /// <summary>
-    /// Récupère l'implémentation du décorateur pour la config.
-    /// </summary>
-    /// <param name="decorator">Décorateur.</param>
-    /// <returns>Implémentation.</returns>
-    public DecoratorImplementation? GetImplementation(Decorator? decorator)
-    {
-        return GetImplementation(decorator?.Implementations);
-    }
-
-    /// <summary>
-    /// Récupère l'implémentation du convertisseur pour la config.
-    /// </summary>
-    /// <param name="converter">Convertisseur.</param>
-    /// <returns>Implémentation.</returns>
-    public ConverterImplementation? GetImplementation(Converter? converter)
-    {
-        return GetImplementation(converter?.Implementations);
-    }
-
-    /// <summary>
     /// Récupère le type d'une propriété.
     /// </summary>
     /// <param name="property">Domaine.</param>
@@ -461,154 +372,9 @@ public abstract class GeneratorConfigBase
         }
     }
 
-    /// <summary>
-    /// Initialise les variables globales, et par tag manquantes.
-    /// </summary>
-    /// <param name="app">Valeur de la variable 'app'.</param>
-    /// <param name="number">Numéro du générateur.</param>
-    public void InitVariables(string app, int number)
-    {
-        if (!Variables.ContainsKey("app"))
-        {
-            Variables["app"] = app;
-        }
-
-        // Si on a défini au moins une variable par tag, alors on s'assure qu'elle est définie pour tous les tags (et on y met "" si ce n'est pas une variable globale).
-        if (TagVariableNames.Any())
-        {
-            foreach (var tag in Tags)
-            {
-                if (!TagVariables.ContainsKey(tag))
-                {
-                    TagVariables[tag] = [];
-                }
-            }
-
-            foreach (var variables in TagVariables.Values)
-            {
-                foreach (var varName in TagVariableNames)
-                {
-                    if (!variables.ContainsKey(varName))
-                    {
-                        Variables.TryGetValue(varName, out var globalVariable);
-                        variables[varName] = globalVariable ?? string.Empty;
-                    }
-                }
-            }
-        }
-
-        var hasMissingVar = false;
-        foreach (var property in GetType().GetProperties().Where(p => p.PropertyType == typeof(string) && p.CanWrite && p.Name != nameof(Language)))
-        {
-            var value = (string?)property.GetValue(this);
-            if (value != null)
-            {
-                value = ResolveGlobalVariables(value);
-                property.SetValue(this, value);
-
-                foreach (var match in Regex.Matches(value, @"\{([$a-zA-Z0-9_-]+)(:\w+)?\}").Cast<Match>())
-                {
-                    var varName = match.Groups[1].Value;
-                    if (TemplateAttributes.TryGetValue(property.Name, out var ta) && ta.Contains(varName))
-                    {
-                        continue;
-                    }
-
-                    if (varName == "module" || varName == "lang" || varName == "fileName")
-                    {
-                        var supportedProperties = varName switch
-                        {
-                            "module" => PropertiesWithModuleVariableSupport,
-                            "lang" => PropertiesWithLangVariableSupport,
-                            "fileName" => PropertiesWithFileNameVariableSupport,
-                            _ => null!
-                        };
-
-                        if (!supportedProperties.Contains(property.Name))
-                        {
-                            hasMissingVar = true;
-                            AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning} {{{GetType().Name}[[{number}]].{property.Name}}} - La variable '{{{varName}}}' n'est pas supportée par cette propriété.[/]");
-                        }
-
-                        continue;
-                    }
-
-                    var hasTagSupport = PropertiesWithTagVariableSupport.Contains(property.Name);
-
-                    if (!hasTagSupport)
-                    {
-                        hasMissingVar = true;
-                        AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning} {{{GetType().Name}[[{number}]].{property.Name}}} - La variable globale '{{{varName}}}' n'est pas définie pour ce générateur.[/]");
-                    }
-                    else if (!TagVariableNames.Contains(varName))
-                    {
-                        hasMissingVar = true;
-                        AnsiConsole.MarkupLine($"[yellow]{Emoji.Known.Warning}  {{{GetType().Name}[[{number}]].{property.Name}}} - La variable '{{{varName}}}' n'est pas définie pour ce générateur.[/]");
-                    }
-                }
-            }
-        }
-
-        foreach (var tagVariables in TagVariables.Values)
-        {
-            foreach (var tagVarName in tagVariables.Keys)
-            {
-                foreach (var varName in GlobalVariableNames)
-                {
-                    tagVariables[tagVarName] = ReplaceVariable(tagVariables[tagVarName], varName, Variables[varName]);
-                }
-            }
-        }
-
-        if (hasMissingVar)
-        {
-            AnsiConsole.WriteLine();
-        }
-    }
-
     public virtual bool IsPersistent(Class classe, string tag)
     {
         return classe.IsPersistent;
-    }
-
-    public string ResolveGlobalVariables(string input)
-    {
-        foreach (var varName in GlobalVariableNames)
-        {
-            input = ReplaceVariable(input, varName, Variables[varName]);
-        }
-
-        return input;
-    }
-
-    /// <summary>
-    /// Résout toutes les variables pour une valeur donnée.
-    /// </summary>
-    /// <param name="value">Valeur.</param>
-    /// <param name="tag">Tag.</param>
-    /// <param name="module">Module.</param>
-    /// <param name="lang">Lang.</param>
-    /// <returns>La valeur avec les variables résolues.</returns>
-    public virtual string ResolveVariables(string value, string? tag = null, string? module = null, string? lang = null)
-    {
-        var result = value;
-
-        if (tag != null)
-        {
-            result = ResolveTagVariables(result, tag);
-        }
-
-        if (module != null)
-        {
-            result = ReplaceVariable(result, "module", module);
-        }
-
-        if (lang != null)
-        {
-            result = ReplaceVariable(result, "lang", lang);
-        }
-
-        return result;
     }
 
     /// <summary>
@@ -638,31 +404,6 @@ public abstract class GeneratorConfigBase
         return $@"""{value}""";
     }
 
-    /// <summary>
-    /// Résout les variables de tag dans une chaîne de caractère.
-    /// </summary>
-    /// <param name="value">Chaîne de caractères.</param>
-    /// <param name="tag">Nom du tag.</param>
-    /// <returns>Value avec les variables remplacées..</returns>
-    protected virtual string ResolveTagVariables(string value, string tag)
-    {
-        if (TagVariables.TryGetValue(tag, out var tagVariables))
-        {
-            foreach (var (varName, varValue) in tagVariables)
-            {
-                value = ReplaceVariable(value, varName, varValue);
-            }
-        }
-
-        return value;
-    }
-
-    private static string ReplaceVariable(string value, string varName, string varValue)
-    {
-        string MatchEvaluator(Match m) => varValue.Transform(m.Value.Trim('{', '}'));
-        return Regex.Replace(value, $"\\{{{varName}(:\\w+)*\\}}", MatchEvaluator);
-    }
-
     private bool FilterAnnotations(TargetedText annotation, IProperty property, string tag)
     {
         return property.Class != null && !property.Class.Abstract && (
@@ -686,24 +427,5 @@ public abstract class GeneratorConfigBase
                 yield return subImplementation;
             }
         }
-    }
-
-    /// <summary>
-    /// Pour un dictionnaire d'implémentations, retourne la première valeur qui match avec un langages
-    /// </summary>
-    /// <typeparam name="T">Type d'implémentation</typeparam>
-    /// <param name="implementations">Dictionnaire de toutes les implémentations</param>
-    /// <returns>L'implémentation sélectionnée si elle existe</returns>
-    private T? GetImplementation<T>(IDictionary<string, T>? implementations)
-    {
-        foreach (var language in Languages)
-        {
-            if (implementations?.ContainsKey(language) ?? false)
-            {
-                return implementations[language];
-            }
-        }
-
-        return default;
     }
 }

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -58,9 +58,8 @@ command.SetHandler(
             try
             {
                 fileChecker.CheckConfigFile(file.FullName);
-                using var textToRead = file.OpenText();
-                var text = textToRead.ReadToEnd();
-                var config = fileChecker.DeserializeConfig(text).Init(file.DirectoryName!);
+                using var text = file.OpenText();
+                var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(file.DirectoryName!);
                 configs.Add(file.FullName, config);
             }
             catch (ModelException me)
@@ -590,9 +589,9 @@ for (var i = 0; i < configs.Count; i++)
                 try
                 {
                     var genConfig = (GeneratorConfigBase)fileChecker.GetGenConfig(configName, configType, genConfigMap);
+                    genConfig.InitVariables(config.App, number);
 
                     genConfig.ExcludedTags = excludedTags;
-                    genConfig.InitVariables(config.App, number);
 
                     genConfig.TranslateReferences ??= config.I18n.TranslateReferences;
                     genConfig.TranslateProperties ??= config.I18n.TranslateProperties;
@@ -603,6 +602,8 @@ for (var i = 0; i < configs.Count; i++)
                     var instance = Activator.CreateInstance(generator);
                     instance!.GetType().GetMethod("Register")!
                         .Invoke(instance, [services, genConfig, number]);
+
+                    config.Configs.Add($"{configName}@{number}", genConfig);
                 }
                 catch (ModelException me)
                 {

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -46,14 +46,8 @@ public class HoverHandler : HoverHandlerBase
                         Decorator d => d.Description,
                         DataFlow d => $"Flux de données '{d.Name}'",
                         (Decorator d, _) => d.Description,
-                        TemplateParameter tp => $"**{tp.Name}** ({tp.Comment})",
-                        Variable v => v == Variable.Property
-                            ? "Variable prédéfinie pour une proprieté"
-                            : v == Variable.PropertyContainer
-                                ? "Variable prédéfinie pour une classe ou un endpoint"
-                                : v == Variable.Converter
-                                    ? "Variable préfinie pour un convertisseur"
-                                    : "Transformation de variable",
+                        TemplateParameter tp => tp.Description,
+                        Variable v => v.Description,
                         _ => string.Empty
                     }))
                 });

--- a/TopModel.LanguageServer/Program.cs
+++ b/TopModel.LanguageServer/Program.cs
@@ -15,8 +15,22 @@ var server = await LanguageServer.From(options =>
         .WithServices(services =>
         {
             var fileChecker = new FileChecker();
-            var configFile = new FileInfo(args.Length > 0 ? args[0] : "topmodel.config");
-            var config = fileChecker.Deserialize<ModelConfig>(configFile.OpenText().ReadToEnd()).Init(configFile.DirectoryName!);
+            var file = new FileInfo(args.Length > 0 ? args[0] : "topmodel.config");
+            using var text = file.OpenText();
+            var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(file.DirectoryName!);
+
+            foreach (var (configName, genConfigMaps) in config.Generators)
+            {
+                for (var j = 0; j < genConfigMaps.Count(); j++)
+                {
+                    var genConfigMap = genConfigMaps.ElementAt(j);
+                    var number = j + 1;
+
+                    var genConfig = fileChecker.GetWatcherConfigBase(genConfigMap);
+                    genConfig.InitVariables(config.App, number);
+                    config.Configs.Add($"{configName}@{number}", genConfig);
+                }
+            }
 
             services
                 .AddModelStore(fileChecker, config)

--- a/TopModel.LanguageServer/ReferencesHandler.cs
+++ b/TopModel.LanguageServer/ReferencesHandler.cs
@@ -27,7 +27,7 @@ public class ReferencesHandler : ReferencesHandlerBase
             var references = _modelStore.GetReferencesForPositionInFile(request.Position, file);
             if (references != null)
             {
-                return Task.FromResult<LocationContainer?>(new LocationContainer(
+                return Task.FromResult<LocationContainer?>(new(
                     references.Select(r => new Location
                     {
                         Uri = new Uri(_facade.GetFilePath(r.File)),


### PR DESCRIPTION
- TopModel reconnaît maintenant les variables définies dans la configuration dans les templates (globales ou par tag)
- Chaque variable de propriété/classe/endpoint... a maintenant sa propre description au lieu d'une description générique

Il s'agit d'une évolution non négligeable de TopModel parce que désormais une partie de la configuration des générateurs est remontée dans le Core, en particulier ce qui concernent les variables, les tags et les langages. Cela ouvre la voie pour des fonctionnalités futures là dessus, comme des warnings sur les variables non définies / pas définies dans tous les générateurs par exemple.

![image](https://github.com/user-attachments/assets/21e829f9-df17-4926-9a41-7dd57a659353)
![image](https://github.com/user-attachments/assets/52d7f156-941d-483f-9f8f-aa78126cd083)
<img width="531" alt="image" src="https://github.com/user-attachments/assets/0da0dc88-1fd5-4672-88e5-85aa1e5acb5a" />

