### PR TITLE
Ajout de l'anotation valid si le parameter est de type ModelAttribute

### DIFF
--- a/TopModel.Generator.Jpa/EndpointGeneration/SpringServerApiGenerator.cs
+++ b/TopModel.Generator.Jpa/EndpointGeneration/SpringServerApiGenerator.cs
@@ -157,20 +157,18 @@ public class SpringServerApiGenerator(ILogger<SpringServerApiGenerator> logger, 
         {
             foreach (var param in endpoint.Params.Where(param => param is CompositionProperty || (param.Domain?.BodyParam ?? false) || (param.Domain?.IsMultipart ?? false)))
             {
-                var ann = string.Empty;
-                JavaAnnotation annotation;
+                var parameter = new JavaMethodParameter(Config.GetType(param), param.GetParamName());
                 if (!(param.Domain?.IsMultipart ?? false))
                 {
-                    annotation = new JavaAnnotation("ModelAttribute", imports: "org.springframework.web.bind.annotation.ModelAttribute");
+                    parameter.AddAnnotation(new JavaAnnotation("ModelAttribute", imports: "org.springframework.web.bind.annotation.ModelAttribute"));
+                    parameter.AddAnnotation(new JavaAnnotation("Valid", imports: Config.JavaxOrJakarta + ".validation.Valid"));
                 }
                 else
                 {
-                    annotation = new JavaAnnotation("RequestPart", imports: "org.springframework.web.bind.annotation.RequestPart", value: @$"""{param.GetParamName()}""")
-                        .AddAttribute("required", param.Required.ToString().ToFirstLower());
+                    parameter.AddAnnotation(new JavaAnnotation("RequestPart", imports: "org.springframework.web.bind.annotation.RequestPart", value: @$"""{param.GetParamName()}""")
+                        .AddAttribute("required", param.Required.ToString().ToFirstLower()));
                 }
 
-                var parameter = new JavaMethodParameter(Config.GetType(param), param.GetParamName());
-                parameter.AddAnnotation(annotation);
                 parameter.Imports.AddRange(param.GetTypeImports(Config, tag));
                 method.AddParameter(parameter);
             }

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 2.9.0
 custom:
-  ../../../TopModel.Generator.Jpa: 8ef529d1ec57067b96d2df1739a69e93
+  ../../../TopModel.Generator.Jpa: de3b20c0253307ddac8b0f98a0db0e57
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
Il faudrait ajouter `@Valid `lorsque le paramètre est de type `@ModelAttribute` dans les controller spring.