### PR TITLE
Exclusion d'annotations

### DIFF
--- a/TopModel.Core/FileModel/ModelFile.cs
+++ b/TopModel.Core/FileModel/ModelFile.cs
@@ -106,6 +106,17 @@ public class ModelFile
                 )
             )
             .Concat(
+                AnnotationContainers.SelectMany(d =>
+                    d.ExcludedAnnotationReferences.Select(ar =>
+                        (
+                            ar as Reference,
+                            d.ExcludedAnnotations.Select(a => a.Annotation)
+                                .FirstOrDefault(d => d.Name == ar.ReferenceName) as object
+                        )
+                    )
+                )
+            )
+            .Concat(
                 VariableContainers.SelectMany(d =>
                     d.VariableReferences.Select(pr =>
                         (

--- a/TopModel.Core/Loaders/ClassLoader.cs
+++ b/TopModel.Core/Loaders/ClassLoader.cs
@@ -117,6 +117,12 @@ public class ClassLoader(ModelConfig modelConfig, FileChecker fileChecker, Prope
                         }
                     });
                     break;
+                case "excludedAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        classe.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                    });
+                    break;
                 case "propertyAnnotations":
                     parser.ConsumeSequence(() =>
                     {

--- a/TopModel.Core/Loaders/DecoratorLoader.cs
+++ b/TopModel.Core/Loaders/DecoratorLoader.cs
@@ -77,6 +77,12 @@ public class DecoratorLoader(FileChecker fileChecker, PropertyLoader propertyLoa
                         }
                     });
                     break;
+                case "excludedAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        decorator.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                    });
+                    break;
                 case "propertyAnnotations":
                     parser.ConsumeSequence(() =>
                     {

--- a/TopModel.Core/Loaders/DomainLoader.cs
+++ b/TopModel.Core/Loaders/DomainLoader.cs
@@ -78,6 +78,12 @@ public class DomainLoader(FileChecker fileChecker) : ILoader<Domain>
                         }
                     });
                     break;
+                case "excludedAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        domain.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                    });
+                    break;
                 default:
                     var implementation = new DomainImplementation();
 

--- a/TopModel.Core/Loaders/EndpointLoader.cs
+++ b/TopModel.Core/Loaders/EndpointLoader.cs
@@ -94,6 +94,12 @@ public class EndpointLoader(FileChecker fileChecker, PropertyLoader propertyLoad
                         }
                     });
                     break;
+                case "excludedAnnotations":
+                    parser.ConsumeSequence(() =>
+                    {
+                        endpoint.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                    });
+                    break;
                 case "propertyAnnotations":
                     parser.ConsumeSequence(() =>
                     {

--- a/TopModel.Core/Loaders/PropertyLoader.cs
+++ b/TopModel.Core/Loaders/PropertyLoader.cs
@@ -74,6 +74,12 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                                 }
                             });
                             break;
+                        case "excludedAnnotations":
+                            parser.ConsumeSequence(() =>
+                            {
+                                rp.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
+                            });
+                            break;
                         case "customProperties":
                             parser.ConsumeMapping(prop =>
                                 rp.CustomProperties.Add(prop.Value, parser.Consume<Scalar>().Value)
@@ -188,6 +194,14 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                                                     }
                                                 });
                                                 break;
+                                            case "excludedAnnotations":
+                                                parser.ConsumeSequence(() =>
+                                                {
+                                                    ap.WithReverse.ExcludedAnnotationReferences.Add(
+                                                        new AnnotationReference(parser.Consume<Scalar>())
+                                                    );
+                                                });
+                                                break;
                                         }
                                     });
                                 }
@@ -227,6 +241,13 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                                 {
                                     ap.AnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                                 }
+                            });
+                            break;
+
+                        case "excludedAnnotations":
+                            parser.ConsumeSequence(() =>
+                            {
+                                ap.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                             });
                             break;
                         case "customProperties":
@@ -312,6 +333,12 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                                 {
                                     cp.AnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                                 }
+                            });
+                            break;
+                        case "excludedAnnotations":
+                            parser.ConsumeSequence(() =>
+                            {
+                                cp.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                             });
                             break;
                         case "customProperties":
@@ -454,6 +481,12 @@ public class PropertyLoader(FileChecker fileChecker, ModelConfig modelConfig) : 
                                 {
                                     alp.AnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                                 }
+                            });
+                            break;
+                        case "excludedAnnotations":
+                            parser.ConsumeSequence(() =>
+                            {
+                                alp.ExcludedAnnotationReferences.Add(new AnnotationReference(parser.Consume<Scalar>()));
                             });
                             break;
                         case "customProperties":

--- a/TopModel.Core/Model/AliasProperty.cs
+++ b/TopModel.Core/Model/AliasProperty.cs
@@ -146,11 +146,22 @@ public class AliasProperty : IProperty
 
     public string? As { get; set; }
 
-    public IList<AnnotationInstance> Annotations => [.. OriginalProperty?.Annotations ?? [], .. OwnAnnotations];
+    public IList<AnnotationInstance> Annotations =>
+        [
+            .. OriginalProperty?.Annotations.Where(ann =>
+                !OriginalProperty.ExcludedAnnotations.Any(ann2 => ann.Annotation == ann2.Annotation)
+                && !OwnAnnotations.Any(ann2 => ann.Annotation == ann2.Annotation)
+            ) ?? [],
+            .. OwnAnnotations,
+        ];
 
     public IList<AnnotationInstance> OwnAnnotations { get; private set; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
+
+    public IList<AnnotationInstance> ExcludedAnnotations { get; set; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; set; } = [];
 
     public IDictionary<string, string> CustomProperties
     {
@@ -228,6 +239,7 @@ public class AliasProperty : IProperty
             DomainParameters = _domainParameters!,
             CustomProperties = _customProperties,
             OwnAnnotations = OwnAnnotations,
+            ExcludedAnnotations = ExcludedAnnotations,
         };
 
         if (_domain != null)
@@ -280,7 +292,9 @@ public class AliasProperty : IProperty
             DomainParameters = _domainParameters!,
             CustomProperties = _customProperties,
             OwnAnnotations = OwnAnnotations,
+            ExcludedAnnotations = ExcludedAnnotations,
             AnnotationReferences = AnnotationReferences,
+            ExcludedAnnotationReferences = ExcludedAnnotationReferences,
         };
 
         if (_domain != null)

--- a/TopModel.Core/Model/AssociationProperty.cs
+++ b/TopModel.Core/Model/AssociationProperty.cs
@@ -78,6 +78,10 @@ public class AssociationProperty : IProperty
 
     public virtual IList<AnnotationReference> AnnotationReferences { get; set; } = [];
 
+    public virtual IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
+    public virtual IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
+
     public IDictionary<string, string> CustomProperties { get; private set; } = new Dictionary<string, string>();
 
     public string Name

--- a/TopModel.Core/Model/Class.cs
+++ b/TopModel.Core/Model/Class.cs
@@ -32,6 +32,8 @@ public class Class : IPropertyContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
     public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
 
     public string? Label { get; set; }
@@ -108,6 +110,8 @@ public class Class : IPropertyContainer
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
 
     public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 

--- a/TopModel.Core/Model/CompositionProperty.cs
+++ b/TopModel.Core/Model/CompositionProperty.cs
@@ -54,6 +54,10 @@ public class CompositionProperty : IProperty
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
+
     public IDictionary<string, string> CustomProperties { get; private set; } = new Dictionary<string, string>();
 
     public IProperty? CompositionPrimaryKey

--- a/TopModel.Core/Model/Decorator.cs
+++ b/TopModel.Core/Model/Decorator.cs
@@ -32,6 +32,8 @@ public class Decorator : IPropertyContainer, IVariableContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
     public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
 
     public IList<IProperty> Properties { get; } = [];
@@ -76,6 +78,8 @@ public class Decorator : IPropertyContainer, IVariableContainer
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
 
     public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 

--- a/TopModel.Core/Model/Domain.cs
+++ b/TopModel.Core/Model/Domain.cs
@@ -33,6 +33,10 @@ public class Domain : IAnnotationContainer, IVariableContainer
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
+
     public IDictionary<string, DomainReference> AsDomainReferences { get; set; } =
         new Dictionary<string, DomainReference>();
 

--- a/TopModel.Core/Model/Endpoint.cs
+++ b/TopModel.Core/Model/Endpoint.cs
@@ -56,6 +56,8 @@ public class Endpoint : IPropertyContainer
 
     public IList<AnnotationInstance> Annotations { get; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
     public IList<AnnotationInstance> PropertyAnnotations { get; } = [];
 
     public IEnumerable<ClassDependency> ClassDependencies => Properties.GetClassDependencies();
@@ -63,6 +65,8 @@ public class Endpoint : IPropertyContainer
     public IList<DecoratorReference> DecoratorReferences { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
 
     public IList<AnnotationReference> PropertyAnnotationReferences { get; } = [];
 

--- a/TopModel.Core/Model/IAnnotationContainer.cs
+++ b/TopModel.Core/Model/IAnnotationContainer.cs
@@ -7,4 +7,8 @@ public interface IAnnotationContainer
     IList<AnnotationInstance> Annotations { get; }
 
     IList<AnnotationReference> AnnotationReferences { get; }
+
+    IList<AnnotationInstance> ExcludedAnnotations { get; }
+
+    IList<AnnotationReference> ExcludedAnnotationReferences { get; }
 }

--- a/TopModel.Core/Model/PropertyMapping.cs
+++ b/TopModel.Core/Model/PropertyMapping.cs
@@ -35,6 +35,10 @@ public class PropertyMapping : IPropertyContainer
 
     public IList<AnnotationReference> AnnotationReferences => throw new NotSupportedException();
 
+    public IList<AnnotationInstance> ExcludedAnnotations => throw new NotSupportedException();
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences => throw new NotSupportedException();
+
     public IList<AnnotationInstance> PropertyAnnotations => throw new NotSupportedException();
 
     public IList<AnnotationReference> PropertyAnnotationReferences => throw new NotSupportedException();

--- a/TopModel.Core/Model/RegularProperty.cs
+++ b/TopModel.Core/Model/RegularProperty.cs
@@ -41,6 +41,10 @@ public class RegularProperty : IProperty
 
     public IList<AnnotationReference> AnnotationReferences { get; set; } = [];
 
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
+
     public IDictionary<string, string> CustomProperties { get; private set; } = new Dictionary<string, string>();
 
     public Class Class { get; set; }

--- a/TopModel.Core/Model/ReverseAssociationDefinition.cs
+++ b/TopModel.Core/Model/ReverseAssociationDefinition.cs
@@ -15,4 +15,8 @@ public class ReverseAssociationDefinition : IAnnotationContainer
     public IList<AnnotationInstance> Annotations { get; } = [];
 
     public IList<AnnotationReference> AnnotationReferences { get; } = [];
+
+    public IList<AnnotationInstance> ExcludedAnnotations { get; } = [];
+
+    public IList<AnnotationReference> ExcludedAnnotationReferences { get; } = [];
 }

--- a/TopModel.Core/Model/ReverseAssociationProperty.cs
+++ b/TopModel.Core/Model/ReverseAssociationProperty.cs
@@ -37,4 +37,10 @@ public class ReverseAssociationProperty : AssociationProperty
 
     public override IList<AnnotationReference> AnnotationReferences =>
         ReverseProperty.WithReverse?.AnnotationReferences ?? [];
+
+    public override IList<AnnotationInstance> ExcludedAnnotations =>
+        ReverseProperty.WithReverse?.ExcludedAnnotations ?? [];
+
+    public override IList<AnnotationReference> ExcludedAnnotationReferences =>
+        ReverseProperty.WithReverse?.ExcludedAnnotationReferences ?? [];
 }

--- a/TopModel.Core/ModelStore.cs
+++ b/TopModel.Core/ModelStore.cs
@@ -869,11 +869,6 @@ public class ModelStore(
             yield return error;
         }
 
-        foreach (var error in annotationResolver.CheckAliasAnnotations())
-        {
-            yield return error;
-        }
-
         foreach (var error in propertyResolver.ResolveAssociationProperties())
         {
             yield return error;

--- a/TopModel.Core/Resolvers/AnnotationResolver.cs
+++ b/TopModel.Core/Resolvers/AnnotationResolver.cs
@@ -11,26 +11,6 @@ public class AnnotationResolver(
     IDictionary<string, Annotation> referencedAnnotations
 )
 {
-    public IEnumerable<ModelError> CheckAliasAnnotations()
-    {
-        foreach (var alp in modelFiles.SelectMany(mf => mf.Properties).OfType<AliasProperty>())
-        {
-            foreach (var g in alp.Annotations.GroupBy(a => a.Annotation.Name).Where(g => g.Count() > 1))
-            {
-                var annotationRef = alp.AnnotationReferences.FirstOrDefault(ar => ar.ReferenceName == g.Key);
-                if (annotationRef != null)
-                {
-                    yield return new ModelError(
-                        ErrorType.TMD2003,
-                        alp,
-                        $"L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations de la propriété aliasée.",
-                        annotationRef
-                    );
-                }
-            }
-        }
-    }
-
     /// <summary>
     /// Résout les annotations.
     /// </summary>
@@ -106,44 +86,16 @@ public class AnnotationResolver(
             }
         }
 
-        foreach (var container in modelFiles.SelectMany(mf => mf.AnnotationContainers))
+        foreach (
+            var container in modelFiles
+                .SelectMany(mf => mf.AnnotationContainers)
+                .OrderBy(ac => ac is Domain or Decorator ? 0 : 1)
+        )
         {
-            var annotationsToResolve = container is AliasProperty alp ? alp.OwnAnnotations : container.Annotations;
-
-            annotationsToResolve.Clear();
-
             var isError = false;
 
-            foreach (var annotation in referencedAnnotations.Values.Where(a => a.Global))
-            {
-                if (
-                    annotation.Target.Count == 0
-                        && container is not Decorator
-                        && container is not Domain
-                        && container is not AliasProperty
-                    || container is Class && annotation.Target.Contains(Target.Class)
-                    || container is Endpoint && annotation.Target.Contains(Target.Endpoint)
-                    || container is AssociationProperty
-                        && (
-                            annotation.Target.Contains(Target.Property)
-                            || annotation.Target.Contains(Target.AssociationProperty)
-                        )
-                    || container is CompositionProperty
-                        && (
-                            annotation.Target.Contains(Target.Property)
-                            || annotation.Target.Contains(Target.CompositionProperty)
-                        )
-                    || container is RegularProperty
-                        && (
-                            annotation.Target.Contains(Target.Property)
-                            || annotation.Target.Contains(Target.RegularProperty)
-                        )
-                )
-                {
-                    annotationsToResolve.Add(new(annotation, new Dictionary<string, string>()));
-                }
-            }
-
+            var annotationsToResolve = container is AliasProperty alp ? alp.OwnAnnotations : container.Annotations;
+            annotationsToResolve.Clear();
             foreach (
                 var error in ResolveAnnotationReferences(
                     container,
@@ -154,6 +106,83 @@ public class AnnotationResolver(
             {
                 isError = true;
                 yield return error;
+            }
+
+            container.ExcludedAnnotations.Clear();
+            foreach (
+                var error in ResolveAnnotationReferences(
+                    container,
+                    container.ExcludedAnnotationReferences,
+                    container.ExcludedAnnotations
+                )
+            )
+            {
+                isError = true;
+                yield return error;
+            }
+
+            var globalExclusions = container.ExcludedAnnotations.Select(a => a.Annotation).ToList();
+
+            void AddDecoratorExclusions(Decorator decorator)
+            {
+                globalExclusions.AddRange(decorator.ExcludedAnnotations.Select(a => a.Annotation));
+                foreach (var subD in decorator.Decorators)
+                {
+                    AddDecoratorExclusions(subD.Decorator);
+                }
+            }
+
+            switch (container)
+            {
+                case IProperty { Domain.ExcludedAnnotations: var dea }:
+                    globalExclusions.AddRange(dea.Select(a => a.Annotation));
+                    break;
+                case Class c:
+                    foreach (var d in c.Decorators)
+                    {
+                        AddDecoratorExclusions(d.Decorator);
+                    }
+                    break;
+                case Endpoint e:
+                    foreach (var d in e.Decorators)
+                    {
+                        AddDecoratorExclusions(d.Decorator);
+                    }
+                    break;
+            }
+
+            foreach (var annotation in referencedAnnotations.Values.Where(a => a.Global))
+            {
+                if (
+                    !globalExclusions.Contains(annotation)
+                    && !annotationsToResolve.Any(a => a.Annotation == annotation)
+                    && (
+                        annotation.Target.Count == 0
+                            && container is not Decorator
+                            && container is not Domain
+                            && container is not AliasProperty
+                        || container is Class && annotation.Target.Contains(Target.Class)
+                        || container is Endpoint && annotation.Target.Contains(Target.Endpoint)
+                        || container is AssociationProperty
+                            && (
+                                annotation.Target.Contains(Target.Property)
+                                || annotation.Target.Contains(Target.AssociationProperty)
+                            )
+                        || container is CompositionProperty
+                            && (
+                                annotation.Target.Contains(Target.Property)
+                                || annotation.Target.Contains(Target.CompositionProperty)
+                            )
+                        || container is RegularProperty
+                            && (
+                                annotation.Target.Contains(Target.Property)
+                                || annotation.Target.Contains(Target.RegularProperty)
+                            )
+                    )
+                )
+                {
+                    annotationsToResolve.Add(new(annotation, new Dictionary<string, string>()));
+                }
             }
 
             if (container is IPropertyContainer pContainer)

--- a/TopModel.Core/Utils/ModelExtensions.cs
+++ b/TopModel.Core/Utils/ModelExtensions.cs
@@ -21,6 +21,20 @@ public static class ModelExtensions
             )
             .Concat(
                 modelStore
+                    .AnnotationContainers.Where(c =>
+                        c.ExcludedAnnotations.Select(d => d.Annotation).Contains(annotation)
+                    )
+                    .Select(c =>
+                        (
+                            Reference: c.ExcludedAnnotationReferences.FirstOrDefault(dr =>
+                                dr.ReferenceName == annotation.Name
+                            )!,
+                            File: c.GetFile()
+                        )
+                    )
+            )
+            .Concat(
+                modelStore
                     .PropertyContainers.Where(c => c.PropertyAnnotations.Select(d => d.Annotation).Contains(annotation))
                     .Select(c =>
                         (

--- a/TopModel.Core/schema.json
+++ b/TopModel.Core/schema.json
@@ -122,6 +122,13 @@
                 "$ref": "#/definitions/annotation"
               }
             },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou du domaine à retirer de cette propriété.",
+              "items": {
+                "type": "string"
+              }
+            },
             "customProperties": {
               "type": "object",
               "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé.",
@@ -210,6 +217,13 @@
                       "items": {
                         "$ref": "#/definitions/annotation"
                       }
+                    },
+                    "excludedAnnotations": {
+                      "type": "array",
+                      "description": "Annotations globales ou du domaine à retirer de la propriété d'association réciproque.",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   }
                 }
@@ -236,6 +250,13 @@
               "description": "Annotations de la propriété.",
               "items": {
                 "$ref": "#/definitions/annotation"
+              }
+            },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou du domaine à retirer de cette propriété.",
+              "items": {
+                "type": "string"
               }
             },
             "customProperties": {
@@ -437,6 +458,13 @@
                 "$ref": "#/definitions/annotation"
               }
             },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales, du domaine ou de la propriété originale à retirer de cette propriété.",
+              "items": {
+                "type": "string"
+              }
+            },
             "customProperties": {
               "type": "object",
               "description": "Propriétés de propriété personnalisées, pour utilisation dans un générateur personnalisé. Elles s'ajouteront à celles de la propriété originale (avec remplacement si conflit).",
@@ -492,6 +520,13 @@
               "description": "Annotations de la propriété.",
               "items": {
                 "$ref": "#/definitions/annotation"
+              }
+            },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou du domaine à retirer de cette propriété.",
+              "items": {
+                "type": "string"
               }
             },
             "customProperties": {
@@ -751,6 +786,13 @@
                 "$ref": "#/definitions/annotation"
               }
             },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales à retirer de ce domaine.",
+              "items": {
+                "type": "string"
+              }
+            },
             "parameters": {
               "type": "array",
               "description": "Définitions de paramètres, utilisables dans les templates pour les implémentations.",
@@ -898,6 +940,13 @@
               "description": "Annotations du décorateur.",
               "items": {
                 "$ref": "#/definitions/annotation"
+              }
+            },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou d'un décorateur à retirer de ce décorateur.",
+              "items": {
+                "type": "string"
               }
             },
             "propertyAnnotations": {
@@ -1051,6 +1100,13 @@
               "description": "Annotations de la classe.",
               "items": {
                 "$ref": "#/definitions/annotation"
+              }
+            },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou d'un décorateur à retirer de cette classe.",
+              "items": {
+                "type": "string"
               }
             },
             "propertyAnnotations": {
@@ -1300,6 +1356,13 @@
               "description": "Annotations de l'endpoint.",
               "items": {
                 "$ref": "#/definitions/annotation"
+              }
+            },
+            "excludedAnnotations": {
+              "type": "array",
+              "description": "Annotations globales ou d'un décorateur à retirer de cet endpoint.",
+              "items": {
+                "type": "string"
               }
             },
             "propertyAnnotations": {

--- a/TopModel.Generator.Core/GeneratorConfigBase.cs
+++ b/TopModel.Generator.Core/GeneratorConfigBase.cs
@@ -108,6 +108,15 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
             }
         }
 
+        foreach (var excludedAnnotation in container.ExcludedAnnotations)
+        {
+            var annotationsToRemove = annotations.Where(a => a.Annotation == excludedAnnotation.Annotation).ToList();
+            foreach (var annotation in annotationsToRemove)
+            {
+                annotations.Remove(annotation);
+            }
+        }
+
         foreach (
             var (implementation, annotation, parameters) in annotations.SelectMany(a =>
                 GetImplementation(a.Annotation)
@@ -152,7 +161,15 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
         {
             foreach (
                 var annotation in pc
-                    .Decorators.SelectMany(d => GetDecoratorAnnotations(pc, d.Decorator, d.Parameters, tag))
+                    .Decorators.SelectMany(d =>
+                        GetDecoratorAnnotations(
+                            pc,
+                            d.Decorator,
+                            d.Parameters,
+                            container.ExcludedAnnotations.Select(e => e.Annotation),
+                            tag
+                        )
+                    )
                     .Distinct()
             )
             {
@@ -170,7 +187,10 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
                 )
             )
             {
-                if (!annotations.Any(a => a.Annotation == annotation))
+                if (
+                    !annotations.Any(a => a.Annotation == annotation)
+                    && !container.ExcludedAnnotations.Any(e => e.Annotation == annotation)
+                )
                 {
                     var resolvedParameters = parameters.ToDictionary(
                         p => p.Key,
@@ -575,12 +595,14 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
         IPropertyContainer container,
         Decorator decorator,
         IDictionary<string, string> parameters,
+        IEnumerable<Annotation> excludedAnnotations,
         string tag
     )
     {
         foreach (
             var (implementation, annotation, annotationParameters) in decorator
-                .Annotations.SelectMany(a =>
+                .Annotations.Where(a => !excludedAnnotations.Contains(a.Annotation))
+                .SelectMany(a =>
                     GetImplementation(a.Annotation).Select(i => (Implementation: i, a.Annotation, a.Parameters))
                 )
                 .Where(a => FilterAnnotations(a.Implementation, a.Annotation, container, tag))
@@ -617,6 +639,7 @@ public abstract class GeneratorConfigBase : WatcherConfigBase
                         p => p.Key,
                         p => p.Value.ParseTemplate(container, decorator.TemplateParameters, parameters, this, tag)
                     ),
+                    excludedAnnotations.Concat(decorator.ExcludedAnnotations.Select(e => e.Annotation)),
                     tag
                 )
             )

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -110,7 +110,7 @@ public class CompletionHandler(
             return CompleteDecorator(request, file, useIndex);
         }
         // Annotation
-        else if (currentKey.Contains("annotation"))
+        else if (currentKey.ToLowerInvariant().Contains("annotation"))
         {
             return CompleteAnnotation(request, file, useIndex);
         }

--- a/TopModel.Utils/ErrorType.cs
+++ b/TopModel.Utils/ErrorType.cs
@@ -113,11 +113,6 @@ public enum ErrorType
     TMD2002,
 
     /// <summary>
-    /// L'annotation '{annotationRef.ReferenceName}' est déjà présente dans la liste des annotations de la propriété aliasée.
-    /// </summary>
-    TMD2003,
-
-    /// <summary>
     /// Impossible d'appliquer l'annotation '{annotationRef.ReferenceName}' à '{container}' : l'annotation ne cible pas le bon type d'objet.
     /// </summary>
     TMD2004,

--- a/docs/model/annotations.md
+++ b/docs/model/annotations.md
@@ -153,10 +153,11 @@ Remarques :
 
 ### Priorité des annotations
 
-Il est interdit de déclarer plusieurs fois la même annotation sur un objet, y compris pour les annotations ajoutées sur les propriétés d'alias. En revanche, les annotations effectives sur les classes, endpoints et propriétés peuvent se retrouver en doublon (par exemple, si une même annotation est définie sur un domaine et une propriété qui utilise ce domaine). Dans le cas où l'annotation définit des paramètres, il est possible que l'instanciation des annotations ne soit pas faite avec les mêmes valeurs. Dans ce cas, la priorité suivante est établie :
+Il est interdit de déclarer plusieurs fois la même annotation sur un objet. En revanche, les annotations effectives sur les classes, endpoints et propriétés peuvent se retrouver en doublon (par exemple, si une même annotation est définie sur un domaine et une propriété qui utilise ce domaine). Dans le cas où l'annotation définit des paramètres, il est possible que l'instanciation des annotations ne soit pas faite avec les mêmes valeurs. Dans ce cas, la priorité suivante est établie :
 
 - Pour une **propriété**, les paramètres sont récupérés en priorité :
   - Sur la propriété elle-même.
+  - Si c'est un alias, sur la propriété originale de l'alias.
   - Sur la classe (via `propertyAnnotations`).
   - Sur le décorateur qui définit la propriété, s'il y en a un (via `propertyAnnotations`).
   - Sur le domaine.
@@ -211,9 +212,37 @@ annotation:
 
 ### `global`
 
-Une annotation peut également être marquée avec `global: true`, ce qui aura pour effet de la **poser automatiquement sur tous les objets ciblés par l'annotation**. Cela l'ajoute donc automatiquement dans les dépendances de tous les fichiers, à l'image des domaines.
+Une annotation peut également être marquée avec `global: true`, ce qui aura pour effet de la **poser automatiquement sur tous les objets ciblés par l'annotation**. Cela l'ajoute donc automatiquement dans les dépendances de tous les fichiers, à l'image des domaines. Ces annotations ne peuvent pas avoir de paramètres.
 
 Cette fonctionnalité peut être utilisée pour compléter les annotations posées systématiquement par un générateur, par exemple pour ajouter des fonctionnalités non gérées à moindre frais.
+
+## Exclusion d'annotations
+
+A tous les endroits où il est possible de définir des annotations, il est également possible de définir des **exclusions**. Cela permet de gérer des exceptions, pour ne pas à avoir à définir une même annotation partout, sauf à un seul endroit.
+
+Par exemple :
+
+```yaml
+domain:
+  name: DO_LIBELLE
+  label: Libellé
+  annotations:
+    - MyAnnotation
+---
+class:
+  name: MyClass
+  comment: Ma classe
+  properties:
+    - name: Libelle
+      domain: DO_LIBELLE
+      comment: Mon libellé sans annotation.
+      excludedAnnotations:
+        - MyAnnotation
+```
+
+Ici, l'annotation `MyAnnotation` sera posée sur tous les propriétés de `DO_LIBELLE`, sauf sur la propriété `Libelle` de `MyClass`.
+
+Ces exclusions sont utilisables à tous les niveaux et pour toutes les sources d'annotations, en particulier les annotations globales (qui pourraient être exclues au niveau d'un domaine par exemple, et pas seulement sur une propriété), ou pour une annotation sur une propriété qu'on ne veut pas reprendre sur un alias.
 
 ## Templating et paramètres
 


### PR DESCRIPTION
On peut maintenant exclure des annotations via `excludedAnnotations` à tous les endroits où on peut mettre des annotations.

Cela permet en particulier : 
- d'exclure des annotations globales à certains endroits (classes, endpoints, décorateurs, domaines, propriétés)
- d'exclure des annotations de domaine ou de décorateur sur une propriété, une classe ou un endpoint
- d'exclure des annotations de propriétés sur un alias

Il n'y a d'ailleurs plus d'erreurs sur les doublons de propriétés sur les alias, si une annotation est redéclarée sur un alias, alors sa définition écrasera l'annotation préexistante (comme c'est déjà le cas pour les annotations globales ou les annotations de domaine)