### PR TITLE
[JS] Mode `fetch`, par défaut, pour la génération des endpoints

### DIFF
--- a/TopModel.Generator.Javascript/GeneratorRegistration.cs
+++ b/TopModel.Generator.Javascript/GeneratorRegistration.cs
@@ -52,6 +52,10 @@ public class GeneratorRegistration : IGeneratorRegistration<JavascriptConfig>
                 {
                     services.AddGenerator<NuxtApiClientGenerator, JavascriptConfig>(config, number);
                 }
+                else if (config.ApiMode == TargetFramework.LEGACY)
+                {
+                    services.AddGenerator<LegacyApiClientGenerator, JavascriptConfig>(config, number);
+                }
                 else
                 {
                     services.AddGenerator<JavascriptApiClientGenerator, JavascriptConfig>(config, number);

--- a/TopModel.Generator.Javascript/JavascriptApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/JavascriptApiClientGenerator.cs
@@ -24,24 +24,29 @@ public class JavascriptApiClientGenerator(
 
     protected override void HandleFile(string filePath, string fileName, string tag, IList<Endpoint> endpoints)
     {
-        var fetch = Config.FetchPath != "@focus4/core" ? "fetch" : "coreFetch";
-        var fetchImport =
-            Config.FetchPath.StartsWith('@') || !Config.FetchPath.StartsWith('.')
-                ? Config.ResolveVariables(Config.FetchPath, tag)
-                : Path.GetRelativePath(
-                        string.Join('/', filePath.Split('/').SkipLast(1)),
-                        Path.Combine(Config.OutputDirectory, Config.ResolveVariables(Config.FetchPath, tag))
-                    )
-                    .Replace('\\', '/');
-
         using var fw = OpenFileWriter(filePath, encoderShouldEmitUTF8Identifier: false);
 
-        fw.WriteLine($@"import {{{fetch}}} from ""{fetchImport}"";");
+        if (Config.FetchPath != null)
+        {
+            var fetchImport =
+                Config.FetchPath.StartsWith('@') || !Config.FetchPath.StartsWith('.')
+                    ? Config.ResolveVariables(Config.FetchPath, tag)
+                    : Path.GetRelativePath(
+                            string.Join('/', filePath.Split('/').SkipLast(1)),
+                            Path.Combine(Config.OutputDirectory, Config.ResolveVariables(Config.FetchPath, tag))
+                        )
+                        .Replace('\\', '/');
+
+            fw.WriteLine($@"import fetch from ""{fetchImport}"";");
+        }
 
         var imports = Config.GetEndpointImports(filePath, endpoints, tag);
         if (imports.Any())
         {
-            fw.WriteLine();
+            if (Config.FetchPath != null)
+            {
+                fw.WriteLine();
+            }
 
             foreach (var (import, path) in imports)
             {
@@ -51,6 +56,21 @@ public class JavascriptApiClientGenerator(
 
         foreach (var endpoint in endpoints)
         {
+            string GetSafeVariableName(string varName)
+            {
+                while (endpoint.Params.Any(p => p.NameCamel == varName))
+                {
+                    varName = $"_{varName}";
+                }
+
+                return varName;
+            }
+
+            var options = GetSafeVariableName("options");
+            var query = GetSafeVariableName("query");
+            var body = GetSafeVariableName("body");
+            var response = GetSafeVariableName("response");
+
             fw.WriteLine();
             fw.WriteLine("/**");
             fw.WriteLine($" * {endpoint.Description}");
@@ -60,7 +80,7 @@ public class JavascriptApiClientGenerator(
                 fw.WriteLine($" * @param {param.GetParamName()} {param.Comment}");
             }
 
-            fw.WriteLine(" * @param options Options pour 'fetch'.");
+            fw.WriteLine($" * @param {options} Options pour 'fetch'.");
 
             if (endpoint.Returns != null)
             {
@@ -68,7 +88,7 @@ public class JavascriptApiClientGenerator(
             }
 
             fw.WriteLine(" */");
-            fw.Write($"export function {endpoint.NameCamel}(");
+            fw.Write($"export async function {endpoint.NameCamel}(");
 
             foreach (var param in endpoint.Params)
             {
@@ -78,7 +98,7 @@ public class JavascriptApiClientGenerator(
                 );
             }
 
-            fw.Write("options: RequestInit = {}): Promise<");
+            fw.Write($"{options}: RequestInit = {{}}): Promise<");
             if (endpoint.Returns == null)
             {
                 fw.Write("void");
@@ -90,9 +110,42 @@ public class JavascriptApiClientGenerator(
 
             fw.WriteLine("> {");
 
+            if (endpoint.GetQueryParams().Any())
+            {
+                fw.WriteLine(1, $"const {query} = new URLSearchParams();");
+
+                foreach (var qParam in endpoint.GetQueryParams())
+                {
+                    var name = qParam.GetParamName();
+                    fw.WriteLine(1, $"if ({name} !== undefined) {{");
+                    var isArray = Config.GetType(qParam).EndsWith("[]");
+                    var isString =
+                        Config.GetImplementation(qParam.Domain)?.Type?.Value.TrimEnd(']').TrimEnd('[') == "string";
+
+                    void Append(int indent, string value)
+                    {
+                        fw.WriteLine(indent, $"{query}.append(\"{name}\", {(isString ? value : $"`${{{value}}}`")})");
+                    }
+
+                    if (isArray)
+                    {
+                        var item = GetSafeVariableName("item");
+                        fw.WriteLine(2, $"for (const {item} of {name}) {{");
+                        Append(3, item);
+                        fw.WriteLine(2, "}");
+                    }
+                    else
+                    {
+                        Append(2, name);
+                    }
+
+                    fw.WriteLine(1, "}");
+                }
+            }
+
             if (endpoint.IsMultipart)
             {
-                fw.WriteLine(1, "const body = new FormData();");
+                fw.WriteLine(1, $"const {body} = new FormData();");
                 fw.WriteLine(1, "fillFormData(");
                 fw.WriteLine(2, "{");
 
@@ -118,44 +171,47 @@ public class JavascriptApiClientGenerator(
                 }
 
                 fw.WriteLine(2, "},");
-                fw.WriteLine(2, "body");
+                fw.WriteLine(2, body);
                 fw.WriteLine(1, ");");
             }
 
-            fw.Write(1, $@"return {fetch}(""{endpoint.Method}"", `./{endpoint.FullRoute.Replace("{", "${")}`, {{");
+            fw.WriteLine(
+                1,
+                $@"{(endpoint.Returns != null ? $"const {response} = " : string.Empty)}await fetch(`./{endpoint.FullRoute.Replace("{", "${")}{(endpoint.GetQueryParams().Any() ? $"?${{{query}}}" : string.Empty)}`, {{"
+            );
+            fw.WriteLine(2, $"...{options},");
+            fw.Write(2, $"method: \"{endpoint.Method}\"");
 
             if (endpoint.GetJsonBodyParam() != null)
             {
-                fw.Write($"body: {endpoint.GetJsonBodyParam()!.GetParamName()}");
+                fw.WriteLine(",");
+                fw.WriteLine(2, $"body: JSON.stringify({endpoint.GetJsonBodyParam()!.GetParamName()}),");
+                fw.WriteLine(2, $"headers: {{...{options}.headers, \"Content-Type\": \"application/json\"}}");
             }
             else if (endpoint.IsMultipart)
             {
-                fw.Write("body");
+                fw.WriteLine(",");
+                fw.WriteLine(2, body == "body" ? body : $"body: {body}");
             }
-
-            if ((endpoint.GetJsonBodyParam() != null || endpoint.IsMultipart) && endpoint.GetQueryParams().Any())
+            else
             {
-                fw.Write(", ");
+                fw.WriteLine();
             }
 
-            if (endpoint.GetQueryParams().Any())
+            fw.WriteLine(1, "});");
+            if (endpoint.Returns != null)
             {
-                fw.Write("query: {");
+                var type =
+                    Config.GetType(endpoint.Returns) == "Blob" ? "blob"
+                    : endpoint.Returns is CompositionProperty or { Domain.BodyParam: true } ? "json"
+                    : "text";
 
-                foreach (var qParam in endpoint.GetQueryParams())
-                {
-                    fw.Write(qParam.GetParamName());
-
-                    if (qParam != endpoint.GetQueryParams().Last())
-                    {
-                        fw.Write(", ");
-                    }
-                }
-
-                fw.Write("}");
+                var domainType = Config.GetImplementation(endpoint.Returns.Domain)?.Type;
+                fw.WriteLine(
+                    1,
+                    $"return {(domainType == "number" ? "+" : string.Empty)}await {response}.{type}(){(domainType == "boolean" ? " === \"true\"" : string.Empty)};"
+                );
             }
-
-            fw.WriteLine("}, options);");
             fw.WriteLine("}");
         }
 

--- a/TopModel.Generator.Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator.Javascript/JavascriptConfig.cs
@@ -34,7 +34,7 @@ public class JavascriptConfig : GeneratorConfigBase
     /// <summary>
     /// Chemin (ou alias commençant par '@') vers un 'fetch' personnalisé, relatif au répertoire de génération.
     /// </summary>
-    public virtual string FetchPath { get; set; } = "@focus4/core";
+    public virtual string? FetchPath { get; set; }
 
     /// <summary>
     /// Chemin (ou alias commençant par '@') vers le fichier 'domain', relatif au répertoire de génération.
@@ -44,7 +44,7 @@ public class JavascriptConfig : GeneratorConfigBase
     /// <summary>
     /// Framework cible pour la génération.
     /// </summary>
-    public virtual TargetFramework ApiMode { get; set; } = TargetFramework.VANILLA;
+    public virtual TargetFramework ApiMode { get; set; }
 
     /// <summary>
     /// Typage des entités générées

--- a/TopModel.Generator.Javascript/LegacyApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/LegacyApiClientGenerator.cs
@@ -1,0 +1,189 @@
+﻿using Microsoft.Extensions.Logging;
+using TopModel.Core.FileModel;
+using TopModel.Core.Model;
+using TopModel.Core.Utils;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+
+namespace TopModel.Generator.Javascript;
+
+/// <summary>
+/// Générateur des objets de traduction javascripts.
+/// </summary>
+public class LegacyApiClientGenerator(ILogger<LegacyApiClientGenerator> logger, IFileWriterProvider writerProvider)
+    : EndpointsGeneratorBase<JavascriptConfig>(logger, writerProvider)
+{
+    public override string Name => "JSLApiClientGen";
+
+    protected override string GetFilePath(ModelFile file, string tag)
+    {
+        return Config.GetEndpointsFileName(file, tag);
+    }
+
+    protected override void HandleFile(string filePath, string fileName, string tag, IList<Endpoint> endpoints)
+    {
+        var fetchPath = Config.FetchPath ?? "@focus4/core";
+
+        var fetch = fetchPath != "@focus4/core" ? "fetch" : "coreFetch";
+        var fetchImport =
+            fetchPath.StartsWith('@') || !fetchPath.StartsWith('.')
+                ? Config.ResolveVariables(fetchPath, tag)
+                : Path.GetRelativePath(
+                        string.Join('/', filePath.Split('/').SkipLast(1)),
+                        Path.Combine(Config.OutputDirectory, Config.ResolveVariables(fetchPath, tag))
+                    )
+                    .Replace('\\', '/');
+
+        using var fw = OpenFileWriter(filePath, encoderShouldEmitUTF8Identifier: false);
+
+        fw.WriteLine($@"import {{{fetch}}} from ""{fetchImport}"";");
+
+        var imports = Config.GetEndpointImports(filePath, endpoints, tag);
+        if (imports.Any())
+        {
+            fw.WriteLine();
+
+            foreach (var (import, path) in imports)
+            {
+                fw.WriteLine($@"import {{{import}}} from ""{path}"";");
+            }
+        }
+
+        foreach (var endpoint in endpoints)
+        {
+            fw.WriteLine();
+            fw.WriteLine("/**");
+            fw.WriteLine($" * {endpoint.Description}");
+
+            foreach (var param in endpoint.Params)
+            {
+                fw.WriteLine($" * @param {param.GetParamName()} {param.Comment}");
+            }
+
+            fw.WriteLine(" * @param options Options pour 'fetch'.");
+
+            if (endpoint.Returns != null)
+            {
+                fw.WriteLine($" * @returns {endpoint.Returns.Comment}");
+            }
+
+            fw.WriteLine(" */");
+            fw.Write($"export function {endpoint.NameCamel}(");
+
+            foreach (var param in endpoint.Params)
+            {
+                var defaultValue = Config.GetValue(param);
+                fw.Write(
+                    $"{param.GetParamName()}{(param.IsQueryParam() && !endpoint.IsMultipart && defaultValue == "undefined" ? "?" : string.Empty)}: {Config.GetType(param)}{(defaultValue != "undefined" ? $" = {defaultValue}" : string.Empty)}, "
+                );
+            }
+
+            fw.Write("options: RequestInit = {}): Promise<");
+            if (endpoint.Returns == null)
+            {
+                fw.Write("void");
+            }
+            else
+            {
+                fw.Write(Config.GetType(endpoint.Returns));
+            }
+
+            fw.WriteLine("> {");
+
+            if (endpoint.IsMultipart)
+            {
+                fw.WriteLine(1, "const body = new FormData();");
+                fw.WriteLine(1, "fillFormData(");
+                fw.WriteLine(2, "{");
+
+                foreach (var param in endpoint.Params.Where(p => !p.IsRouteParam() && !p.IsQueryParam()))
+                {
+                    if (param is not CompositionProperty and not AliasProperty { Property: CompositionProperty })
+                    {
+                        fw.Write(3, $@"{param.GetParamName()}");
+                    }
+                    else
+                    {
+                        fw.Write(3, $@"...{param.GetParamName()}");
+                    }
+
+                    if (endpoint.Params.IndexOf(param) < endpoint.Params.Count - 1)
+                    {
+                        fw.WriteLine(",");
+                    }
+                    else
+                    {
+                        fw.WriteLine();
+                    }
+                }
+
+                fw.WriteLine(2, "},");
+                fw.WriteLine(2, "body");
+                fw.WriteLine(1, ");");
+            }
+
+            fw.Write(1, $@"return {fetch}(""{endpoint.Method}"", `./{endpoint.FullRoute.Replace("{", "${")}`, {{");
+
+            if (endpoint.GetJsonBodyParam() != null)
+            {
+                fw.Write($"body: {endpoint.GetJsonBodyParam()!.GetParamName()}");
+            }
+            else if (endpoint.IsMultipart)
+            {
+                fw.Write("body");
+            }
+
+            if ((endpoint.GetJsonBodyParam() != null || endpoint.IsMultipart) && endpoint.GetQueryParams().Any())
+            {
+                fw.Write(", ");
+            }
+
+            if (endpoint.GetQueryParams().Any())
+            {
+                fw.Write("query: {");
+
+                foreach (var qParam in endpoint.GetQueryParams())
+                {
+                    fw.Write(qParam.GetParamName());
+
+                    if (qParam != endpoint.GetQueryParams().Last())
+                    {
+                        fw.Write(", ");
+                    }
+                }
+
+                fw.Write("}");
+            }
+
+            fw.WriteLine("}, options);");
+            fw.WriteLine("}");
+        }
+
+        if (
+            endpoints.Any(endpoint =>
+                endpoint.Params.Any(p =>
+                    p is not CompositionProperty and not AliasProperty { Property: CompositionProperty }
+                    && Config.GetType(p).Contains("File")
+                )
+            )
+        )
+        {
+            fw.WriteLine(
+                @"
+function fillFormData(data: any, formData: FormData, prefix = """") {
+    if (Array.isArray(data)) {
+        for (const [i, item] of data.entries()) {
+            fillFormData(item, formData, prefix + (typeof item === ""object"" && !(item instanceof File) ? `[${i}]` : """"));
+        }
+    } else if (typeof data === ""object"" && !(data instanceof File)) {
+        for (const key in data) {
+            fillFormData(data[key], formData, (prefix ? `${prefix}.` : """") + key);
+        }
+    } else {
+        formData.append(prefix, data);
+    }
+}"
+            );
+        }
+    }
+}

--- a/TopModel.Generator.Javascript/TargetFramework.cs
+++ b/TopModel.Generator.Javascript/TargetFramework.cs
@@ -3,6 +3,11 @@
 public enum TargetFramework
 {
     /// <summary>
+    /// Fetch.
+    /// </summary>
+    FETCH,
+
+    /// <summary>
     /// Angular.
     /// </summary>
     ANGULAR,
@@ -18,7 +23,7 @@ public enum TargetFramework
     NUXT,
 
     /// <summary>
-    /// Vanilla.
+    /// Legacy.
     /// </summary>
-    VANILLA,
+    LEGACY,
 }

--- a/TopModel.Generator.Javascript/javascript.config.json
+++ b/TopModel.Generator.Javascript/javascript.config.json
@@ -123,7 +123,7 @@
       "type": "string",
       "description": "Framework cible pour la génération.",
       "default": "focus",
-      "enum": [ "angular", "angular_promise", "vanilla", "nuxt" ]
+      "enum": [ "fetch", "angular", "angular_promise", "nuxt", "legacy" ]
     },
     "entityMode": {
       "type": "string",

--- a/docs/generator/js.md
+++ b/docs/generator/js.md
@@ -6,7 +6,15 @@ _Remarque : tous les imports spécifiés pour le générateur JS dans les domain
 
 ### Modes de génération de l'API client
 
-Il est possible de générer l'API cliente selon quatre modes (`apiMode`) : `vanilla`, `nuxt`, `angular` ou `angular_promise`.
+Il est possible de générer l'API cliente selon 5 modes (`apiMode`) : `fetch` (par défaut), `nuxt`, `angular`, `angular_promise` ou `legacy`.
+
+### Fetch
+
+Par défaut, TopModel génère des appels d'API en utilisant le fetch natif du navigateur. Pour générer l'authentification et la gestion des erreurs, il est fortement conseillé d'utiliser une librairie comme [`ky`](https://github.com/sindresorhus/ky) qui surcharge le fetch natif avec des hooks pour y inclure des traitements à effectuer avant l'envoi des requêtes (pour l'authentification) ou à la réception d'une réponse en erreur.
+
+Vous pouvez surcharger le `fetch` natif en spécifiant `fetchPath` dans la configuration.
+
+_(Remarque : Il s'agit du mode à utiliser pour focus4 12.7+)_
 
 #### Angular
 
@@ -37,24 +45,28 @@ export function getProfil(
   id: number,
   options: AsyncDataOptions<ProfilDto> = {}
 ): AsyncData<ProfilDto | null, Error | null> {
-  return useAsyncData(`/api/profil/${id}`, () =>
-    $fetch<ProfilDto>(`/api/profil/${id}`, {
-      method: 'GET',
-    }),
+  return useAsyncData(
+    `/api/profil/${id}`,
+    () =>
+      $fetch<ProfilDto>(`/api/profil/${id}`, {
+        method: "GET",
+      }),
     options
   );
 }
 ```
 
-#### Vanilla
+#### Legacy
 
-Le mode `vanilla` permet de générer un fichier ts, contenant les méthodes d'appels à l'API exportées sous forme de fonctions. Ce mode nécessite la définition d'une méthode `fetch`. Par défaut, cette méthode est importée de `@focus4/core`, mais il est possible de la surcharger avec le paramètre `fetchPath`.
+Le mode `legacy` permet de générer un fichier ts, contenant les méthodes d'appels à l'API exportées sous forme de fonctions. Ce mode nécessite la définition d'une méthode `fetch`. Par défaut, cette méthode est importée de `@focus4/core`, mais il est possible de la surcharger avec le paramètre `fetchPath`.
 
 Exemple :
 
 ```yaml
 fetchPath: "@api-services"
 ```
+
+Les APIs générées correspondant au format de Focus pré-12.7.
 
 ### Chemins de configuration
 
@@ -239,12 +251,12 @@ export const securite = {
   profil: {
     id: "Identifiant",
     typeProfilCode: "Type de profil",
-    droits: "Droits"
+    droits: "Droits",
   },
   profilDto: {
     utilisateurs: "Utilisateurs",
-    secteurs: "Secteurs"
-  }
+    secteurs: "Secteurs",
+  },
 };
 ```
 
@@ -304,8 +316,8 @@ export const securiteComments = {
   profil: {
     id: "Identifiant unique du profil",
     typeProfilCode: "Code du type de profil",
-    droits: "Liste des droits associés au profil"
-  }
+    droits: "Liste des droits associés au profil",
+  },
 };
 ```
 
@@ -395,10 +407,11 @@ Le module JavaScript génère plusieurs types de fichiers :
 
 1. **TypescriptDefinitionGenerator** (`JSDefinitionGen`) : Génère les définitions TypeScript des classes (DTOs et entités)
 2. **TypescriptReferenceGenerator** (`JSReferenceGen`) : Génère les définitions des listes de références
-3. **JavascriptApiClientGenerator** (`JSApiClientGen`) : Génère les clients API en mode vanilla
+3. **JavascriptApiClientGenerator** (`JSApiClientGen`) : Génère les clients API en mode fetch
 4. **AngularApiClientGenerator** (`JSNGApiClientGen`) : Génère les services Angular pour les clients API
 5. **NuxtApiClientGenerator** (`JSApiClientGen`) : Génère les fonctions API pour Nuxt
-6. **JavascriptResourceGenerator** (`JSResourceGen`) : Génère les fichiers de ressources (traductions)
+6. **LegacyApiClientGenerator** (`JSLApiClientGen`) : Génère les clients API en mode legacy (ancienne API Focus)
+7. **JavascriptResourceGenerator** (`JSResourceGen`) : Génère les fichiers de ressources (traductions)
 
 Vous pouvez désactiver certains générateurs avec la propriété `disable` :
 

--- a/samples/model/topmodel.config.schema.json
+++ b/samples/model/topmodel.config.schema.json
@@ -541,10 +541,11 @@
             "description": "Framework cible pour la génération.",
             "default": "focus",
             "enum": [
+              "fetch",
               "angular",
               "angular_promise",
-              "vanilla",
-              "nuxt"
+              "nuxt",
+              "legacy"
             ]
           },
           "entityMode": {

--- a/samples/model/topmodel.lock
+++ b/samples/model/topmodel.lock
@@ -5,7 +5,7 @@
 version: 3.7.0
 custom:
   ../../TopModel.Generator.Csharp: 542ae3035b9db87e9b8ee1580c93c26c
-  ../../TopModel.Generator.Javascript: de4c28a0bddf1920b0440fc31181a223
+  ../../TopModel.Generator.Javascript: e8b107f9bdb9487b1fe1f70b5aa910a6
   ../../TopModel.Generator.Jpa: 1dc5386932e817cf9ece136495d8aa23
   ../../TopModel.Generator.Sql: 4996bdc4802663b93a1a69de9413a382
   ../../TopModel.Generator.Translation: 42f228bfbbe42e2db8a3adf7f52a8d62

--- a/samples/output/focus/src/services/securite/profil/profil.ts
+++ b/samples/output/focus/src/services/securite/profil/profil.ts
@@ -2,8 +2,6 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {coreFetch} from "@focus4/core";
-
 import {ProfilItem} from "../../../model/securite/profil/profil-item";
 import {ProfilRead} from "../../../model/securite/profil/profil-read";
 import {ProfilWrite} from "../../../model/securite/profil/profil-write";
@@ -14,8 +12,14 @@ import {ProfilWrite} from "../../../model/securite/profil/profil-write";
  * @param options Options pour 'fetch'.
  * @returns Profil sauvegardé
  */
-export function addProfil(profil: ProfilWrite, options: RequestInit = {}): Promise<ProfilRead> {
-    return coreFetch("POST", `./api/profils`, {body: profil}, options);
+export async function addProfil(profil: ProfilWrite, options: RequestInit = {}): Promise<ProfilRead> {
+    const response = await fetch(`./api/profils`, {
+        ...options,
+        method: "POST",
+        body: JSON.stringify(profil),
+        headers: {...options.headers, "Content-Type": "application/json"}
+    });
+    return await response.json();
 }
 
 /**
@@ -24,8 +28,12 @@ export function addProfil(profil: ProfilWrite, options: RequestInit = {}): Promi
  * @param options Options pour 'fetch'.
  * @returns Le détail du profil
  */
-export function getProfil(proId: number, options: RequestInit = {}): Promise<ProfilRead> {
-    return coreFetch("GET", `./api/profils/${proId}`, {}, options);
+export async function getProfil(proId: number, options: RequestInit = {}): Promise<ProfilRead> {
+    const response = await fetch(`./api/profils/${proId}`, {
+        ...options,
+        method: "GET"
+    });
+    return await response.json();
 }
 
 /**
@@ -33,8 +41,12 @@ export function getProfil(proId: number, options: RequestInit = {}): Promise<Pro
  * @param options Options pour 'fetch'.
  * @returns Profils matchant les critères
  */
-export function getProfils(options: RequestInit = {}): Promise<ProfilItem[]> {
-    return coreFetch("GET", `./api/profils`, {}, options);
+export async function getProfils(options: RequestInit = {}): Promise<ProfilItem[]> {
+    const response = await fetch(`./api/profils`, {
+        ...options,
+        method: "GET"
+    });
+    return await response.json();
 }
 
 /**
@@ -44,6 +56,12 @@ export function getProfils(options: RequestInit = {}): Promise<ProfilItem[]> {
  * @param options Options pour 'fetch'.
  * @returns Profil sauvegardé
  */
-export function updateProfil(proId: number, profil: ProfilWrite, options: RequestInit = {}): Promise<ProfilRead> {
-    return coreFetch("PUT", `./api/profils/${proId}`, {body: profil}, options);
+export async function updateProfil(proId: number, profil: ProfilWrite, options: RequestInit = {}): Promise<ProfilRead> {
+    const response = await fetch(`./api/profils/${proId}`, {
+        ...options,
+        method: "PUT",
+        body: JSON.stringify(profil),
+        headers: {...options.headers, "Content-Type": "application/json"}
+    });
+    return await response.json();
 }

--- a/samples/output/focus/src/services/securite/utilisateur/utilisateur.ts
+++ b/samples/output/focus/src/services/securite/utilisateur/utilisateur.ts
@@ -2,8 +2,6 @@
 //// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
 ////
 
-import {coreFetch} from "@focus4/core";
-
 import {TypeUtilisateurCode} from "../../../model/securite/utilisateur/references";
 import {UtilisateurItem} from "../../../model/securite/utilisateur/utilisateur-item";
 import {UtilisateurRead} from "../../../model/securite/utilisateur/utilisateur-read";
@@ -15,8 +13,14 @@ import {UtilisateurWrite} from "../../../model/securite/utilisateur/utilisateur-
  * @param options Options pour 'fetch'.
  * @returns Utilisateur sauvegardé
  */
-export function addUtilisateur(utilisateur: UtilisateurWrite, options: RequestInit = {}): Promise<UtilisateurRead> {
-    return coreFetch("POST", `./api/utilisateurs`, {body: utilisateur}, options);
+export async function addUtilisateur(utilisateur: UtilisateurWrite, options: RequestInit = {}): Promise<UtilisateurRead> {
+    const response = await fetch(`./api/utilisateurs`, {
+        ...options,
+        method: "POST",
+        body: JSON.stringify(utilisateur),
+        headers: {...options.headers, "Content-Type": "application/json"}
+    });
+    return await response.json();
 }
 
 /**
@@ -24,8 +28,11 @@ export function addUtilisateur(utilisateur: UtilisateurWrite, options: RequestIn
  * @param utiId Id de l'utilisateur
  * @param options Options pour 'fetch'.
  */
-export function deleteUtilisateur(utiId: number, options: RequestInit = {}): Promise<void> {
-    return coreFetch("DELETE", `./api/utilisateurs/${utiId}`, {}, options);
+export async function deleteUtilisateur(utiId: number, options: RequestInit = {}): Promise<void> {
+    await fetch(`./api/utilisateurs/${utiId}`, {
+        ...options,
+        method: "DELETE"
+    });
 }
 
 /**
@@ -34,8 +41,12 @@ export function deleteUtilisateur(utiId: number, options: RequestInit = {}): Pro
  * @param options Options pour 'fetch'.
  * @returns Fichier de la photo
  */
-export function downloadPicture(utiId: number, options: RequestInit = {}): Promise<Blob> {
-    return coreFetch("GET", `./api/utilisateurs/${utiId}/picture`, {}, options);
+export async function downloadPicture(utiId: number, options: RequestInit = {}): Promise<Blob> {
+    const response = await fetch(`./api/utilisateurs/${utiId}/picture`, {
+        ...options,
+        method: "GET"
+    });
+    return await response.blob();
 }
 
 /**
@@ -44,8 +55,12 @@ export function downloadPicture(utiId: number, options: RequestInit = {}): Promi
  * @param options Options pour 'fetch'.
  * @returns Le détail de l'utilisateur
  */
-export function getUtilisateur(utiId: number, options: RequestInit = {}): Promise<UtilisateurRead> {
-    return coreFetch("GET", `./api/utilisateurs/${utiId}`, {}, options);
+export async function getUtilisateur(utiId: number, options: RequestInit = {}): Promise<UtilisateurRead> {
+    const response = await fetch(`./api/utilisateurs/${utiId}`, {
+        ...options,
+        method: "GET"
+    });
+    return await response.json();
 }
 
 /**
@@ -61,8 +76,37 @@ export function getUtilisateur(utiId: number, options: RequestInit = {}): Promis
  * @param options Options pour 'fetch'.
  * @returns Utilisateurs matchant les critères
  */
-export function searchUtilisateur(nom?: string, prenom?: string, email?: string, dateNaissance?: string, adresse?: string, actif?: boolean, profilId?: number, typeUtilisateurCode?: TypeUtilisateurCode, options: RequestInit = {}): Promise<UtilisateurItem[]> {
-    return coreFetch("GET", `./api/utilisateurs`, {query: {nom, prenom, email, dateNaissance, adresse, actif, profilId, typeUtilisateurCode}}, options);
+export async function searchUtilisateur(nom?: string, prenom?: string, email?: string, dateNaissance?: string, adresse?: string, actif?: boolean, profilId?: number, typeUtilisateurCode?: TypeUtilisateurCode, options: RequestInit = {}): Promise<UtilisateurItem[]> {
+    const query = new URLSearchParams();
+    if (nom !== undefined) {
+        query.append("nom", nom)
+    }
+    if (prenom !== undefined) {
+        query.append("prenom", prenom)
+    }
+    if (email !== undefined) {
+        query.append("email", email)
+    }
+    if (dateNaissance !== undefined) {
+        query.append("dateNaissance", dateNaissance)
+    }
+    if (adresse !== undefined) {
+        query.append("adresse", adresse)
+    }
+    if (actif !== undefined) {
+        query.append("actif", `${actif}`)
+    }
+    if (profilId !== undefined) {
+        query.append("profilId", `${profilId}`)
+    }
+    if (typeUtilisateurCode !== undefined) {
+        query.append("typeUtilisateurCode", typeUtilisateurCode)
+    }
+    const response = await fetch(`./api/utilisateurs?${query}`, {
+        ...options,
+        method: "GET"
+    });
+    return await response.json();
 }
 
 /**
@@ -72,8 +116,14 @@ export function searchUtilisateur(nom?: string, prenom?: string, email?: string,
  * @param options Options pour 'fetch'.
  * @returns Utilisateur sauvegardé
  */
-export function updateUtilisateur(utiId: number, utilisateur: UtilisateurWrite, options: RequestInit = {}): Promise<UtilisateurRead> {
-    return coreFetch("PUT", `./api/utilisateurs/${utiId}`, {body: utilisateur}, options);
+export async function updateUtilisateur(utiId: number, utilisateur: UtilisateurWrite, options: RequestInit = {}): Promise<UtilisateurRead> {
+    const response = await fetch(`./api/utilisateurs/${utiId}`, {
+        ...options,
+        method: "PUT",
+        body: JSON.stringify(utilisateur),
+        headers: {...options.headers, "Content-Type": "application/json"}
+    });
+    return await response.json();
 }
 
 /**
@@ -82,7 +132,7 @@ export function updateUtilisateur(utiId: number, utilisateur: UtilisateurWrite, 
  * @param file Fichier de la photo
  * @param options Options pour 'fetch'.
  */
-export function uploadPicture(utiId: number, file: File, options: RequestInit = {}): Promise<void> {
+export async function uploadPicture(utiId: number, file: File, options: RequestInit = {}): Promise<void> {
     const body = new FormData();
     fillFormData(
         {
@@ -90,7 +140,11 @@ export function uploadPicture(utiId: number, file: File, options: RequestInit = 
         },
         body
     );
-    return coreFetch("POST", `./api/utilisateurs/${utiId}/picture`, {body}, options);
+    await fetch(`./api/utilisateurs/${utiId}/picture`, {
+        ...options,
+        method: "POST",
+        body
+    });
 }
 
 function fillFormData(data: any, formData: FormData, prefix = "") {


### PR DESCRIPTION
Fix #517 

Cette PR ajoute un nouveau mode de génération pour les clients APIs, **renseigné par défaut**, `fetch`, qui génère des appels d'API en utilisant uniquement les APIs natives du navigateur.

Dans l'idée, il faut toujours surcharger le fetch par une implémentation compatible pour gérer l'authent et les erreurs, sinon c'est un peu limite 😅 A priori le choix recommandé se porterait vers [Ky](https://github.com/sindresorhus/ky) qui permet de faire exactement ça.

L'ancien mode de génération est conservé à l'identique dans le mode `legacy`. Le breaking change de cette version, pour ceux qui ne feront pas la mise à jour dans leur application pour changer leur implémentation de fetch (ce qui nécessitera une montée de version Focus pour les gens concernés), sera donc simplement contourné en mettant `apiMode: legacy` dans la config.