### PR TITLE
Configuration du `rootModule` par config

### DIFF
--- a/TopModel.Core/Model/Namespace.cs
+++ b/TopModel.Core/Model/Namespace.cs
@@ -1,4 +1,6 @@
-﻿using TopModel.Utils;
+﻿#pragma warning disable S1133
+
+using TopModel.Utils;
 
 namespace TopModel.Core.Model;
 
@@ -17,5 +19,6 @@ public struct Namespace
     public string ModulePathKebab =>
         string.Join(Path.DirectorySeparatorChar, Module.Split('.').Select(m => m.ToKebabCase()));
 
+    [Obsolete("Utiliser Config.GetRootModule(ns) à la place")]
     public string RootModule => Module.Split('.')[0];
 }

--- a/TopModel.Core/WatcherConfigBase.cs
+++ b/TopModel.Core/WatcherConfigBase.cs
@@ -47,6 +47,11 @@ public class WatcherConfigBase
         new Dictionary<string, IDictionary<string, string>>();
 
     /// <summary>
+    /// Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).
+    /// </summary>
+    public string RootModule { get; set; } = "{module:head}";
+
+    /// <summary>
     /// Noms de toutes les variables par tag du module.
     /// </summary>
     public IEnumerable<string> TagVariableNames => TagVariables.Values.SelectMany(v => v.Keys).Distinct();
@@ -178,7 +183,7 @@ public class WatcherConfigBase
                     {
                         var supportedProperties = varName switch
                         {
-                            "module" => PropertiesWithModuleVariableSupport,
+                            "module" => [.. PropertiesWithModuleVariableSupport, nameof(RootModule)],
                             "lang" => PropertiesWithLangVariableSupport,
                             "fileName" => PropertiesWithFileNameVariableSupport,
                             _ => null!,

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -306,6 +306,16 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
     }
 
     /// <summary>
+    /// Récupère le module racine pour un namespace.
+    /// </summary>
+    /// <param name="ns">Namespace.</param>
+    /// <returns>Module racine.</returns>
+    public virtual string GetRootModule(Namespace ns)
+    {
+        return ResolveVariables(RootModule, module: ns.Module);
+    }
+
+    /// <summary>
     /// Récupère le type d'une propriété.
     /// </summary>
     /// <param name="property">Domaine.</param>

--- a/TopModel.Generator.Core/GeneratorUtils.cs
+++ b/TopModel.Generator.Core/GeneratorUtils.cs
@@ -70,6 +70,7 @@ public static class GeneratorUtils
             return [];
         }
 
+#pragma warning disable CS0618
         return availableClasses
             .SelectMany(c => c.Properties)
             .OfType<AssociationProperty>()

--- a/TopModel.Generator.Core/TranslationGeneratorBase.cs
+++ b/TopModel.Generator.Core/TranslationGeneratorBase.cs
@@ -84,7 +84,7 @@ public abstract class TranslationGeneratorBase<T>(
                         (
                             resources.Key.MainFilePath,
                             resources.Key.ModuleFilePath,
-                            properties.First().Parent.Namespace.RootModule
+                            Config.GetRootModule(properties.First().Parent.Namespace)
                         )
                     );
                 }
@@ -126,7 +126,7 @@ public abstract class TranslationGeneratorBase<T>(
                         (
                             resources.Key.MainFilePath,
                             resources.Key.ModuleFilePath,
-                            $"{properties.First().Parent.Namespace.RootModule}Comments"
+                            $"{Config.GetRootModule(properties.First().Parent.Namespace)}Comments"
                         )
                     );
                 }

--- a/TopModel.Generator.Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator.Javascript/JavascriptConfig.cs
@@ -115,8 +115,8 @@ public class JavascriptConfig : GeneratorConfigBase
     {
         return Path.Combine(
                 OutputDirectory,
-                ResolveVariables(ResourceRootPath!, tag, ns.RootModule.ToKebabCase(), lang),
-                $"{ns.RootModule.ToKebabCase()}.comments{(ResourceMode == ResourceMode.JS ? ".ts" : ".json")}"
+                ResolveVariables(ResourceRootPath!, tag, GetRootModule(ns).ToKebabCase(), lang),
+                $"{GetRootModule(ns).ToKebabCase()}.comments{(ResourceMode == ResourceMode.JS ? ".ts" : ".json")}"
             )
             .Replace('\\', '/');
     }
@@ -262,8 +262,8 @@ public class JavascriptConfig : GeneratorConfigBase
     {
         return Path.Combine(
                 OutputDirectory,
-                ResolveVariables(ResourceRootPath!, tag, ns.RootModule.ToKebabCase(), lang),
-                $"{ns.RootModule.ToKebabCase()}{(ResourceMode == ResourceMode.JS ? ".ts" : ".json")}"
+                ResolveVariables(ResourceRootPath!, tag, GetRootModule(ns).ToKebabCase(), lang),
+                $"{GetRootModule(ns).ToKebabCase()}{(ResourceMode == ResourceMode.JS ? ".ts" : ".json")}"
             )
             .Replace('\\', '/');
     }

--- a/TopModel.Generator.Javascript/JavascriptResourceGenerator.cs
+++ b/TopModel.Generator.Javascript/JavascriptResourceGenerator.cs
@@ -50,7 +50,7 @@ public class JavascriptResourceGenerator(
         using var fw = OpenFileWriter(filePath, encoderShouldEmitUTF8Identifier: false);
         fw.EnableHeader = Config.ResourceMode == ResourceMode.JS;
 
-        var module = properties.First().Parent.Namespace.RootModule;
+        var module = Config.GetRootModule(properties.First().Parent.Namespace);
 
         if (Config.ResourceMode != ResourceMode.JS)
         {
@@ -119,7 +119,7 @@ public class JavascriptResourceGenerator(
         using var fw = OpenFileWriter(filePath, encoderShouldEmitUTF8Identifier: false);
         fw.EnableHeader = Config.ResourceMode == ResourceMode.JS;
 
-        var module = properties.First().Parent.Namespace.RootModule;
+        var module = Config.GetRootModule(properties.First().Parent.Namespace);
 
         if (Config.ResourceMode != ResourceMode.JS)
         {

--- a/TopModel.Generator.Javascript/javascript.config.json
+++ b/TopModel.Generator.Javascript/javascript.config.json
@@ -76,6 +76,11 @@
       "type": "boolean",
       "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
     },
+    "rootModule": {
+      "type": "string",
+      "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+      "default": "{module:head}"
+    },
     "modelRootPath": {
       "type": "string",
       "description": "Localisation du modèle, relative au répertoire de génération. Si non renseigné, aucun modèle ne sera généré. Si '{module}' n'est pas présent dans le chemin, alors il sera ajouté à la fin."
@@ -106,13 +111,13 @@
       "type": "string",
       "description": "Framework cible pour la génération.",
       "default": "focus",
-      "enum": ["angular", "angular_promise", "vanilla", "nuxt"]
+      "enum": [ "angular", "angular_promise", "vanilla", "nuxt" ]
     },
     "entityMode": {
       "type": "string",
       "description": "Framework cible pour la génération.",
       "default": "typed",
-      "enum": ["untyped", "typed", "none"]
+      "enum": [ "untyped", "typed", "none" ]
     },
     "extendedCompositions": {
       "type": "boolean",
@@ -126,7 +131,7 @@
     "resourceMode": {
       "type": "string",
       "description": "Mode de génération (JS, JSON ou JSON Schema).",
-      "enum": ["js", "json"]
+      "enum": [ "js", "json" ]
     },
     "translateReferences": {
       "type": "boolean",
@@ -149,7 +154,7 @@
     "referenceMode": {
       "type": "string",
       "description": "Mode de génération des listes de références (définitions ou valeurs).",
-      "enum": ["definition", "values"],
+      "enum": [ "definition", "values" ],
       "default": "definition"
     }
   }

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
@@ -682,7 +682,8 @@ public class JpaModelPropertyGenerator(
         else
         {
             var pk = property.Class.PrimaryKey.Single().SqlName;
-            var hasReverse = property.Class.Namespace.RootModule == property.Association.Namespace.RootModule;
+            var hasReverse =
+                Config.GetRootModule(property.Class.Namespace) == Config.GetRootModule(property.Association.Namespace);
 
             association
                 .AddAttribute("cascade", "CascadeType.ALL", $"{JavaxOrJakarta}.persistence.CascadeType")

--- a/TopModel.Generator.Jpa/EndpointGeneration/FeignClientApiGenerator.cs
+++ b/TopModel.Generator.Jpa/EndpointGeneration/FeignClientApiGenerator.cs
@@ -31,7 +31,7 @@ public class FeignClientApiGenerator(ILogger<FeignClientApiGenerator> logger, IF
             "FeignClient",
             imports: "org.springframework.cloud.openfeign.FeignClient"
         )
-            .AddAttribute("name", $@"""{file.Namespace.RootModule}""")
+            .AddAttribute("name", $@"""{Config.GetRootModule(file.Namespace)}""")
             .AddAttribute("contextId", $@"""{GetClassName(fileName)}""");
 
         if (!string.IsNullOrEmpty(file.Options.Endpoints.Prefix))

--- a/TopModel.Generator.Jpa/JpaResourceGenerator.cs
+++ b/TopModel.Generator.Jpa/JpaResourceGenerator.cs
@@ -28,7 +28,7 @@ public class JpaResourceGenerator(
             return Path.Combine(
                 Config.OutputDirectory,
                 Config.ResolveVariables(Config.ResourcesPath!, tag: tag, lang: lang).ToLower(),
-                $"{p.Parent.Namespace.RootModule.ToKebabCase()}{(string.IsNullOrEmpty(lang) ? string.Empty : $"_{lang}")}.properties"
+                $"{Config.GetRootModule(p.Parent.Namespace).ToKebabCase()}{(string.IsNullOrEmpty(lang) ? string.Empty : $"_{lang}")}.properties"
             );
         }
 

--- a/TopModel.Generator.Jpa/jpa.config.json
+++ b/TopModel.Generator.Jpa/jpa.config.json
@@ -97,6 +97,11 @@
       "type": "boolean",
       "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
     },
+    "rootModule": {
+      "type": "string",
+      "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+      "default": "{module:head}"
+    },
     "entitiesPath": {
       "type": "string",
       "description": "Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen:{app:path}/entities/{module:path}'."

--- a/TopModel.Generator.Translation/TranslationOutGenerator.cs
+++ b/TopModel.Generator.Translation/TranslationOutGenerator.cs
@@ -42,7 +42,7 @@ public class TranslationOutGenerator(
             return Path.Combine(
                 Config.OutputDirectory,
                 Config.ResolveVariables(Config.RootPath, tag: tag, lang: lang),
-                $"{p.Parent.Namespace.RootModule.ToKebabCase()}_{lang}.properties"
+                $"{Config.GetRootModule(p.Parent.Namespace).ToKebabCase()}_{lang}.properties"
             );
         }
 

--- a/TopModel.Generator.Translation/translation.config.json
+++ b/TopModel.Generator.Translation/translation.config.json
@@ -51,6 +51,11 @@
       "type": "boolean",
       "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
     },
+    "rootModule": {
+      "type": "string",
+      "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+      "default": "{module:head}"
+    },
     "rootPath": {
       "type": "string",
       "description": "Template du chemin des dossiers de traductions sortants (manquants). Doit contenir le template {lang}",

--- a/docs/generator/jpa.md
+++ b/docs/generator/jpa.md
@@ -707,6 +707,14 @@ Le générateur créé un fichier de configuration de job par module. Ce job ord
 
 ### Fichier de configuration
 
+- `rootModule`
+
+  Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).
+
+  _Templating_: `{module}`
+
+  _Valeur par défaut_: `{module:head}`
+
 - `entitiesPath`
 
   Localisation des classses persistées du modèle, relatif au répertoire de génération.

--- a/samples/generators/angular/topmodel.config.schema.json
+++ b/samples/generators/angular/topmodel.config.schema.json
@@ -188,6 +188,11 @@
             "type": "boolean",
             "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
           },
+          "rootModule": {
+            "type": "string",
+            "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+            "default": "{module:head}"
+          },
           "modelRootPath": {
             "type": "string",
             "description": "Localisation du modèle, relative au répertoire de génération. Si non renseigné, aucun modèle ne sera généré. Si '{module}' n'est pas présent dans le chemin, alors il sera ajouté à la fin."

--- a/samples/generators/angular/topmodel.lock
+++ b/samples/generators/angular/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.0.5
 custom:
-  ../../../TopModel.Generator.Javascript: f9e959ba9a661fdf1fb3b6cba63fb965
+  ../../../TopModel.Generator.Javascript: 1bcaaadf39eddc370b8e3615973c98e1
 generatedFiles:
   - ./src/appgenerated/api/securite/profil/profil.service.ts
   - ./src/appgenerated/api/securite/utilisateur/utilisateur.service.ts

--- a/samples/generators/focus/topmodel.config.schema.json
+++ b/samples/generators/focus/topmodel.config.schema.json
@@ -188,6 +188,11 @@
             "type": "boolean",
             "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
           },
+          "rootModule": {
+            "type": "string",
+            "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+            "default": "{module:head}"
+          },
           "modelRootPath": {
             "type": "string",
             "description": "Localisation du modèle, relative au répertoire de génération. Si non renseigné, aucun modèle ne sera généré. Si '{module}' n'est pas présent dans le chemin, alors il sera ajouté à la fin."

--- a/samples/generators/focus/topmodel.lock
+++ b/samples/generators/focus/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.0.5
 custom:
-  ../../../TopModel.Generator.Javascript: f9e959ba9a661fdf1fb3b6cba63fb965
+  ../../../TopModel.Generator.Javascript: 1bcaaadf39eddc370b8e3615973c98e1
 generatedFiles:
   - ./src/locale/common.ts
   - ./src/locale/securite.ts

--- a/samples/generators/jpa/topmodel.config
+++ b/samples/generators/jpa/topmodel.config
@@ -22,7 +22,7 @@ jpa:
     apiPath: "{apiPath}"
     apiGeneration: "{apiGeneration}"
     resourcesPath: resources/i18n/model
-    fieldsEnum: 
+    fieldsEnum:
       - persisted
       - non-persisted
     persistenceMode: jakarta

--- a/samples/generators/jpa/topmodel.config.schema.json
+++ b/samples/generators/jpa/topmodel.config.schema.json
@@ -209,6 +209,11 @@
             "type": "boolean",
             "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
           },
+          "rootModule": {
+            "type": "string",
+            "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+            "default": "{module:head}"
+          },
           "entitiesPath": {
             "type": "string",
             "description": "Localisation des classes persistées du modèle, relative au répertoire de génération. Par défaut, 'javagen:{app:path}/entities/{module:path}'."

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.0.5
 custom:
-  ../../../TopModel.Generator.Jpa: 2ad5a68dc3804fe6c1f5130f19eaa593
+  ../../../TopModel.Generator.Jpa: f673e69256b219d80c7492e9e034b74a
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java

--- a/samples/generators/translation/topmodel.config.schema.json
+++ b/samples/generators/translation/topmodel.config.schema.json
@@ -160,6 +160,11 @@
             "type": "boolean",
             "description": "Désactive la génération des valeurs par défaut des propriétés dans les classes et endpoints générés avec cette configuration."
           },
+          "rootModule": {
+            "type": "string",
+            "description": "Définition du module racine, pour les différents regroupements à faire dessus (fichiers de traductions...).",
+            "default": "{module:head}"
+          },
           "rootPath": {
             "type": "string",
             "description": "Template du chemin des dossiers de traductions sortants (manquants). Doit contenir le template {lang}",

--- a/samples/generators/translation/topmodel.lock
+++ b/samples/generators/translation/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.0.5
 custom:
-  ../../../TopModel.Generator.Translation: e46443bc754ab972bf40f4f9fa7c87d3
+  ../../../TopModel.Generator.Translation: ede6323a73bbcd9cd7689425ea6213c2
 generatedFiles:
   - ./i18n/de_DE/out/common_de_DE.properties
   - ./i18n/de_DE/out/securite_de_DE.properties


### PR DESCRIPTION
Les générateurs (et plus particulier ceux qui l'utilisent : JPA, Translation et JS) peuvent désormais surcharger la valeur de `rootModule` dans leur configuration, au lieu que ça soit `{module:head}` en dur.

(La détermination des reverse properties utilise toujours le `rootModule` par défaut en revanche...)