### PR TITLE
Associations réciproques dans le modèle

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -350,13 +350,6 @@ public class ModelFile
             .DistinctBy(t => t.Item1)
             .ToDictionary(t => t.Item1, t => t.Item2);
 
-    public IList<Reference> UselessImports =>
-        Uses.Where(use =>
-                use.ReferenceName == Name
-                || !References.Values.Select(r => r.GetFile().Name).Contains(use.ReferenceName)
-            )
-            .ToList();
-
     public override string ToString()
     {
         return Name;

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -70,6 +70,8 @@ public class AssociationProperty : IProperty
 
     public virtual ReverseAssociationDefinition? WithReverse { get; set; }
 
+    public virtual AssociationProperty? ReverseProperty { get; set; }
+
     public virtual IList<AnnotationInstance> Annotations { get; private set; } = [];
 
     public virtual IList<AnnotationReference> AnnotationReferences { get; set; } = [];

--- a/TopModel.Core/Model/ReverseAssociationProperty.cs
+++ b/TopModel.Core/Model/ReverseAssociationProperty.cs
@@ -1,11 +1,13 @@
 ﻿using TopModel.Core.FileModel;
-using TopModel.Core.Model;
 
-namespace TopModel.Generator;
+namespace TopModel.Core.Model;
 
 public class ReverseAssociationProperty : AssociationProperty
 {
-    public required AssociationProperty ReverseProperty { get; set; }
+#nullable disable
+    public override required AssociationProperty ReverseProperty { get; set; }
+
+#nullable enable
 
     public override Class Association => ReverseProperty.Class;
 

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -857,11 +857,7 @@ public class ModelStore(
 
         foreach (var modelFile in modelFiles)
         {
-            foreach (
-                var use in modelFile.UselessImports.Where(u =>
-                    modelFiles.Concat(dependencies).Any(d => d.Name == u.ReferenceName)
-                )
-            )
+            foreach (var use in this.GetUselessImports(modelFile))
             {
                 yield return new ModelError(
                     ErrorType.TMD1003,

--- a/TopModel.Core/Resolvers/PropertyResolver.cs
+++ b/TopModel.Core/Resolvers/PropertyResolver.cs
@@ -387,6 +387,16 @@ internal class PropertyResolver(
     /// <returns>Erreurs.</returns>
     public IEnumerable<ModelError> ResolveNonAliasProperties()
     {
+        var classes = modelFiles.SelectMany(mf => mf.Classes);
+
+        foreach (var classe in classes)
+        {
+            foreach (var rap in classe.Properties.OfType<ReverseAssociationProperty>().ToList())
+            {
+                classe.Properties.Remove(rap);
+            }
+        }
+
         foreach (var prop in modelFiles.SelectMany(mf => mf.Properties).Where(p => p.SourceDecorator is null))
         {
             switch (prop)
@@ -418,7 +428,8 @@ internal class PropertyResolver(
                     );
                     break;
 
-                case AssociationProperty ap:
+                case AssociationProperty ap
+                and not ReverseAssociationProperty:
                     if ((ap.Class.Extends == null || !ap.Class.IsPersistent) && ap.Class.PrimaryKey.Count() != 1)
                     {
                         if (ap.Type.IsToMany())
@@ -426,17 +437,17 @@ internal class PropertyResolver(
                             yield return new ModelError(
                                 ErrorType.TMD9005,
                                 ap,
-                                $"Il est impossible de définir une association oneToMany ou manyToMany sur classe sans clé primaire unique.",
+                                $"Il est impossible de définir une association oneToMany ou manyToMany sur classe sans clé primaire simple.",
                                 ap.Reference
                             );
                             break;
                         }
-                        else if (ap.WithReverse != null)
+                        else if (ap.WithReverse != null || ap.Class == null)
                         {
                             yield return new ModelError(
                                 ErrorType.TMD9006,
                                 ap,
-                                $"Il est impossible de définir une association réciproque sur classe sans clé primaire unique.",
+                                $"Une association réciproque ne peut être définie que dans une classe avec une clé primaire simple.",
                                 ap.Reference
                             );
                             break;
@@ -481,6 +492,28 @@ internal class PropertyResolver(
                     }
 
                     ap.Association = association;
+
+                    if (ap.WithReverse != null && ap.Class != null)
+                    {
+                        if (!classes.Contains(association))
+                        {
+                            yield return new ModelError(
+                                ErrorType.TMD9007,
+                                ap,
+                                "Le fichier de la classe cible doit référencer le fichier courant pour définir une association réciproque.",
+                                ap.Reference
+                            );
+                            break;
+                        }
+
+                        ap.ReverseProperty = new ReverseAssociationProperty
+                        {
+                            Class = association,
+                            ReverseProperty = ap,
+                        };
+                        association.Properties.Add(ap.ReverseProperty);
+                    }
+
                     break;
 
                 case CompositionProperty cp:

--- a/TopModel.Core/Utils/ModelExtensions.cs
+++ b/TopModel.Core/Utils/ModelExtensions.cs
@@ -335,6 +335,20 @@ public static class ModelExtensions
         return modelStore.GetPropertyReferencesCore(property, includeTransitive, includeTransitive).Distinct();
     }
 
+    public static IEnumerable<Reference> GetUselessImports(this ModelStore modelStore, ModelFile modelFile)
+    {
+        return modelFile.Uses.Where(use =>
+            use.ReferenceName == modelFile.Name
+            || (!modelFile.References.Values.Select(r => r.GetFile().Name).Contains(use.ReferenceName))
+                && modelStore.Files.Any(d => d.Name == use.ReferenceName)
+                && !modelStore.Files.Any(mf =>
+                    mf.Name == use.ReferenceName
+                    && mf.Properties.OfType<AssociationProperty>()
+                        .Any(ap => ap.Association.ModelFile == modelFile && ap.ReverseProperty != null)
+                )
+        );
+    }
+
     private static IEnumerable<(Reference Reference, ModelFile File)> GetPropertyReferencesCore(
         this ModelStore modelStore,
         IProperty property,

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -185,11 +185,11 @@
               "oneOf": [
                 {
                   "type": "boolean",
-                  "description": "Ajoute une propriété correspondant à la réciproque de la relation sur la classe cible de l'association (en génération uniquement)."
+                  "description": "Ajoute une propriété correspondant à la réciproque de la relation sur la classe cible de l'association."
                 },
                 {
                   "type": "object",
-                  "description": "Ajoute une propriété correspondant à la réciproque de la relation sur la classe cible de l'association (en génération uniquement).",
+                  "description": "Ajoute une propriété correspondant à la réciproque de la relation sur la classe cible de l'association.",
                   "additionalProperties": false,
                   "properties": {
                     "className": {

--- a/TopModel.Generator.Core/GeneratorUtils.cs
+++ b/TopModel.Generator.Core/GeneratorUtils.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using TopModel.Core;
-using TopModel.Core.Model;
 
 namespace TopModel.Generator.Core;
 
@@ -30,32 +29,5 @@ public static class GeneratorUtils
             generator.Number = number;
             return generator;
         });
-    }
-
-    public static IList<IProperty> GetProperties(this Class classe, IEnumerable<Class> availableClasses)
-    {
-        if (classe.Reference)
-        {
-            return classe.Properties;
-        }
-
-        return classe.Properties.Concat(classe.GetReverseProperties(availableClasses)).ToList();
-    }
-
-    private static IEnumerable<ReverseAssociationProperty> GetReverseProperties(
-        this Class classe,
-        IEnumerable<Class> availableClasses
-    )
-    {
-        if (classe.Reference)
-        {
-            return [];
-        }
-
-        return availableClasses
-            .SelectMany(c => c.Properties)
-            .OfType<AssociationProperty>()
-            .Where(p => p.WithReverse != null && p.Association == classe)
-            .Select(p => new ReverseAssociationProperty { Class = classe, ReverseProperty = p });
     }
 }

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaClassGeneratorBase.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaClassGeneratorBase.cs
@@ -95,30 +95,28 @@ public abstract class JavaClassGeneratorBase(ILogger<JavaClassGeneratorBase> log
         enumDeclaration += " {";
         fw.WriteLine(1, enumDeclaration);
 
-        var props = classe
-            .GetProperties(Classes)
-            .Select(prop =>
+        var props = classe.Properties.Select(prop =>
+        {
+            string name;
+            if (prop is AssociationProperty ap && ap.Association.IsPersistent && !Config.UseJdbc)
             {
-                string name;
-                if (prop is AssociationProperty ap && ap.Association.IsPersistent && !Config.UseJdbc)
-                {
-                    name = ap.NameByClassCamel.ToConstantCase();
-                }
-                else
-                {
-                    name = prop.NameCamel.ToConstantCase();
-                }
+                name = ap.NameByClassCamel.ToConstantCase();
+            }
+            else
+            {
+                name = prop.NameCamel.ToConstantCase();
+            }
 
-                var javaType = Config.GetType(
-                    prop,
-                    useClassForAssociation: classe.IsPersistent
-                        && !Config.UseJdbc
-                        && prop is AssociationProperty asp
-                        && asp.Association.IsPersistent
-                );
-                javaType = javaType.Split("<")[0];
-                return $"        {name}({javaType}.class)";
-            });
+            var javaType = Config.GetType(
+                prop,
+                useClassForAssociation: classe.IsPersistent
+                    && !Config.UseJdbc
+                    && prop is AssociationProperty asp
+                    && asp.Association.IsPersistent
+            );
+            javaType = javaType.Split("<")[0];
+            return $"        {name}({javaType}.class)";
+        });
 
         fw.WriteLine(string.Join(", //\n", props) + ";");
 
@@ -143,7 +141,7 @@ public abstract class JavaClassGeneratorBase(ILogger<JavaClassGeneratorBase> log
     {
         if (!Config.HasAnnotation(classe, "Getter"))
         {
-            foreach (var property in classe.GetProperties(Classes))
+            foreach (var property in classe.Properties)
             {
                 if (!Config.HasAnnotation(property, "Getter"))
                 {
@@ -159,7 +157,7 @@ public abstract class JavaClassGeneratorBase(ILogger<JavaClassGeneratorBase> log
     {
         if (!Config.HasAnnotation(classe, "Setter"))
         {
-            foreach (var property in classe.GetProperties(Classes))
+            foreach (var property in classe.Properties)
             {
                 if (!Config.HasAnnotation(property, "Setter"))
                 {

--- a/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JavaEnumConstructorGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using TopModel.Core.Model;
-using TopModel.Generator.Core;
 
 namespace TopModel.Generator.Jpa.ClassGeneration;
 
@@ -29,14 +28,14 @@ public class JavaEnumConstructorGenerator(JpaConfig config) : JavaConstructorGen
         }
 
         constructor.AddBodyLine($@"this.{classe.EnumKey!.NameCamel} = {classe.EnumKey!.NameCamel};");
-        if (classe.GetProperties(availableClasses).Count > 1)
+        if (classe.Properties.Count > 1)
         {
             constructor.AddBodyLine($@"switch({classe.EnumKey!.NameCamel}) {{");
             foreach (var refValue in classe.Values.OrderBy(x => x.Name, StringComparer.Ordinal))
             {
                 var code = refValue.Value[codeProperty];
                 constructor.AddBodyLine(1, $@"case {code} :");
-                foreach (var prop in classe.GetProperties(availableClasses).Where(p => p != codeProperty))
+                foreach (var prop in classe.Properties.Where(p => p != codeProperty))
                 {
                     var isString = Config.GetType(prop) == "String";
                     var value = refValue.Value.TryGetValue(prop, out var v) ? v : "null";

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaEntityGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaEntityGenerator.cs
@@ -2,7 +2,6 @@
 using TopModel.Core.Model;
 using TopModel.Core.Model.Implementation;
 using TopModel.Core.Utils;
-using TopModel.Generator.Core;
 using TopModel.Utils;
 
 namespace TopModel.Generator.Jpa.ClassGeneration;
@@ -164,17 +163,9 @@ public class JpaEntityGenerator(ILogger<JpaEntityGenerator> logger, IFileWriterP
     {
         if (classe.IsPersistent && Config.AssociationAdders)
         {
-            foreach (
-                var ap in classe.GetProperties(Classes).OfType<AssociationProperty>().Where(t => t.Type.IsToMany())
-            )
+            foreach (var ap in classe.Properties.OfType<AssociationProperty>().Where(t => t.Type.IsToMany()))
             {
-                var reverse = ap is ReverseAssociationProperty rap
-                    ? rap.ReverseProperty
-                    : ap
-                        .Association.GetProperties(Classes)
-                        .OfType<ReverseAssociationProperty>()
-                        .FirstOrDefault(r => r.ReverseProperty == ap);
-                if (reverse != null)
+                if (ap.ReverseProperty != null)
                 {
                     var propertyName = ap.NameByClassCamel;
                     fw.WriteLine();
@@ -189,13 +180,19 @@ public class JpaEntityGenerator(ILogger<JpaEntityGenerator> logger, IFileWriterP
                         @$"public void add{ap.Association.NamePascal}{ap.Role}({ap.Association.NamePascal} {ap.Association.NameCamel}) {{"
                     );
                     fw.WriteLine(2, @$"this.{propertyName}.add({ap.Association.NameCamel});");
-                    if (reverse.Type.IsToMany())
+                    if (ap.ReverseProperty.Type.IsToMany())
                     {
-                        fw.WriteLine(2, @$"{ap.Association.NameCamel}.get{reverse.NameByClassPascal}().add(this);");
+                        fw.WriteLine(
+                            2,
+                            @$"{ap.Association.NameCamel}.get{ap.ReverseProperty.NameByClassPascal}().add(this);"
+                        );
                     }
                     else
                     {
-                        fw.WriteLine(2, @$"{ap.Association.NameCamel}.set{reverse.NameByClassPascal}(this);");
+                        fw.WriteLine(
+                            2,
+                            @$"{ap.Association.NameCamel}.set{ap.ReverseProperty.NameByClassPascal}(this);"
+                        );
                     }
 
                     fw.WriteLine(1, "}");
@@ -329,17 +326,9 @@ public class JpaEntityGenerator(ILogger<JpaEntityGenerator> logger, IFileWriterP
     {
         if (classe.IsPersistent && Config.AssociationRemovers)
         {
-            foreach (
-                var ap in classe.GetProperties(Classes).OfType<AssociationProperty>().Where(t => t.Type.IsToMany())
-            )
+            foreach (var ap in classe.Properties.OfType<AssociationProperty>().Where(t => t.Type.IsToMany()))
             {
-                var reverse = ap is ReverseAssociationProperty rap
-                    ? rap.ReverseProperty
-                    : ap
-                        .Association.GetProperties(Classes)
-                        .OfType<ReverseAssociationProperty>()
-                        .FirstOrDefault(r => r.ReverseProperty == ap);
-                if (reverse != null)
+                if (ap.ReverseProperty != null)
                 {
                     var propertyName = ap.NameByClassCamel;
                     fw.WriteLine();
@@ -354,13 +343,19 @@ public class JpaEntityGenerator(ILogger<JpaEntityGenerator> logger, IFileWriterP
                         @$"public void remove{ap.Association.NamePascal}{ap.Role}({ap.Association.NamePascal} {ap.Association.NameCamel}) {{"
                     );
                     fw.WriteLine(2, @$"this.{propertyName}.remove({ap.Association.NameCamel});");
-                    if (reverse.Type.IsToMany())
+                    if (ap.ReverseProperty.Type.IsToMany())
                     {
-                        fw.WriteLine(2, @$"{ap.Association.NameCamel}.get{reverse.NameByClassPascal}().remove(this);");
+                        fw.WriteLine(
+                            2,
+                            @$"{ap.Association.NameCamel}.get{ap.ReverseProperty.NameByClassPascal}().remove(this);"
+                        );
                     }
                     else
                     {
-                        fw.WriteLine(2, @$"{ap.Association.NameCamel}.set{reverse.NameByClassPascal}(null);");
+                        fw.WriteLine(
+                            2,
+                            @$"{ap.Association.NameCamel}.set{ap.ReverseProperty.NameByClassPascal}(null);"
+                        );
                     }
 
                     fw.WriteLine(1, "}");

--- a/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
+++ b/TopModel.Generator.Jpa/ClassGeneration/JpaModelPropertyGenerator.cs
@@ -236,7 +236,7 @@ public class JpaModelPropertyGenerator(
 
     public virtual void WriteProperties(JavaWriter fw, Class classe, string tag)
     {
-        foreach (var property in classe.GetProperties(Classes))
+        foreach (var property in classe.Properties)
         {
             WriteProperty(fw, property, tag);
         }
@@ -687,7 +687,7 @@ public class JpaModelPropertyGenerator(
                 .AddAttribute("cascade", "CascadeType.ALL", $"{JavaxOrJakarta}.persistence.CascadeType")
                 .AddAttribute("fetch", "FetchType.LAZY", $"{JavaxOrJakarta}.persistence.FetchType");
 
-            if (property.WithReverse != null)
+            if (property.ReverseProperty != null)
             {
                 association.AddAttribute("mappedBy", @$"""{property.Class.NameCamel}{property.Role ?? string.Empty}""");
             }

--- a/TopModel.Generator.Php/PhpModelGenerator.cs
+++ b/TopModel.Generator.Php/PhpModelGenerator.cs
@@ -92,9 +92,9 @@ public class PhpModelGenerator(ILogger<PhpModelGenerator> logger, IFileWriterPro
 
     private void WriteConstructor(PhpWriter fw, Class classe)
     {
-        var collectionProperties = classe
-            .GetProperties(Classes)
-            .Where(p => Config.GetType(p, Classes, p.Class.IsPersistent) == "Collection");
+        var collectionProperties = classe.Properties.Where(p =>
+            Config.GetType(p, Classes, p.Class.IsPersistent) == "Collection"
+        );
         if (collectionProperties.Any())
         {
             fw.WriteLine();
@@ -112,7 +112,7 @@ public class PhpModelGenerator(ILogger<PhpModelGenerator> logger, IFileWriterPro
 
     private void WriteGetters(PhpWriter fw, Class classe)
     {
-        foreach (var property in classe.GetProperties(Classes))
+        foreach (var property in classe.Properties)
         {
             fw.WriteLine();
             if (property is AssociationProperty ap && ap.Type.IsToMany())
@@ -136,7 +136,7 @@ public class PhpModelGenerator(ILogger<PhpModelGenerator> logger, IFileWriterPro
 
     private void WriteSetters(PhpWriter fw, Class classe)
     {
-        foreach (var property in classe.GetProperties(Classes))
+        foreach (var property in classe.Properties)
         {
             var propertyName = property.NameByClassCamel;
             fw.WriteLine();

--- a/TopModel.Generator.Php/PhpModelPropertyGenerator.cs
+++ b/TopModel.Generator.Php/PhpModelPropertyGenerator.cs
@@ -13,7 +13,7 @@ public class PhpModelPropertyGenerator(PhpConfig config, IEnumerable<Class> clas
     public void WriteProperties(PhpWriter fw, Class classe, IEnumerable<Class> availableClasses, string tag)
     {
         var isFirst = true;
-        foreach (var property in classe.GetProperties(availableClasses))
+        foreach (var property in classe.Properties)
         {
             if (!isFirst)
             {

--- a/TopModel.Generator.Sql/ScriptUtils.cs
+++ b/TopModel.Generator.Sql/ScriptUtils.cs
@@ -15,11 +15,9 @@ public static class ScriptUtils
     public static IEnumerable<IProperty> GetAllProperties(this Class classe, IEnumerable<Class> availableClasses)
     {
         foreach (
-            var prop in classe
-                .GetProperties(availableClasses)
-                .Where(p =>
-                    p is not AssociationProperty { Type: AssociationType.OneToMany or AssociationType.ManyToMany }
-                )
+            var prop in classe.Properties.Where(p =>
+                p is not AssociationProperty { Type: AssociationType.OneToMany or AssociationType.ManyToMany }
+            )
         )
         {
             yield return prop;

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -5,6 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
+using TopModel.Core.Utils;
 using TopModel.Utils;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -35,7 +36,7 @@ public class CodeActionHandler(
         var codeActions = new List<CommandOrCodeAction>();
         if (modelFile != null)
         {
-            if (modelFile.Uses.Except(modelFile.UselessImports).Any())
+            if (modelFile.Uses.Except(modelStore.GetUselessImports(modelFile)).Any())
             {
                 codeActions.Add(GetCodeActionOrganizeImports(request, modelFile));
             }
@@ -71,40 +72,6 @@ public class CodeActionHandler(
         }
 
         return CommandOrCodeActionContainer.From(codeActions);
-    }
-
-    protected static CodeAction GetCodeActionOrganizeImports(CodeActionParams request, ModelFile modelFile)
-    {
-        var start = modelFile.Uses[0].ToRange()!.Start;
-        var end = modelFile.Uses[^1].ToRange()!.End;
-        var uselessImports = modelFile.UselessImports;
-        return new CodeAction()
-        {
-            Title = "Trier les Uses",
-            Kind = CodeActionKind.SourceOrganizeImports,
-            IsPreferred = true,
-            Edit = new WorkspaceEdit
-            {
-                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
-                {
-                    [request.TextDocument.Uri] =
-                    [
-                        new()
-                        {
-                            NewText = string.Join(
-                                "\n  - ",
-                                modelFile
-                                    .Uses.Except(uselessImports)
-                                    .DistinctBy(u => u.ReferenceName)
-                                    .OrderBy(u => u.ReferenceName)
-                                    .Select(u => u.ReferenceName)
-                            ),
-                            Range = new Range(start, end),
-                        },
-                    ],
-                },
-            },
-        };
     }
 
     protected override CodeActionRegistrationOptions CreateRegistrationOptions(
@@ -279,6 +246,39 @@ domain:
             .Select(endpointToImport =>
                 GetFileImportAction(diagnostic, modelFile, endpointToImport.ModelFile, useIndex)
             );
+    }
+
+    protected CodeAction GetCodeActionOrganizeImports(CodeActionParams request, ModelFile modelFile)
+    {
+        var start = modelFile.Uses[0].ToRange()!.Start;
+        var end = modelFile.Uses[^1].ToRange()!.End;
+        return new CodeAction()
+        {
+            Title = "Trier les Uses",
+            Kind = CodeActionKind.SourceOrganizeImports,
+            IsPreferred = true,
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [request.TextDocument.Uri] =
+                    [
+                        new()
+                        {
+                            NewText = string.Join(
+                                "\n  - ",
+                                modelFile
+                                    .Uses.Except(modelStore.GetUselessImports(modelFile))
+                                    .DistinctBy(u => u.ReferenceName)
+                                    .OrderBy(u => u.ReferenceName)
+                                    .Select(u => u.ReferenceName)
+                            ),
+                            Range = new Range(start, end),
+                        },
+                    ],
+                },
+            },
+        };
     }
 
     private CommandOrCodeAction GetFileImportAction(

--- a/TopModel.Utils/ErrorType.cs
+++ b/TopModel.Utils/ErrorType.cs
@@ -346,14 +346,19 @@ public enum ErrorType
     TMD9004,
 
     /// <summary>
-    /// Il est impossible de définir une association oneToMany ou manyToMany sur classe sans clé primaire unique.
+    /// Il est impossible de définir une association oneToMany ou manyToMany sur classe sans clé primaire simple.
     /// </summary>
     TMD9005,
 
     /// <summary>
-    /// Il sera impossible de générer une association réciproque pour cette association.
+    /// Une association réciproque ne peut être définie que dans une classe avec une clé primaire simple.
     /// </summary>
     TMD9006,
+
+    /// <summary>
+    /// Le fichier de la classe cible doit référencer le fichier courant pour définir une association réciproque.
+    /// </summary>
+    TMD9007,
 
     #endregion
 }

--- a/docs/model/properties.md
+++ b/docs/model/properties.md
@@ -57,6 +57,22 @@ La propriété qui en découlera sera `ClasseCibleExempleId` (si la `primaryKey`
 
 Une association peut référencer une classe non persistée, dans ce cas il faut identifier la propriété de la classe cible à utiliser via `property` (puisqu'une telle classe ne peut pas avoir de clé primaire par définition).
 
+### Associations réciproques
+
+Via `withReverse`, il est possible de déclarer l'association réciproque sur la classe cible de l'association. Son type sera l'inverse de celle de l'association courante (`ManyToOne` <> `OneToMany`, et `OneToOne` <> `OneToOne` / `ManyToMany` <> `ManyToMany`), et elle sera **ajoutée effectivement comme une propriété d'association sur la classe cible**. En particulier, cela imposera une **référence circulaire** entre les deux classes, et donc les fichiers qui les contiennent. Cette dépendance devra être déclarée explicitement (si elle ne l'est pas déjà par ailleurs, ou si les deux classes ne sont pas déjà dans le même fichier) sur le fichier de la classe cible. Les cycles de dépendances sont traités comme un seul gros fichier par TopModel, donc pour simplifier la résolution et éviter des effets de bord indésirables, il est conseillé de les réduire au minimum possible.
+
+Une association réciproque peut être déclarée via `withReverse: true`, ou par un objet qui peut paramétrer la propriété d'association réciproque :
+
+```yaml
+withReverse:
+  className: # Equivalent de `className` sur l'association.
+  label: # Equivalent de `label` sur l'association.
+  comment: # Equivalent de `comment` sur l'association. Un commentaire est généré par défaut s'il n'y en a pas.
+  annotations: # Annotations a ajouter sur l'association réciproque.
+```
+
+Les associations réciproques étant de vraies propriétés de classe dans le modèle, elles sont disponibles dans les alias et les mappers.
+
 ## Composition
 
 Une composition est une propriété spéciale qui permet de **référencer une autre classe**, à l'inverse de l'association qui ne concerne que la clé primaire. Par conséquent, la composition est le seul type de **propriété non primitif** (ce qui ne prescrit pas à priori son usage dans un objet persisté puisqu'elle pourrait y être stockée en JSON, mais on préfèrera bien souvent utiliser une association à la place). Elle est identifiée par la présence de la propriété `composition` en premier.

--- a/samples/generators/csharp/src/Clients/TopModel.Sample.Clients.Db/Models/Securite/Profil/generated/Profil.cs
+++ b/samples/generators/csharp/src/Clients/TopModel.Sample.Clients.Db/Models/Securite/Profil/generated/Profil.cs
@@ -43,6 +43,14 @@ public partial record Profil
     public Droit.Codes[] Droits { get; set; }
 
     /// <summary>
+    /// Association réciproque de Utilisateur.ProfilId.
+    /// </summary>
+    [Column("uti_id")]
+    [Domain(Domains.IdListe)]
+    [NotMapped]
+    public int[] Utilisateurs { get; set; }
+
+    /// <summary>
     /// Date de création de l'utilisateur.
     /// </summary>
     [Column("pro_date_creation")]

--- a/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Profil.java
+++ b/samples/generators/jpa/src/main/javagen/topmodel/jpa/sample/demo/entities/securite/profil/Profil.java
@@ -62,6 +62,12 @@ public class Profil {
 	private List<Droit> droits;
 
 	/**
+	 * Association réciproque de Utilisateur.ProfilId.
+	 */
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY, mappedBy = "profil")
+	private List<Utilisateur> utilisateurs;
+
+	/**
 	 * Date de création de l'utilisateur.
 	 */
 	@CreatedDate
@@ -74,12 +80,6 @@ public class Profil {
 	@LastModifiedDate
 	@Column(name = "PRO_DATE_MODIFICATION", columnDefinition = "date")
 	private LocalDateTime dateModification = LocalDateTime.now();
-
-	/**
-	 * Association réciproque de Utilisateur.ProfilId.
-	 */
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY, mappedBy = "profil")
-	private List<Utilisateur> utilisateurs;
 
 	/**
 	 * Getter for id.
@@ -112,6 +112,18 @@ public class Profil {
 	}
 
 	/**
+	 * Getter for utilisateurs.
+	 *
+	 * @return value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#utilisateurs utilisateurs}.
+	 */
+	public List<Utilisateur> getUtilisateurs() {
+		if (this.utilisateurs == null) {
+			this.utilisateurs = new ArrayList<>();
+		}
+		return this.utilisateurs;
+	}
+
+	/**
 	 * Getter for dateCreation.
 	 *
 	 * @return value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#dateCreation dateCreation}.
@@ -127,18 +139,6 @@ public class Profil {
 	 */
 	public LocalDateTime getDateModification() {
 		return this.dateModification;
-	}
-
-	/**
-	 * Getter for utilisateurs.
-	 *
-	 * @return value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#utilisateurs utilisateurs}.
-	 */
-	public List<Utilisateur> getUtilisateurs() {
-		if (this.utilisateurs == null) {
-			this.utilisateurs = new ArrayList<>();
-		}
-		return this.utilisateurs;
 	}
 
 	/**
@@ -166,6 +166,14 @@ public class Profil {
 	}
 
 	/**
+	 * Set the value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#utilisateurs utilisateurs}.
+	 * @param utilisateurs value to set.
+	 */
+	public void setUtilisateurs(List<Utilisateur> utilisateurs) {
+		this.utilisateurs = utilisateurs;
+	}
+
+	/**
 	 * Set the value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#dateCreation dateCreation}.
 	 * @param dateCreation value to set.
 	 */
@@ -179,14 +187,6 @@ public class Profil {
 	 */
 	public void setDateModification(LocalDateTime dateModification) {
 		this.dateModification = dateModification;
-	}
-
-	/**
-	 * Set the value of {@link topmodel.jpa.sample.demo.entities.securite.profil.Profil#utilisateurs utilisateurs}.
-	 * @param utilisateurs value to set.
-	 */
-	public void setUtilisateurs(List<Utilisateur> utilisateurs) {
-		this.utilisateurs = utilisateurs;
 	}
 
 	/**
@@ -206,9 +206,9 @@ public class Profil {
         ID(Integer.class), //
         LIBELLE(String.class), //
         DROITS(List.class), //
+        UTILISATEURS(List.class), //
         DATE_CREATION(LocalDateTime.class), //
-        DATE_MODIFICATION(LocalDateTime.class), //
-        UTILISATEURS(List.class);
+        DATE_MODIFICATION(LocalDateTime.class);
 
 		private final Class<?> type;
 

--- a/samples/generators/jpa/topmodel.lock
+++ b/samples/generators/jpa/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.1.0
 custom:
-  ../../../TopModel.Generator.Jpa: c64bb665fa3c9ccf16918f397f4fae05
+  ../../../TopModel.Generator.Jpa: 3c3bb174a6eb0b532730ab5bedaed718
 generatedFiles:
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/profil/ProfilClient.java
   - ./src/main/javagen/topmodel/jpa/sample/demo/api/client/securite/utilisateur/UtilisateurClient.java

--- a/samples/generators/pg/topmodel.lock
+++ b/samples/generators/pg/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.1.0
 custom:
-  ../../../TopModel.Generator.Sql: 9b71370732e8d1796784a4efca24ba0e
+  ../../../TopModel.Generator.Sql: 009a0ad755d5bb8496710065abab97c3
 generatedFiles:
   - ./src/01_tables.sql
   - ./src/02_fk_indexes.sql

--- a/samples/generators/php/src/Entity/Securite/Profil/Profil.php
+++ b/samples/generators/php/src/Entity/Securite/Profil/Profil.php
@@ -41,17 +41,17 @@ class Profil
   #[ManyToMany(targetEntity: Droit::class)]
   private Collection $droits;
 
-  #[Column(name: 'PRO_DATE_CREATION')]
-  private Date $dateCreation = now;
-
-  #[Column(name: 'PRO_DATE_MODIFICATION', nullable: true)]
-  private Date|null $dateModification = now;
-
   /**
    * @var Collection<Utilisateur>
    */
   #[OneToMany(mappedBy: 'profil', targetEntity: Utilisateur::class)]
   private Collection $utilisateurs;
+
+  #[Column(name: 'PRO_DATE_CREATION')]
+  private Date $dateCreation = now;
+
+  #[Column(name: 'PRO_DATE_MODIFICATION', nullable: true)]
+  private Date|null $dateModification = now;
 
   public function __construct()
   {
@@ -77,6 +77,14 @@ class Profil
     return $this->droits;
   }
 
+  /**
+   * @return Collection<Utilisateur>
+   */
+  public function getUtilisateurs(): Collection
+  {
+    return $this->utilisateurs;
+  }
+
   public function getDateCreation(): Date
   {
     return $this->dateCreation;
@@ -85,14 +93,6 @@ class Profil
   public function getDateModification(): Date|null
   {
     return $this->dateModification;
-  }
-
-  /**
-   * @return Collection<Utilisateur>
-   */
-  public function getUtilisateurs(): Collection
-  {
-    return $this->utilisateurs;
   }
 
   public function setId(int|null $id): self
@@ -119,6 +119,16 @@ class Profil
     return $this;
   }
 
+  /**
+   * @param Collection<Utilisateur> $utilisateurs
+   */
+  public function setUtilisateurs(Collection|null $utilisateurs): self
+  {
+    $this->utilisateurs = $utilisateurs;
+
+    return $this;
+  }
+
   public function setDateCreation(Date|null $dateCreation): self
   {
     $this->dateCreation = $dateCreation;
@@ -129,16 +139,6 @@ class Profil
   public function setDateModification(Date|null $dateModification): self
   {
     $this->dateModification = $dateModification;
-
-    return $this;
-  }
-
-  /**
-   * @param Collection<Utilisateur> $utilisateurs
-   */
-  public function setUtilisateurs(Collection|null $utilisateurs): self
-  {
-    $this->utilisateurs = $utilisateurs;
 
     return $this;
   }

--- a/samples/generators/php/topmodel.lock
+++ b/samples/generators/php/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.1.0
 custom:
-  ../../../TopModel.Generator.Php: 0d69aeee674bd61c00ec3427c9e87609
+  ../../../TopModel.Generator.Php: d1fb6907bd6febc8a0b708333e704941
 generatedFiles:
   - ./src/Entity/Securite/Profil/Droit.php
   - ./src/Entity/Securite/Profil/Profil.php

--- a/samples/generators/ssdt/topmodel.lock
+++ b/samples/generators/ssdt/topmodel.lock
@@ -4,7 +4,7 @@
 
 version: 3.1.0
 custom:
-  ../../../TopModel.Generator.Sql: 9b71370732e8d1796784a4efca24ba0e
+  ../../../TopModel.Generator.Sql: 009a0ad755d5bb8496710065abab97c3
 generatedFiles:
   - ./src/init/DROIT.insert.sql
   - ./src/init/main.sql

--- a/samples/model/Securite/Profil/02_Entities.tmd
+++ b/samples/model/Securite/Profil/02_Entities.tmd
@@ -5,6 +5,7 @@ tags:
 uses:
   - meta/decorators
   - Securite/Profil/01_References
+  - Securite/Utilisateur/02_Entities
 
 ---
 class:
@@ -40,3 +41,4 @@ class:
           Id: false
           DateCreation: false
           DateModification: false
+          Utilisateurs: false

--- a/samples/model/Securite/Profil/03_Dtos.tmd
+++ b/samples/model/Securite/Profil/03_Dtos.tmd
@@ -36,6 +36,7 @@ class:
         exclude:
           - DateCreation
           - DateModification
+          - Utilisateurs
 
     - alias:
         class: Profil
@@ -64,6 +65,7 @@ class:
           - Id
           - DateCreation
           - DateModification
+          - Utilisateurs
 
   mappers:
     to:


### PR DESCRIPTION
Maintenant que l'on sait gérer des dépendances circulaires, on peut désormais inclure les associations réciproques dans le modèle.

Spécifier `withReverse: true` va ajouter la propriété d'association réciproque sur la classe cible dans le modèle, et elle sera ajoutée à la liste des propriétés de la classe (un peu à la manière des propriétés de décorateurs). En particulier, elles sont référençables dans les alias et les mappers.

La dépendance circulaire doit être définie explicitement dans les `uses` des fichiers : il faudra donc à priori ajouter le `use` du fichier qui déclare l'association réciproque dans le fichier de la classe cible de l'association.

Cette PR est un breaking change sur la gestion des associations réciproques (en plus de la précédente qui ajoutait `withReverse` explicite). Il faudra en particulier : 
- Ajouter les uses qui manquent pour la dépendance circulaire
- Vérifier les définitions d'alias et de mappings qui pourraient attraper les associations réciproques à tort.

Il faudra aussi nécessaire mettre à jour les générateurs vers la dernière version, puisque le modèle de TopModel a changé.