### PR TITLE
Annotations de propriétés sur classes/endpoints/décorateurs

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -137,6 +137,31 @@ public class ModelFile
                     )
                 )
             )
+            .Concat(
+                PropertyContainers.SelectMany(c =>
+                    c.PropertyAnnotationReferences.Select(par =>
+                        (
+                            par as Reference,
+                            c.PropertyAnnotations.Select(d => d.Annotation)
+                                .FirstOrDefault(d => d.Name == par.ReferenceName) as object
+                        )
+                    )
+                )
+            )
+            .Concat(
+                PropertyContainers.SelectMany(c =>
+                    c.PropertyAnnotationReferences.SelectMany(par =>
+                        par.ParameterReferences.Keys.Select(
+                            (pr, i) =>
+                                (
+                                    pr as Reference,
+                                    c.PropertyAnnotations.FirstOrDefault(d => d.Annotation.Name == par.ReferenceName)
+                                        ?.Annotation.TemplateParameters.ElementAtOrDefault(i) as object
+                                )
+                        )
+                    )
+                )
+            )
             .Concat(Classes.Select(c => (c.ExtendsReference as Reference, c.Extends as object)))
             .Concat(
                 Endpoints.SelectMany(e =>

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -111,6 +111,29 @@ public class ClassLoader(ModelConfig modelConfig, FileChecker fileChecker, Prope
                         }
                     });
                     break;
+                case "propertyAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        if (parser.Current is MappingStart)
+                        {
+                            parser.ConsumeMapping(prop =>
+                            {
+                                var annotation = new AnnotationReference(prop)
+                                {
+                                    ParameterReferences = fileChecker.Deserialize<
+                                        Dictionary<ParameterReference, StringWithVariables>
+                                    >(parser),
+                                };
+
+                                classe.PropertyAnnotationReferences.Add(annotation);
+                            });
+                        }
+                        else
+                        {
+                            classe.PropertyAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                        }
+                    });
+                    break;
                 case "properties":
                     parser.ConsumeSequence(() =>
                     {

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -77,6 +77,31 @@ public class DecoratorLoader(FileChecker fileChecker, PropertyLoader propertyLoa
                         }
                     });
                     break;
+                case "propertyAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        if (parser.Current is MappingStart)
+                        {
+                            parser.ConsumeMapping(prop =>
+                            {
+                                var annotation = new AnnotationReference(prop)
+                                {
+                                    ParameterReferences = fileChecker.Deserialize<
+                                        Dictionary<ParameterReference, StringWithVariables>
+                                    >(parser),
+                                };
+
+                                decorator.PropertyAnnotationReferences.Add(annotation);
+                            });
+                        }
+                        else
+                        {
+                            decorator.PropertyAnnotationReferences.Add(
+                                new AnnotationReference(parser.Consume<Scalar>())
+                            );
+                        }
+                    });
+                    break;
                 case "properties":
                     parser.ConsumeSequence(() =>
                     {

--- a/TopModel.Core/Loaders/EndpointLoader.cs
+++ b/TopModel.Core/Loaders/EndpointLoader.cs
@@ -94,6 +94,31 @@ public class EndpointLoader(FileChecker fileChecker, PropertyLoader propertyLoad
                         }
                     });
                     break;
+                case "propertyAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        if (parser.Current is MappingStart)
+                        {
+                            parser.ConsumeMapping(prop =>
+                            {
+                                var annotation = new AnnotationReference(prop)
+                                {
+                                    ParameterReferences = fileChecker.Deserialize<
+                                        Dictionary<ParameterReference, StringWithVariables>
+                                    >(parser),
+                                };
+
+                                endpoint.PropertyAnnotationReferences.Add(annotation);
+                            });
+                        }
+                        else
+                        {
+                            endpoint.PropertyAnnotationReferences.Add(
+                                new AnnotationReference(parser.Consume<Scalar>())
+                            );
+                        }
+                    });
+                    break;
                 case "customProperties":
                     parser.ConsumeMapping(prop =>
                         endpoint.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value)

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -208,7 +208,7 @@ public class AliasProperty : IProperty
     {
         var alp = new AliasProperty
         {
-            SourceDecorator = Decorator,
+            SourceDecorator = SourceDecorator ?? Decorator,
             Class = classe,
             Comment = _comment!,
             Decorator = decorator,

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -202,7 +202,7 @@ public class AssociationProperty : IProperty
     {
         return new AssociationProperty
         {
-            SourceDecorator = Decorator,
+            SourceDecorator = SourceDecorator ?? Decorator,
             Association = Association,
             Class = classe,
             Comment = Comment,

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -32,6 +32,8 @@ public class Class : IPropertyContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
+
     public string? Label { get; set; }
 
     public bool Reference { get; set; }
@@ -102,6 +104,8 @@ public class Class : IPropertyContainer
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; } = [];
+
+    public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 
     public IList<IList<Reference>> UniqueKeyReferences { get; } = [];
 

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -88,7 +88,7 @@ public class CompositionProperty : IProperty
     {
         return new CompositionProperty
         {
-            SourceDecorator = Decorator,
+            SourceDecorator = SourceDecorator ?? Decorator,
             Class = classe,
             Comment = Comment,
             Composition = Composition,

--- a/TopModel.Core/Model/Decorator.cs
+++ b/TopModel.Core/Model/Decorator.cs
@@ -32,6 +32,8 @@ public class Decorator : IPropertyContainer, IVariableContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
+
     public IList<IProperty> Properties { get; } = [];
 
     public bool PreservePropertyCasing { get; set; }
@@ -48,7 +50,10 @@ public class Decorator : IPropertyContainer, IVariableContainer
                         .. i.Imports.SelectMany(a => a.Variables),
                     ]
             )
-            .Concat(AnnotationReferences.SelectMany(a => a.ParameterReferences.Values.SelectMany(v => v.Variables)));
+            .Concat(AnnotationReferences.SelectMany(a => a.ParameterReferences.Values.SelectMany(v => v.Variables)))
+            .Concat(
+                PropertyAnnotationReferences.SelectMany(a => a.ParameterReferences.Values.SelectMany(v => v.Variables))
+            );
 
     public IDictionary<string, Variable> Variables { get; } = new Dictionary<string, Variable>();
 
@@ -63,11 +68,16 @@ public class Decorator : IPropertyContainer, IVariableContainer
                     ]
             )
             .Concat(AnnotationReferences.SelectMany(a => a.ParameterReferences.Values.SelectMany(v => v.Transforms)))
+            .Concat(
+                PropertyAnnotationReferences.SelectMany(a => a.ParameterReferences.Values.SelectMany(v => v.Transforms))
+            )
             .Where(pr => pr.ReferenceName.IsValidTransform());
 
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
+
+    public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 
     internal Reference Location { get; set; }
 

--- a/TopModel.Core/Model/Endpoint.cs
+++ b/TopModel.Core/Model/Endpoint.cs
@@ -58,11 +58,15 @@ public class Endpoint : IPropertyContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
+
     public IEnumerable<ClassDependency> ClassDependencies => Properties.GetClassDependencies();
 
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
+
+    public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 
 #nullable disable
 

--- a/TopModel.Core/Model/IPropertyContainer.cs
+++ b/TopModel.Core/Model/IPropertyContainer.cs
@@ -41,5 +41,9 @@ public interface IPropertyContainer : IAnnotationContainer
 
     IList<IProperty> Properties { get; }
 
+    IList<AnnotationInstance> PropertyAnnotations { get; }
+
+    IList<AnnotationReference> PropertyAnnotationReferences { get; }
+
     bool PreservePropertyCasing { get; }
 }

--- a/TopModel.Core/Model/PropertyMapping.cs
+++ b/TopModel.Core/Model/PropertyMapping.cs
@@ -34,4 +34,8 @@ public class PropertyMapping : IPropertyContainer
     public IList<AnnotationInstance> Annotations => throw new NotSupportedException();
 
     public IList<AnnotationReference> AnnotationReferences => throw new NotSupportedException();
+
+    public IList<AnnotationInstance> PropertyAnnotations => throw new NotSupportedException();
+
+    public IList<AnnotationReference> PropertyAnnotationReferences => throw new NotSupportedException();
 }

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -71,7 +71,7 @@ public class RegularProperty : IProperty
     {
         return new RegularProperty
         {
-            SourceDecorator = Decorator,
+            SourceDecorator = SourceDecorator ?? Decorator,
             Class = classe,
             Comment = Comment,
             Decorator = decorator,

--- a/TopModel.Core/Resolvers/AnnotationResolver.cs
+++ b/TopModel.Core/Resolvers/AnnotationResolver.cs
@@ -28,20 +28,6 @@ public class AnnotationResolver(
                     );
                 }
             }
-
-            foreach (var (annotation, _) in (alp.Domain?.Annotations ?? []).Intersect(alp.Annotations))
-            {
-                var annotationRef = alp.AnnotationReferences.FirstOrDefault(ar => ar.ReferenceName == annotation.Name);
-                if (annotationRef != null)
-                {
-                    yield return new ModelError(
-                        ErrorType.TMD2003,
-                        alp,
-                        $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations du domaine de la propriété '{alp}'.",
-                        annotationRef
-                    );
-                }
-            }
         }
     }
 
@@ -265,35 +251,6 @@ public class AnnotationResolver(
                 }
                 else
                 {
-                    if (
-                        container is IPropertyContainer propertyContainer
-                        && propertyContainer.AllDecorators.Any(d => d.Annotations.Any(a => a.Annotation == annotation))
-                    )
-                    {
-                        isError = true;
-                        yield return new ModelError(
-                            ErrorType.TMD2003,
-                            propertyContainer,
-                            $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations d'un des décorateurs de l'objet '{propertyContainer}'.",
-                            annotationRef
-                        );
-                    }
-
-                    if (
-                        container is IProperty property
-                        && property is not AliasProperty
-                        && (property.Domain?.Annotations.Any(d => d.Annotation == annotation) ?? false)
-                    )
-                    {
-                        isError = true;
-                        yield return new ModelError(
-                            ErrorType.TMD2003,
-                            property,
-                            $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations du domaine de la propriété '{property}'.",
-                            annotationRef
-                        );
-                    }
-
                     if (
                         annotation.Target.Any()
                         && (

--- a/TopModel.Core/Resolvers/AnnotationResolver.cs
+++ b/TopModel.Core/Resolvers/AnnotationResolver.cs
@@ -158,104 +158,33 @@ public class AnnotationResolver(
                 }
             }
 
-            foreach (var annotationRef in container.AnnotationReferences)
+            foreach (
+                var error in ResolveAnnotationReferences(
+                    container,
+                    container.AnnotationReferences,
+                    annotationsToResolve
+                )
+            )
             {
-                if (!referencedAnnotations.TryGetValue(annotationRef.ReferenceName, out var annotation))
+                isError = true;
+                yield return error;
+            }
+
+            if (container is IPropertyContainer pContainer)
+            {
+                pContainer.PropertyAnnotations.Clear();
+
+                foreach (
+                    var error in ResolveAnnotationReferences(
+                        pContainer,
+                        pContainer.PropertyAnnotationReferences,
+                        pContainer.PropertyAnnotations,
+                        isProperty: true
+                    )
+                )
                 {
                     isError = true;
-                    yield return new ModelError(
-                        ErrorType.TMD2001,
-                        container,
-                        $"L'annotation '{annotationRef.ReferenceName}' est introuvable dans le fichier ou l'une de ses dépendances.",
-                        annotationRef
-                    );
-                }
-                else
-                {
-                    if (annotationsToResolve.Any(d => d.Annotation == annotation))
-                    {
-                        isError = true;
-                        yield return new ModelError(
-                            ErrorType.TMD2002,
-                            container,
-                            $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations de l'objet.",
-                            annotationRef
-                        );
-                    }
-                    else
-                    {
-                        if (
-                            container is IPropertyContainer propertyContainer
-                            && propertyContainer.AllDecorators.Any(d =>
-                                d.Annotations.Any(a => a.Annotation == annotation)
-                            )
-                        )
-                        {
-                            isError = true;
-                            yield return new ModelError(
-                                ErrorType.TMD2003,
-                                propertyContainer,
-                                $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations d'un des décorateurs de l'objet '{propertyContainer}'.",
-                                annotationRef
-                            );
-                        }
-
-                        if (
-                            container is IProperty property
-                            && property is not AliasProperty
-                            && (property.Domain?.Annotations.Any(d => d.Annotation == annotation) ?? false)
-                        )
-                        {
-                            isError = true;
-                            yield return new ModelError(
-                                ErrorType.TMD2003,
-                                property,
-                                $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations du domaine de la propriété '{property}'.",
-                                annotationRef
-                            );
-                        }
-
-                        if (
-                            annotation.Target.Any()
-                            && (
-                                container is Class && !annotation.Target.Contains(Target.Class)
-                                || container is Endpoint && !annotation.Target.Contains(Target.Endpoint)
-                                || container is Decorator { Target: Target dt } && !annotation.Target.Contains(dt)
-                                || container is Domain or IProperty
-                                    && !annotation.Target.Contains(Target.Property)
-                                    && !annotation.Target.Contains(Target.AssociationProperty)
-                                    && !annotation.Target.Contains(Target.CompositionProperty)
-                                    && !annotation.Target.Contains(Target.RegularProperty)
-                            )
-                        )
-                        {
-                            isError = true;
-                            yield return new ModelError(
-                                ErrorType.TMD2004,
-                                container,
-                                $"Impossible d'appliquer l'annotation '{annotationRef.ReferenceName}' à '{container}' : l'annotation ne cible pas le bon type d'objet.",
-                                annotationRef
-                            );
-                        }
-
-                        foreach (var error in CheckAnnotationParameters(container, annotationRef, annotation))
-                        {
-                            yield return error;
-                        }
-
-                        if (!isError)
-                        {
-                            annotationsToResolve.Add(
-                                new(
-                                    annotation,
-                                    annotationRef.ParameterReferences.ToDictionary(
-                                        pr => pr.Key.ReferenceName,
-                                        pr => pr.Value.Value
-                                    )
-                                )
-                            );
-                        }
-                    }
+                    yield return error;
                 }
             }
 
@@ -298,6 +227,117 @@ public class AnnotationResolver(
                 $"Le paramètre '{missingParameter.Name}' de l'annotation '{annotation.Name}' est obligatoire.",
                 annotationRef
             );
+        }
+    }
+
+    private IEnumerable<ModelError> ResolveAnnotationReferences(
+        IAnnotationContainer container,
+        IEnumerable<AnnotationReference> annotationReferences,
+        IList<AnnotationInstance> annotationsToResolve,
+        bool isProperty = false
+    )
+    {
+        var isError = false;
+
+        foreach (var annotationRef in annotationReferences)
+        {
+            if (!referencedAnnotations.TryGetValue(annotationRef.ReferenceName, out var annotation))
+            {
+                isError = true;
+                yield return new ModelError(
+                    ErrorType.TMD2001,
+                    container,
+                    $"L'annotation '{annotationRef.ReferenceName}' est introuvable dans le fichier ou l'une de ses dépendances.",
+                    annotationRef
+                );
+            }
+            else
+            {
+                if (annotationsToResolve.Any(d => d.Annotation == annotation))
+                {
+                    isError = true;
+                    yield return new ModelError(
+                        ErrorType.TMD2002,
+                        container,
+                        $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations de l'objet.",
+                        annotationRef
+                    );
+                }
+                else
+                {
+                    if (
+                        container is IPropertyContainer propertyContainer
+                        && propertyContainer.AllDecorators.Any(d => d.Annotations.Any(a => a.Annotation == annotation))
+                    )
+                    {
+                        isError = true;
+                        yield return new ModelError(
+                            ErrorType.TMD2003,
+                            propertyContainer,
+                            $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations d'un des décorateurs de l'objet '{propertyContainer}'.",
+                            annotationRef
+                        );
+                    }
+
+                    if (
+                        container is IProperty property
+                        && property is not AliasProperty
+                        && (property.Domain?.Annotations.Any(d => d.Annotation == annotation) ?? false)
+                    )
+                    {
+                        isError = true;
+                        yield return new ModelError(
+                            ErrorType.TMD2003,
+                            property,
+                            $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations du domaine de la propriété '{property}'.",
+                            annotationRef
+                        );
+                    }
+
+                    if (
+                        annotation.Target.Any()
+                        && (
+                            container is Class && !annotation.Target.Contains(Target.Class) && !isProperty
+                            || container is Endpoint && !annotation.Target.Contains(Target.Endpoint) && !isProperty
+                            || container is Decorator { Target: Target dt }
+                                && !annotation.Target.Contains(dt)
+                                && !isProperty
+                            || (container is Domain or IProperty || isProperty)
+                                && !annotation.Target.Contains(Target.Property)
+                                && !annotation.Target.Contains(Target.AssociationProperty)
+                                && !annotation.Target.Contains(Target.CompositionProperty)
+                                && !annotation.Target.Contains(Target.RegularProperty)
+                        )
+                    )
+                    {
+                        isError = true;
+                        yield return new ModelError(
+                            ErrorType.TMD2004,
+                            container,
+                            $"Impossible d'appliquer l'annotation '{annotationRef.ReferenceName}' à '{container}' : l'annotation ne cible pas le bon type d'objet.",
+                            annotationRef
+                        );
+                    }
+
+                    foreach (var error in CheckAnnotationParameters(container, annotationRef, annotation))
+                    {
+                        yield return error;
+                    }
+
+                    if (!isError)
+                    {
+                        annotationsToResolve.Add(
+                            new(
+                                annotation,
+                                annotationRef.ParameterReferences.ToDictionary(
+                                    pr => pr.Key.ReferenceName,
+                                    pr => pr.Value.Value
+                                )
+                            )
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/TopModel.Core/Utils/ModelExtensions.cs
+++ b/TopModel.Core/Utils/ModelExtensions.cs
@@ -19,6 +19,18 @@ public static class ModelExtensions
                     File: c.GetFile()
                 )
             )
+            .Concat(
+                modelStore
+                    .PropertyContainers.Where(c => c.PropertyAnnotations.Select(d => d.Annotation).Contains(annotation))
+                    .Select(c =>
+                        (
+                            Reference: c.PropertyAnnotationReferences.FirstOrDefault(dr =>
+                                dr.ReferenceName == annotation.Name
+                            )!,
+                            File: c.GetFile()
+                        )
+                    )
+            )
             .Where(r => r.Reference is not null)
             .DistinctBy(l => l.File.Name + l.Reference.Start.Line);
     }
@@ -264,6 +276,23 @@ public static class ModelExtensions
                                 (
                                     Reference: pc
                                         .DecoratorReferences.FirstOrDefault(ac => ac.ReferenceName == d.Decorator.Name)
+                                        ?.ParameterReferences.Keys.FirstOrDefault(pr => pr.ReferenceName == tp.Name)!,
+                                    File: pc.GetFile()!
+                                )
+                            )
+                    )
+                )
+            )
+            .Concat(
+                modelStore.PropertyContainers.SelectMany(pc =>
+                    pc.PropertyAnnotations.SelectMany(d =>
+                        d.Annotation.TemplateParameters.Where(tp => tp == parameter)
+                            .Select(tp =>
+                                (
+                                    Reference: pc
+                                        .PropertyAnnotationReferences.FirstOrDefault(ac =>
+                                            ac.ReferenceName == d.Annotation.Name
+                                        )
                                         ?.ParameterReferences.Keys.FirstOrDefault(pr => pr.ReferenceName == tp.Name)!,
                                     File: pc.GetFile()!
                                 )

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -866,6 +866,13 @@
                 "$ref": "#/definitions/annotation"
               }
             },
+            "propertyAnnotations": {
+              "type": "array",
+              "description": "Annotations à poser sur toutes les propriétés du décorateur.",
+              "items": {
+                "$ref": "#/definitions/annotation"
+              }
+            },
             "properties": {
               "type": "array",
               "description": "Liste des propriétés du décorateur.",
@@ -1000,6 +1007,13 @@
             "annotations": {
               "type": "array",
               "description": "Annotations de la classe.",
+              "items": {
+                "$ref": "#/definitions/annotation"
+              }
+            },
+            "propertyAnnotations": {
+              "type": "array",
+              "description": "Annotations à poser sur toutes les propriétés de la classe.",
               "items": {
                 "$ref": "#/definitions/annotation"
               }
@@ -1242,6 +1256,13 @@
             "annotations": {
               "type": "array",
               "description": "Annotations de l'endpoint.",
+              "items": {
+                "$ref": "#/definitions/annotation"
+              }
+            },
+            "propertyAnnotations": {
+              "type": "array",
+              "description": "Annotations à poser sur toutes les propriétés de l'endpoint'.",
               "items": {
                 "$ref": "#/definitions/annotation"
               }

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -81,8 +81,29 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
         string tag
     )
     {
+        IList<AnnotationInstance> annotations = [.. container.Annotations];
+
+        if (container is IProperty prop)
+        {
+            foreach (var parentAnnotation in prop.Parent.PropertyAnnotations)
+            {
+                if (!annotations.Any(a => a.Annotation == parentAnnotation.Annotation))
+                {
+                    annotations.Add(parentAnnotation);
+                }
+            }
+
+            foreach (var decoratorAnnotation in prop.SourceDecorator?.PropertyAnnotations ?? [])
+            {
+                if (!annotations.Any(a => a.Annotation == decoratorAnnotation.Annotation))
+                {
+                    annotations.Add(decoratorAnnotation);
+                }
+            }
+        }
+
         foreach (
-            var (implementation, annotation, parameters) in container.Annotations.SelectMany(a =>
+            var (implementation, annotation, parameters) in annotations.SelectMany(a =>
                 GetImplementation(a.Annotation)
                     .Select(i => (Implementation: i, a.Annotation, a.Parameters))
                     .Where(a => FilterAnnotations(a.Implementation, a.Annotation, container, tag))

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -164,22 +164,31 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
                 )
             )
             {
-                var resolvedParameters = parameters.ToDictionary(
-                    p => p.Key,
-                    p => p.Value.ParseTemplate(property, this, tag)
-                );
-                yield return (
-                    Annotation: implementation.Text.Value.ParseTemplate(
-                        property,
-                        annotation.TemplateParameters,
-                        resolvedParameters,
-                        this,
-                        tag
-                    ),
-                    Imports: implementation.Imports.Select(i =>
-                        i.Value.ParseTemplate(property, annotation.TemplateParameters, resolvedParameters, this, tag)
-                    )
-                );
+                if (!annotations.Any(a => a.Annotation == annotation))
+                {
+                    var resolvedParameters = parameters.ToDictionary(
+                        p => p.Key,
+                        p => p.Value.ParseTemplate(property, this, tag)
+                    );
+                    yield return (
+                        Annotation: implementation.Text.Value.ParseTemplate(
+                            property,
+                            annotation.TemplateParameters,
+                            resolvedParameters,
+                            this,
+                            tag
+                        ),
+                        Imports: implementation.Imports.Select(i =>
+                            i.Value.ParseTemplate(
+                                property,
+                                annotation.TemplateParameters,
+                                resolvedParameters,
+                                this,
+                                tag
+                            )
+                        )
+                    );
+                }
             }
         }
     }
@@ -564,22 +573,25 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
                 .Where(a => FilterAnnotations(a.Implementation, a.Annotation, container, tag))
         )
         {
-            var resolvedParameters = annotationParameters.ToDictionary(
-                p => p.Key,
-                p => p.Value.ParseTemplate(container, decorator.TemplateParameters, parameters, this, tag)
-            );
-            yield return (
-                Annotation: implementation.Text.Value.ParseTemplate(
-                    container,
-                    annotation.TemplateParameters,
-                    resolvedParameters,
-                    this,
-                    tag
-                ),
-                Imports: implementation.Imports.Select(i =>
-                    i.Value.ParseTemplate(container, annotation.TemplateParameters, resolvedParameters, this, tag)
-                )
-            );
+            if (!container.Annotations.Any(a => a.Annotation == annotation))
+            {
+                var resolvedParameters = annotationParameters.ToDictionary(
+                    p => p.Key,
+                    p => p.Value.ParseTemplate(container, decorator.TemplateParameters, parameters, this, tag)
+                );
+                yield return (
+                    Annotation: implementation.Text.Value.ParseTemplate(
+                        container,
+                        annotation.TemplateParameters,
+                        resolvedParameters,
+                        this,
+                        tag
+                    ),
+                    Imports: implementation.Imports.Select(i =>
+                        i.Value.ParseTemplate(container, annotation.TemplateParameters, resolvedParameters, this, tag)
+                    )
+                );
+            }
         }
 
         foreach (var subD in decorator.Decorators)

--- a/TopModel.Generator.Jpa/JpaConfig.cs
+++ b/TopModel.Generator.Jpa/JpaConfig.cs
@@ -389,6 +389,13 @@ public class JpaConfig : GeneratorConfigBase
         return ResolveVariables(modelPath, tag, module: ns.Module).ToPackageName();
     }
 
+    public bool HasAnnotation(IAnnotationContainer classe, string annotation)
+    {
+        return classe
+            .Annotations.SelectMany(a => GetImplementation(a.Annotation))
+            .Any(a => a.Text.Trim('@') == annotation.Trim('@'));
+    }
+
     public bool IsEnumNameJavaValid(string name)
     {
         return IsEnumNameValid(name);
@@ -407,13 +414,6 @@ public class JpaConfig : GeneratorConfigBase
         }
 
         return $"{className.ToPascalCase()}{propName.ToPascalCase()}";
-    }
-
-    public bool HasAnnotation(IAnnotationContainer classe, string annotation)
-    {
-        return classe
-            .Annotations.SelectMany(a => GetImplementation(a.Annotation))
-            .Any(a => a.Text.Trim('@') == annotation.Trim('@'));
     }
 
     protected override bool IsEnumNameValid(string name)

--- a/TopModel.Utils/ErrorType.cs
+++ b/TopModel.Utils/ErrorType.cs
@@ -113,7 +113,7 @@ public enum ErrorType
     TMD2002,
 
     /// <summary>
-    /// L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations du domaine de la propriété '{property}'.
+    /// L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations de la propriété aliasée.
     /// </summary>
     TMD2003,
 

--- a/docs/model/annotations.md
+++ b/docs/model/annotations.md
@@ -90,6 +90,80 @@ Cela générera la route suivante dans un contrôleur :
 public async Task Get()
 ```
 
+## Application des annotations
+
+### Règles générales
+
+- Les classes, les endpoints et les propriétés peuvent définir leurs propres annotations.
+- Une propriété d'alias héritera des annotations de sa propriété originale, et pourra en définir de nouvelles.
+- Les annotations posées sur les domaines seront posées sur chaque propriété qui utilise ce domaine.
+- Les annotations posées sur les décorateurs seront posées sur chaque classe ou endpoint qui utilise ce décorateur.
+
+### Annotations de propriétés
+
+En plus des annotations posées directement dessus ou héritées de leur domaine, il est également possible de poser des annotations sur des **propriétés au niveau de leur conteneur**, donc la classe, l'endpoint, ou le décorateur.
+
+Par exemple, sur une classe :
+
+```yaml
+class:
+  name: MyClass
+  propertyAnnotations:
+    - MyAnnotation
+  properties:
+    - name: Property1
+      domain: DO_DOMAIN
+      comment: Propriété 1.
+    - name: Property2
+      domain: DO_DOMAIN
+      comment: Propriété 2.
+```
+
+Ainsi, l'annotation `MyAnnotation` sera prise en compte pour le listing des annotations de toutes les propriétés de la classe.
+
+Remarques :
+
+- Ces annotations ne seront disponibles sur chaque propriété **que dans le contexte de la classe ou du endpoint qui les défini**. Elles ne feront dont **pas** partie de la liste des annotations de la propriété, et ne seront donc pas incluses dans les annotations d'un alias de cette propriété par exemple.
+- Les annotations de propriétés définies dans un décorateur ne s'appliqueront que sur les propriétés définies dans le décorateur. En revanche, ces propriétés récupèreront aussi les annotations de propriété de la classe ou du endpoint qui utilise ce décorateur. Par exemple, pour :
+  ```yaml
+  ---
+  decorator:
+    name: MyDecorator
+    description: Mon décorateur.
+    propertyAnnotations:
+      - MyAnnotation1
+    properties:
+      name: MyProperty
+      domain: DO_DOMAIN
+      comment: Ma propriété.
+  ---
+  class:
+    name: MyClass
+    comment: Ma classe.
+    decorators:
+      - MyDecorator
+    propertyAnnotations:
+      - MyAnnotation2
+    properties:
+      - name: MyClassProperty
+        domain: DO_DOMAIN
+        comment: Ma propriété de classe.
+  ```
+  `MyProperty` dans `MyClass` aura bien `MyAnnotation1` et `MyAnnotation2`, tandis que `MyClassProperty` n'aura que `MyAnnotation2`.
+
+### Priorité des annotations
+
+Il est interdit de déclarer plusieurs fois la même annotation sur un objet, y compris pour les annotations ajoutées sur les propriétés d'alias. En revanche, les annotations effectives sur les classes, endpoints et propriétés peuvent se retrouver en doublon (par exemple, si une même annotation est définie sur un domaine et une propriété qui utilise ce domaine). Dans le cas où l'annotation définit des paramètres, il est possible que l'instanciation des annotations ne soit pas faite avec les mêmes valeurs. Dans ce cas, la priorité suivante est établie :
+
+- Pour une **propriété**, les paramètres sont récupérés en priorité :
+  - Sur la propriété elle-même.
+  - Sur la classe (via `propertyAnnotations`).
+  - Sur le décorateur qui définit la propriété, s'il y en a un (via `propertyAnnotations`).
+  - Sur le domaine.
+- Pour une **classe** ou un **endpoint**, les paramètres sont récupérés en priorité :
+  - Sur la classe/l'endpoint elle/lui-même.
+  - Sur le premier décorateur qui définit l'annotation, s'il y en a un.
+
 ## Ciblage des annotations
 
 ### `target`
@@ -178,56 +252,3 @@ Les variables et paramètres sont utilisables dans les propriétés d'implément
 
 - `text`
 - `imports`
-
-## Annotations de propriétés
-
-En plus des annotations posées directement dessus ou héritées de leur domaine, il est également possible de poser des annotations sur des **propriétés au niveau de leur conteneur**, donc la classe, l'endpoint, ou le décorateur.
-
-Par exemple, sur une classe :
-
-```yaml
-class:
-  name: MyClass
-  propertyAnnotations:
-    - MyAnnotation
-  properties:
-    - name: Property1
-      domain: DO_DOMAIN
-      comment: Propriété 1.
-    - name: Property2
-      domain: DO_DOMAIN
-      comment: Propriété 2.
-```
-
-Ainsi, l'annotation `MyAnnotation` sera prise en compte pour le listing des annotations de toutes les propriétés de la classe.
-
-Remarques :
-
-- Ces annotations ne seront disponibles sur chaque propriété **que dans le contexte de la classe ou du endpoint qui les défini**. Elles ne feront dont **pas** partie de la liste des annotations de la propriété, et ne seront donc pas incluses dans les annotations d'un alias de cette propriété par exemple.
-- Les annotations de propriétés définies dans un décorateur ne s'appliqueront que sur les propriétés définies dans le décorateur. En revanche, ces propriétés récupèreront aussi les annotations de propriété de la classe ou du endpoint qui utilise ce décorateur. Par exemple, pour :
-  ```yaml
-  ---
-  decorator:
-    name: MyDecorator
-    description: Mon décorateur.
-    propertyAnnotations:
-      - MyAnnotation1
-    properties:
-      name: MyProperty
-      domain: DO_DOMAIN
-      comment: Ma propriété.
-  ---
-  class:
-    name: MyClass
-    comment: Ma classe.
-    decorators:
-      - MyDecorator
-    propertyAnnotations:
-      - MyAnnotation2
-    properties:
-      - name: MyClassProperty
-        domain: DO_DOMAIN
-        comment: Ma propriété de classe.
-  ```
-  `MyProperty` dans `MyClass` aura bien `MyAnnotation1` et `MyAnnotation2`, tandis que `MyClassProperty` n'aura que `MyAnnotation2`.
-- Si une propriété définit la même annotation que sa/son classe/endpoint/décorateur, alors son instance propre sera prioritaire (dans le cas où elle définit des paramètres en particulier). De même, si une classe ou un endpoint définit la même annotation de propriétés qu'un décorateur qu'elle utilise, son instance sera prioritaire également.

--- a/docs/model/annotations.md
+++ b/docs/model/annotations.md
@@ -178,3 +178,56 @@ Les variables et paramètres sont utilisables dans les propriétés d'implément
 
 - `text`
 - `imports`
+
+## Annotations de propriétés
+
+En plus des annotations posées directement dessus ou héritées de leur domaine, il est également possible de poser des annotations sur des **propriétés au niveau de leur conteneur**, donc la classe, l'endpoint, ou le décorateur.
+
+Par exemple, sur une classe :
+
+```yaml
+class:
+  name: MyClass
+  propertyAnnotations:
+    - MyAnnotation
+  properties:
+    - name: Property1
+      domain: DO_DOMAIN
+      comment: Propriété 1.
+    - name: Property2
+      domain: DO_DOMAIN
+      comment: Propriété 2.
+```
+
+Ainsi, l'annotation `MyAnnotation` sera prise en compte pour le listing des annotations de toutes les propriétés de la classe.
+
+Remarques :
+
+- Ces annotations ne seront disponibles sur chaque propriété **que dans le contexte de la classe ou du endpoint qui les défini**. Elles ne feront dont **pas** partie de la liste des annotations de la propriété, et ne seront donc pas incluses dans les annotations d'un alias de cette propriété par exemple.
+- Les annotations de propriétés définies dans un décorateur ne s'appliqueront que sur les propriétés définies dans le décorateur. En revanche, ces propriétés récupèreront aussi les annotations de propriété de la classe ou du endpoint qui utilise ce décorateur. Par exemple, pour :
+  ```yaml
+  ---
+  decorator:
+    name: MyDecorator
+    description: Mon décorateur.
+    propertyAnnotations:
+      - MyAnnotation1
+    properties:
+      name: MyProperty
+      domain: DO_DOMAIN
+      comment: Ma propriété.
+  ---
+  class:
+    name: MyClass
+    comment: Ma classe.
+    decorators:
+      - MyDecorator
+    propertyAnnotations:
+      - MyAnnotation2
+    properties:
+      - name: MyClassProperty
+        domain: DO_DOMAIN
+        comment: Ma propriété de classe.
+  ```
+  `MyProperty` dans `MyClass` aura bien `MyAnnotation1` et `MyAnnotation2`, tandis que `MyClassProperty` n'aura que `MyAnnotation2`.
+- Si une propriété définit la même annotation que sa/son classe/endpoint/décorateur, alors son instance propre sera prioritaire (dans le cas où elle définit des paramètres en particulier). De même, si une classe ou un endpoint définit la même annotation de propriétés qu'un décorateur qu'elle utilise, son instance sera prioritaire également.

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.0.5
 custom:
-  ../../../TopModel.Generator.Jpa: f85648ff56e5a8ef6dcc2c2bd2f3d0ea
+  ../../../TopModel.Generator.Jpa: 2ad5a68dc3804fe6c1f5130f19eaa593
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java


### PR DESCRIPTION
Cette PR ajoute la possibilité de définir des annotations sur toutes les propriétés d'une classe, d'un endpoint, ou d'un décorateur, via `propertyAnnotations`. Ces annotations seront prises en compte lors du listing des annotations à poser sur une propriété, au même titre que celles du domaine. En particulier, elles seront contextuelles à la classe ou à l'endpoint en cours, donc elles ne seront pas recopiées dans un alias de propriété.

Cette PR autorise aussi les doublons d'annotations entre un domaine et sa propriété, ou un décorateur et sa classe/son endpoint (et c'est aussi le cas pour les nouvelles annotations de propriétés). S'il y a un doublon, c'est l'instance déclarée en dernier qui sera prioritaire (ce qui n'a d'impact que si les annotations définissent des paramètres).

Fix #308 (mais pas vraiment comme décrit dans l'issue qui a 2 ans maintenant, vu qu'on a des annotations first class maintenant 😉)