### PR TITLE
Associations réciproques explicites

### DIFF
--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -139,6 +139,9 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                         case "defaultValue":
                             ap.DefaultValue = value!.Value;
                             break;
+                        case "hasReverse":
+                            ap.HasReverse = value!.Value == "true";
+                            break;
                         case "comment":
                             ap.Comment = value!.Value;
                             break;

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -68,6 +68,8 @@ public class AssociationProperty : IProperty
 
     public string? DefaultValue { get; set; }
 
+    public virtual bool HasReverse { get; set; }
+
     public IList<AnnotationInstance> Annotations { get; private set; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
@@ -215,6 +217,7 @@ public class AssociationProperty : IProperty
             Role = Role,
             Type = Type,
             Readonly = Readonly,
+            HasReverse = HasReverse,
             Trigram = Trigram,
             UseLegacyRoleName = UseLegacyRoleName,
             CustomProperties = CustomProperties,

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -442,6 +442,17 @@ internal class PropertyResolver(
                     }
 
                     ap.Association = association;
+
+                    if (ap.HasReverse && (ap.Type == AssociationType.OneToOne || !(ap.Class?.IsPersistent ?? false)))
+                    {
+                        yield return new ModelError(
+                            ErrorType.TMD9005,
+                            ap,
+                            $"Il sera impossible de générer une association réciproque pour cette association.",
+                            ap.Reference
+                        );
+                    }
+
                     break;
 
                 case CompositionProperty cp:

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -181,6 +181,10 @@
             "defaultValue": {
               "description": "Valeur par défaut de la propriété, dans les classes et les endpoints."
             },
+            "hasReverse": {
+              "type": "boolean",
+              "description": "Ajoute une propriété correspondant à la réciproque de la relation sur la classe cible de l'association (en génération uniquement)."
+            },
             "comment": {
               "type": "string",
               "description": "Description de la propriété."

--- a/TopModel.Generator.Core/GeneratorUtils.cs
+++ b/TopModel.Generator.Core/GeneratorUtils.cs
@@ -52,17 +52,10 @@ public static class GeneratorUtils
             return [];
         }
 
-#pragma warning disable CS0618
         return availableClasses
             .SelectMany(c => c.Properties)
             .OfType<AssociationProperty>()
-            .Where(p =>
-                p.Type != AssociationType.OneToOne
-                && p.Class.IsPersistent
-                && (p.Association.PrimaryKey.Count() == 1 || p.Type == AssociationType.ManyToOne)
-                && p.Association == classe
-                && (p.Type == AssociationType.OneToMany || p.Class.Namespace.RootModule == classe.Namespace.RootModule)
-            )
+            .Where(p => p.HasReverse && p.Association == classe)
             .Select(p => new ReverseAssociationProperty { Class = classe, ReverseProperty = p });
     }
 }

--- a/TopModel.Generator.Core/ReverseAssociationProperty.cs
+++ b/TopModel.Generator.Core/ReverseAssociationProperty.cs
@@ -18,4 +18,6 @@ public class ReverseAssociationProperty : AssociationProperty
 
     public override string Comment =>
         $"Association réciproque de {ReverseProperty.Class.NamePascal}.{ReverseProperty.Name}";
+
+    public override bool HasReverse => true;
 }

--- a/TopModel.Utils/ErrorType.cs
+++ b/TopModel.Utils/ErrorType.cs
@@ -343,7 +343,12 @@ public enum ErrorType
     /// <summary>
     /// Le domaine '{prop.Domain}' doit définir un domaine de liste pour définir un alias liste sur la propriété '{prop.OriginalProperty}' de la classe '{prop.OriginalProperty?.Class}'.
     /// </summary>
-    TMD9004
+    TMD9004,
+
+    /// <summary>
+    /// Il sera impossible de générer une association réciproque pour cette association.
+    /// </summary>
+    TMD9005,
 
     #endregion
 }

--- a/samples/model/Securite/Utilisateur/02_Entities.tmd
+++ b/samples/model/Securite/Utilisateur/02_Entities.tmd
@@ -58,6 +58,7 @@ class:
     - association: Profil
       label: Profil
       required: true
+      hasReverse: true
       comment: Profil de l'utilisateur
 
     - association: TypeUtilisateur


### PR DESCRIPTION
Les associations réciproques ne seront désormais générées que si `hasReverse: true` a été renseigné sur l'association, au lieu de se baser sur des heuristiques plus ou moins douteuses.

Elles n'existent toujours bien qu'en génération (et uniquement dans le générateur JPA). On espère toujours un jour pouvoir les intégrer au modèle, mais cela ne se fera pas sans grosse restriction (il faudra vraisemblablement que les deux classes soient dans le même fichier par exemple). En attendant, si on les explicite et qu'on ne les ajoute que là ou on a en besoin, on devrait mieux estimer leur usage réel.