### PR TITLE
[LS] Déporter la gestion des workspaces multi-config sur le LSP

### DIFF
--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -141,6 +141,7 @@ public class ModelFileLoader(
             if (fw.Configs.Count == 0)
             {
                 fw.FileWatcher.Dispose();
+                FileWatchers.Remove(config.ModelRoot);
             }
         };
     }

--- a/TopModel.Generator.Jpa/JavaLanguage/JavaEnum.cs
+++ b/TopModel.Generator.Jpa/JavaLanguage/JavaEnum.cs
@@ -1,4 +1,4 @@
-using NuGet.Packaging;
+using TopModel.Utils;
 
 namespace TopModel.Generator.Jpa;
 

--- a/TopModel.Generator/AssembliesUtils.cs
+++ b/TopModel.Generator/AssembliesUtils.cs
@@ -1,0 +1,34 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace TopModel.Generator;
+
+public static class AssembliesUtils
+{
+    private static readonly Dictionary<string, Assembly> loadedAssemblies = AppDomain
+        .CurrentDomain.GetAssemblies()
+        .ToDictionary(a => a.ManifestModule.Name);
+    public static ISet<string> LoadedAssemblies => loadedAssemblies.Keys.ToImmutableHashSet();
+
+    public static IEnumerable<Assembly> LoadAssemblies(IEnumerable<FileInfo> fileInfos)
+    {
+        var assembliesToLoad = fileInfos.Where(f => !f.Name.EndsWith(".resources.dll")).DistinctBy(a => a.Name);
+
+        foreach (var assembly in assembliesToLoad)
+        {
+            if (LoadedAssemblies.Contains(assembly.Name))
+            {
+                yield return loadedAssemblies[assembly.Name];
+                continue;
+            }
+            yield return LoadAssemblyFromFileInfo(assembly);
+        }
+    }
+
+    private static Assembly LoadAssemblyFromFileInfo(FileInfo fileInfo)
+    {
+        var assemblyLoaded = Assembly.LoadFrom(fileInfo.FullName);
+        loadedAssemblies.Add(assemblyLoaded.ManifestModule.Name, assemblyLoaded);
+        return assemblyLoaded;
+    }
+}

--- a/TopModel.Generator/ConfigObserver.cs
+++ b/TopModel.Generator/ConfigObserver.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using Spectre.Console;
+using TopModel.Core;
+using TopModel.Core.Loaders;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class ConfigObserver(
+    FileInfo configInfo,
+    FileChecker fileChecker,
+    int configIndex,
+    Func<ModelConfig, FileInfo, int, TopModelWorker> createWorker
+) : IDisposable
+{
+    private readonly MemoryCache fsCache = new(new MemoryCacheOptions());
+    private FileSystemWatcher? ConfigWatcher;
+    private TopModelWorker? Worker;
+
+    public bool HasError => Worker?.HasError ?? true;
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose()
+    {
+        Worker?.Dispose();
+        ConfigWatcher?.Dispose();
+        fsCache.Dispose();
+    }
+
+    public async Task Start(CancellationToken cancellationToken)
+    {
+        LogConfigFound();
+        StartWatchConfig(cancellationToken);
+        await Run(cancellationToken);
+    }
+
+    private void LogConfigFound()
+    {
+        var color = LogUtils.Colors[configIndex % LogUtils.Colors.Length];
+        AnsiConsole.MarkupLine(
+            $"[{color}]#{configIndex + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), configInfo.FullName)}[/]"
+        );
+    }
+
+    private async Task ReadConfig(CancellationToken cancellationToken)
+    {
+        try
+        {
+            fileChecker.CheckConfigFile(configInfo.FullName);
+            using var text = configInfo.OpenText();
+            var config = fileChecker
+                .DeserializeConfig(await text.ReadToEndAsync(cancellationToken))
+                .Init(configInfo.DirectoryName!);
+            Worker = createWorker(config, configInfo, configIndex);
+        }
+        catch (ModelException me)
+        {
+            AnsiConsole.WriteLine($"[red]{me.Message}[/]");
+        }
+    }
+
+    private async Task Restart(CancellationToken cancellationToken)
+    {
+        Worker?.Dispose();
+        Worker = null;
+        await Run(cancellationToken);
+    }
+
+    private async Task Run(CancellationToken cancellationToken)
+    {
+        await ReadConfig(cancellationToken);
+        if (Worker != null)
+        {
+            await Worker.Run(cancellationToken);
+        }
+    }
+
+    private void StartWatchConfig(CancellationToken cancellationToken)
+    {
+        var fsWatcher = new FileSystemWatcher(configInfo.DirectoryName!, configInfo.Name);
+        fsWatcher.Changed += (sender, args) =>
+        {
+            fsCache.Set(
+                args.FullPath,
+                args,
+                new MemoryCacheEntryOptions()
+                    .AddExpirationToken(
+                        new CancellationChangeToken(new CancellationTokenSource(TimeSpan.FromMilliseconds(500)).Token)
+                    )
+                    .RegisterPostEvictionCallback(
+                        async (k, v, r, a) =>
+                        {
+                            if (r != EvictionReason.TokenExpired)
+                            {
+                                return;
+                            }
+
+                            await Restart(cancellationToken);
+                        }
+                    )
+            );
+        };
+        fsWatcher.IncludeSubdirectories = true;
+        fsWatcher.EnableRaisingEvents = true;
+        ConfigWatcher = fsWatcher;
+    }
+}

--- a/TopModel.Generator/CustomModule.cs
+++ b/TopModel.Generator/CustomModule.cs
@@ -1,0 +1,235 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using TopModel.Core;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class CustomModule(
+    string customGenerator,
+    string fullName,
+    string modgenRoot,
+    Microsoft.Extensions.Logging.ILogger logger,
+    TopModelLock topModelLock
+)
+{
+    public bool HasError { get; private set; } = false;
+
+    public static string GetHashFilePath(string modgenRoot, string customGenerator)
+    {
+        return Path.Combine(modgenRoot, customGenerator.Replace('/', '-').Replace('\\', '-'));
+    }
+
+    public async Task BuildAsync(CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(modgenRoot);
+
+        var customDir = Path.GetFullPath(
+            Path.Combine(new FileInfo(Path.GetFullPath(fullName)).DirectoryName!, customGenerator)
+        );
+
+        var customHash =
+            ModuleUtils.GetHash(
+                Directory
+                    .EnumerateFiles(
+                        Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!),
+                        "*.cs",
+                        SearchOption.AllDirectories
+                    )
+                    .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")),
+                customDir
+            ) ?? string.Empty;
+
+        var customHashLocalFile = GetHashFilePath(modgenRoot, customGenerator);
+        var customHashLocal = File.Exists(customHashLocalFile)
+            ? await File.ReadAllTextAsync(customHashLocalFile, cancellationToken)
+            : string.Empty;
+
+        if (
+            !topModelLock.Custom.TryGetValue(customGenerator, out var customLockHash)
+            || customHash != customLockHash
+            || customHash != customHashLocal
+        )
+        {
+            var expectedDll = $"{customGenerator.Replace('\\', '/').Split('/')[^1].ToLower()}.dll";
+            if (!AssembliesUtils.LoadedAssemblies.Contains(expectedDll, StringComparer.CurrentCultureIgnoreCase))
+            {
+                await BuildCSharpProject(customDir, cancellationToken);
+                if (HasError)
+                {
+                    return;
+                }
+
+                logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildCompleted, customGenerator));
+            }
+
+            topModelLock.Custom ??= new Dictionary<string, string>();
+            topModelLock.Custom[customGenerator] = customHash;
+            await File.WriteAllTextAsync(customHashLocalFile, topModelLock.Custom[customGenerator], cancellationToken);
+        }
+    }
+
+    public void Check(TopModelLock topModelLock, Microsoft.Extensions.Logging.ILogger logger)
+    {
+        var projDir = Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!);
+        if (!Directory.EnumerateFiles(projDir, "*.csproj").Any())
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoCsprojFound, customGenerator));
+            HasError = true;
+            return;
+        }
+
+        var assetsPath = Path.Combine(projDir, "obj", "project.assets.json");
+        if (!File.Exists(assetsPath))
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.GeneratorModuleNotBuilt, customGenerator));
+            HasError = true;
+            return;
+        }
+
+        var lockFile = LockFileUtilities.GetLockFile(assetsPath, NullLogger.Instance);
+
+        foreach (
+            var dep in lockFile
+                .Targets.FirstOrDefault(dg => dg.TargetFramework.Version.Major <= VersionUtils.DotnetMajor)
+                ?.Libraries.Where(n => n.Name?.StartsWith("TopModel.Generator") ?? false)
+            ?? []
+        )
+        {
+            if (dep.Name == "TopModel.Generator.Core")
+            {
+                if (dep.Version?.Major != VersionUtils.MajorVersion)
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleBadMajorVersion,
+                            customGenerator,
+                            dep.Version?.ToString() ?? string.Empty,
+                            VersionUtils.Version
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+                else if (dep.Version?.Minor > VersionUtils.MinorVersion)
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleNewerVersion,
+                            customGenerator,
+                            dep.Version?.ToString() ?? string.Empty,
+                            VersionUtils.Version
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+            }
+            else
+            {
+                var configKey = dep.Name?.Split('.')[^1].ToLower() ?? string.Empty;
+                if (!topModelLock.Modules.TryGetValue(configKey, out var ev))
+                {
+                    topModelLock.Modules.Add(configKey, new() { Version = dep.Version?.ToString() ?? string.Empty });
+                }
+                else if (ev.Version != dep.Version?.ToString())
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.CustomModuleWrongLockfileVersion,
+                            customGenerator,
+                            configKey,
+                            dep.Version?.ToString() ?? string.Empty,
+                            ev
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    public void LoadAssemblies(string fullName, IList<Type> generators)
+    {
+        Check(topModelLock, logger);
+        if (HasError)
+        {
+            return;
+        }
+
+        var files = new DirectoryInfo(
+            Path.Combine(Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!), "bin")
+        ).GetFiles($"*.dll", SearchOption.AllDirectories);
+        var assemblies = AssembliesUtils.LoadAssemblies(files);
+        if (HasError)
+        {
+            return;
+        }
+
+        var assemblyModule = assemblies.Where(a =>
+            a.ManifestModule.Name.Equals(
+                $"{customGenerator
+                .Replace('\\', '/')
+                .Split('/')[^1].ToLower()}.dll",
+                StringComparison.CurrentCultureIgnoreCase
+            )
+        );
+        var moduleExportedTypes = assemblyModule.SelectMany(a => a.GetExportedTypes());
+        var generatorTypes = moduleExportedTypes.Where(t => ModuleUtils.GetIGenRegInterface(t) != null);
+        generators.AddRange(generatorTypes);
+        return;
+    }
+
+    private async Task BuildCSharpProject(string customDir, CancellationToken cancellationToken)
+    {
+        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildInProgress, customGenerator));
+        var build = Process.Start(
+            new ProcessStartInfo
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                FileName = "dotnet",
+                Arguments = "build -v q",
+                WorkingDirectory = customDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            }
+        );
+        string stdout;
+        try
+        {
+            await using var registration = cancellationToken.Register(() => build?.Kill());
+            var stdoutTask = build!.StandardOutput.ReadToEndAsync(cancellationToken);
+            await build!.WaitForExitAsync(cancellationToken);
+            stdout = await stdoutTask;
+        }
+        catch (OperationCanceledException)
+        {
+            HasError = true;
+            return;
+        }
+
+        if (build.ExitCode != 0)
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.BuildError, customGenerator));
+            var output = stdout.Trim();
+            if (!string.IsNullOrEmpty(output))
+            {
+                logger.LogError(output);
+            }
+            HasError = true;
+            return;
+        }
+    }
+}

--- a/TopModel.Generator/GeneratorMessage.cs
+++ b/TopModel.Generator/GeneratorMessage.cs
@@ -26,4 +26,7 @@ public enum GeneratorMessage
     ConfigSchemaGenerated,
     ConfigNameAlreadyInUse,
     ReferencedConfigNotFound,
+    ExcludeOptionDescription,
+    UpdateOptionDescription,
+    SchemaOptionDescription,
 }

--- a/TopModel.Generator/GeneratorMessage.cs
+++ b/TopModel.Generator/GeneratorMessage.cs
@@ -1,0 +1,29 @@
+namespace TopModel.Generator;
+
+public enum GeneratorMessage
+{
+    ExcludedTags,
+    UpdateModeEnabled,
+    BuildInProgress,
+    BuildError,
+    BuildCompleted,
+    NoCsprojFound,
+    GeneratorModuleNotBuilt,
+    GeneratorModuleBadMajorVersion,
+    GeneratorModuleNewerVersion,
+    CustomModuleWrongLockfileVersion,
+    NoGeneratorModuleFound,
+    ModuleCorrupted,
+    ModuleInstallInProgress,
+    PackageNotFound,
+    ModuleInstallCompleted,
+    ModuleBadMajorVersion,
+    ModuleNewerVersion,
+    GeneratorsInUse,
+    GeneratorUpdatesAvailable,
+    ModgenUpdateCommand,
+    GeneratingConfigSchema,
+    ConfigSchemaGenerated,
+    ConfigNameAlreadyInUse,
+    ReferencedConfigNotFound,
+}

--- a/TopModel.Generator/GeneratorMessage.fr.resx
+++ b/TopModel.Generator/GeneratorMessage.fr.resx
@@ -110,4 +110,13 @@
   <data name="ReferencedConfigNotFound" xml:space="preserve">
     <value>La configuration '{0}' n'existe pas, le tag référencé '{1}' pour la config '{2}' sera ignoré.</value>
   </data>
+  <data name="ExcludeOptionDescription" xml:space="preserve">
+    <value>Tag à ignorer lors de la génération.</value>
+  </data>
+  <data name="UpdateOptionDescription" xml:space="preserve">
+    <value>Met à jour le module de générateurs spécifié (ou tous les modules si 'all').</value>
+  </data>
+  <data name="SchemaOptionDescription" xml:space="preserve">
+    <value>Génère le fichier de schéma JSON du fichier de config.</value>
+  </data>
 </root>

--- a/TopModel.Generator/GeneratorMessage.fr.resx
+++ b/TopModel.Generator/GeneratorMessage.fr.resx
@@ -72,16 +72,16 @@
     <value>Aucun module de générateurs trouvé pour '{0}'.</value>
   </data>
   <data name="ModuleCorrupted" xml:space="preserve">
-    <value>({0}) Module corrompu, réinstallation...</value>
+    <value>Module {0} corrompu, suppression...</value>
   </data>
   <data name="ModuleInstallInProgress" xml:space="preserve">
-    <value>({0}) Installation de {1}@{2} en cours...</value>
+    <value>Installation de {0}@{1} en cours...</value>
   </data>
   <data name="PackageNotFound" xml:space="preserve">
-    <value>({0}) Le package {1}@{2} est introuvable.</value>
+    <value>Le package {0}@{1} est introuvable.</value>
   </data>
   <data name="ModuleInstallCompleted" xml:space="preserve">
-    <value>({0}) Installation de {1}@{2} terminée avec succès.</value>
+    <value>Installation de {0}@{1} terminée.</value>
   </data>
   <data name="ModuleBadMajorVersion" xml:space="preserve">
     <value>Le module '{0}' ne référence pas la bonne version majeure de TopModel ({1} &lt; {2}).</value>

--- a/TopModel.Generator/GeneratorMessage.fr.resx
+++ b/TopModel.Generator/GeneratorMessage.fr.resx
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExcludedTags" xml:space="preserve">
+    <value>Tags [teal]exclus[/] de la génération : {0}.</value>
+  </data>
+  <data name="UpdateModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]update[/] activé pour : [gray]{0}[/].</value>
+  </data>
+  <data name="BuildInProgress" xml:space="preserve">
+    <value>Build de '{0}' en cours...</value>
+  </data>
+  <data name="BuildError" xml:space="preserve">
+    <value>Erreur lors du build de '{0}'</value>
+  </data>
+  <data name="BuildCompleted" xml:space="preserve">
+    <value>Build de '{0}' terminé.</value>
+  </data>
+  <data name="NoCsprojFound" xml:space="preserve">
+    <value>Aucun fichier csproj trouvé pour le module de générateurs '{0}'.</value>
+  </data>
+  <data name="GeneratorModuleNotBuilt" xml:space="preserve">
+    <value>Le module de générateurs '{0}' n'a pas été buildé correctement...</value>
+  </data>
+  <data name="GeneratorModuleBadMajorVersion" xml:space="preserve">
+    <value>Le module de générateurs '{0}' ne référence pas la bonne version majeure de TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="GeneratorModuleNewerVersion" xml:space="preserve">
+    <value>Le module de générateurs '{0}' référence une version plus récente de TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="CustomModuleWrongLockfileVersion" xml:space="preserve">
+    <value>Le module personalisé '{0}' référence le module '{1}' en version '{2}', ce qui n'est pas la version du lockfile ('{3}').</value>
+  </data>
+  <data name="NoGeneratorModuleFound" xml:space="preserve">
+    <value>Aucun module de générateurs trouvé pour '{0}'.</value>
+  </data>
+  <data name="ModuleCorrupted" xml:space="preserve">
+    <value>({0}) Module corrompu, réinstallation...</value>
+  </data>
+  <data name="ModuleInstallInProgress" xml:space="preserve">
+    <value>({0}) Installation de {1}@{2} en cours...</value>
+  </data>
+  <data name="PackageNotFound" xml:space="preserve">
+    <value>({0}) Le package {1}@{2} est introuvable.</value>
+  </data>
+  <data name="ModuleInstallCompleted" xml:space="preserve">
+    <value>({0}) Installation de {1}@{2} terminée avec succès.</value>
+  </data>
+  <data name="ModuleBadMajorVersion" xml:space="preserve">
+    <value>Le module '{0}' ne référence pas la bonne version majeure de TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="ModuleNewerVersion" xml:space="preserve">
+    <value>Le module '{0}' référence une version plus récente de TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="GeneratorsInUse" xml:space="preserve">
+    <value>Générateurs utilisés :{0}</value>
+  </data>
+  <data name="GeneratorUpdatesAvailable" xml:space="preserve">
+    <value>Il existe une mise à jour pour les générateurs suivants :{0}</value>
+  </data>
+  <data name="ModgenUpdateCommand" xml:space="preserve">
+    <value>Vous pouvez lancer la commande `modgen --update {0}` pour effectuer la mise à jour.</value>
+  </data>
+  <data name="GeneratingConfigSchema" xml:space="preserve">
+    <value>Génération du schéma de configuration...</value>
+  </data>
+  <data name="ConfigSchemaGenerated" xml:space="preserve">
+    <value>Schéma de configuration généré avec succès.</value>
+  </data>
+  <data name="ConfigNameAlreadyInUse" xml:space="preserve">
+    <value>Le nom de configuration '{0}' est déjà utilisé.</value>
+  </data>
+  <data name="ReferencedConfigNotFound" xml:space="preserve">
+    <value>La configuration '{0}' n'existe pas, le tag référencé '{1}' pour la config '{2}' sera ignoré.</value>
+  </data>
+</root>

--- a/TopModel.Generator/GeneratorMessage.resx
+++ b/TopModel.Generator/GeneratorMessage.resx
@@ -72,16 +72,16 @@
     <value>No generator module found for '{0}'.</value>
   </data>
   <data name="ModuleCorrupted" xml:space="preserve">
-    <value>({0}) Module corrupted, reinstalling...</value>
+    <value>Module {0} corrupted, deleting...</value>
   </data>
   <data name="ModuleInstallInProgress" xml:space="preserve">
-    <value>({0}) Installing {1}@{2}...</value>
+    <value>Installing {0}@{1}...</value>
   </data>
   <data name="PackageNotFound" xml:space="preserve">
-    <value>({0}) Package {1}@{2} not found.</value>
+    <value>Package {0}@{1} not found.</value>
   </data>
   <data name="ModuleInstallCompleted" xml:space="preserve">
-    <value>({0}) Installation of {1}@{2} completed successfully.</value>
+    <value>Installation of {0}@{1} completed successfully.</value>
   </data>
   <data name="ModuleBadMajorVersion" xml:space="preserve">
     <value>Module '{0}' does not reference the correct major version of TopModel ({1} &lt; {2}).</value>

--- a/TopModel.Generator/GeneratorMessage.resx
+++ b/TopModel.Generator/GeneratorMessage.resx
@@ -110,4 +110,13 @@
   <data name="ReferencedConfigNotFound" xml:space="preserve">
     <value>Configuration '{0}' does not exist, referenced tag '{1}' for config '{2}' will be ignored.</value>
   </data>
+  <data name="ExcludeOptionDescription" xml:space="preserve">
+    <value>Tag to ignore during generation.</value>
+  </data>
+  <data name="UpdateOptionDescription" xml:space="preserve">
+    <value>Updates the specified generator module (or all modules if 'all').</value>
+  </data>
+  <data name="SchemaOptionDescription" xml:space="preserve">
+    <value>Generates the JSON schema file for the config file.</value>
+  </data>
 </root>

--- a/TopModel.Generator/GeneratorMessage.resx
+++ b/TopModel.Generator/GeneratorMessage.resx
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExcludedTags" xml:space="preserve">
+    <value>Generation [teal]excluded[/] tags: {0}.</value>
+  </data>
+  <data name="UpdateModeEnabled" xml:space="preserve">
+    <value>[darkcyan]update[/] mode enabled for: [gray]{0}[/].</value>
+  </data>
+  <data name="BuildInProgress" xml:space="preserve">
+    <value>Building '{0}'...</value>
+  </data>
+  <data name="BuildError" xml:space="preserve">
+    <value>Error building '{0}'</value>
+  </data>
+  <data name="BuildCompleted" xml:space="preserve">
+    <value>Build of '{0}' completed.</value>
+  </data>
+  <data name="NoCsprojFound" xml:space="preserve">
+    <value>No csproj file found for generator module '{0}'.</value>
+  </data>
+  <data name="GeneratorModuleNotBuilt" xml:space="preserve">
+    <value>Generator module '{0}' was not built correctly...</value>
+  </data>
+  <data name="GeneratorModuleBadMajorVersion" xml:space="preserve">
+    <value>Generator module '{0}' does not reference the correct major version of TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="GeneratorModuleNewerVersion" xml:space="preserve">
+    <value>Generator module '{0}' references a newer version of TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="CustomModuleWrongLockfileVersion" xml:space="preserve">
+    <value>Custom module '{0}' references module '{1}' in version '{2}', which does not match the lockfile version ('{3}').</value>
+  </data>
+  <data name="NoGeneratorModuleFound" xml:space="preserve">
+    <value>No generator module found for '{0}'.</value>
+  </data>
+  <data name="ModuleCorrupted" xml:space="preserve">
+    <value>({0}) Module corrupted, reinstalling...</value>
+  </data>
+  <data name="ModuleInstallInProgress" xml:space="preserve">
+    <value>({0}) Installing {1}@{2}...</value>
+  </data>
+  <data name="PackageNotFound" xml:space="preserve">
+    <value>({0}) Package {1}@{2} not found.</value>
+  </data>
+  <data name="ModuleInstallCompleted" xml:space="preserve">
+    <value>({0}) Installation of {1}@{2} completed successfully.</value>
+  </data>
+  <data name="ModuleBadMajorVersion" xml:space="preserve">
+    <value>Module '{0}' does not reference the correct major version of TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="ModuleNewerVersion" xml:space="preserve">
+    <value>Module '{0}' references a newer version of TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="GeneratorsInUse" xml:space="preserve">
+    <value>Generators in use:{0}</value>
+  </data>
+  <data name="GeneratorUpdatesAvailable" xml:space="preserve">
+    <value>Updates available for the following generators:{0}</value>
+  </data>
+  <data name="ModgenUpdateCommand" xml:space="preserve">
+    <value>You can run `modgen --update {0}` to update.</value>
+  </data>
+  <data name="GeneratingConfigSchema" xml:space="preserve">
+    <value>Generating configuration schema...</value>
+  </data>
+  <data name="ConfigSchemaGenerated" xml:space="preserve">
+    <value>Configuration schema generated successfully.</value>
+  </data>
+  <data name="ConfigNameAlreadyInUse" xml:space="preserve">
+    <value>Configuration name '{0}' is already in use.</value>
+  </data>
+  <data name="ReferencedConfigNotFound" xml:space="preserve">
+    <value>Configuration '{0}' does not exist, referenced tag '{1}' for config '{2}' will be ignored.</value>
+  </data>
+</root>

--- a/TopModel.Generator/ModuleUtils.cs
+++ b/TopModel.Generator/ModuleUtils.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using TopModel.Generator.Core;
+
+namespace TopModel.Generator;
+
+public static class ModuleUtils
+{
+    public static string? GetFolderHash(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return null;
+        }
+
+        return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
+    }
+
+    public static string? GetHash(IEnumerable<string> f, string path)
+    {
+        var md5 = MD5.Create();
+        var files = f.Order().ToList();
+        foreach (var file in files)
+        {
+            var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
+            var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
+            md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
+
+            var contentBytes = File.ReadAllBytes(file);
+            if (files.IndexOf(file) == files.Count - 1)
+            {
+                md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
+            }
+            else
+            {
+                md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
+            }
+        }
+
+        return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
+    }
+
+    public static Type? GetIGenRegInterface(Type t)
+    {
+        return t.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IGeneratorRegistration<>));
+    }
+
+    public static (Type Type, string Name) GetIGenRegInterfaceAndName(Type generator)
+    {
+        var configType = GetIGenRegInterface(generator)!.GetGenericArguments()[0];
+        var configName = configType.Name.Replace("Config", string.Empty).ToLower();
+        return (configType, configName);
+    }
+}

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -106,46 +106,9 @@ if (files.Any())
 }
 else
 {
-    var dir = Directory.GetCurrentDirectory();
-    var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
-
-    void SearchConfigFile(string dirName, int depth = 0)
+    foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory()))
     {
-        if (depth > 3)
-        {
-            return;
-        }
-
-        foreach (var entryName in Directory.EnumerateFileSystemEntries(dirName))
-        {
-            if (Directory.Exists(entryName))
-            {
-                SearchConfigFile(entryName, depth + 1);
-            }
-            else if (pattern.IsMatch(entryName))
-            {
-                HandleFile(new FileInfo(entryName));
-            }
-        }
-    }
-
-    SearchConfigFile(dir);
-
-    if (configs.Count == 0)
-    {
-        var found = false;
-        while (!found && dir != null)
-        {
-            dir = Directory.GetParent(dir)?.FullName;
-            if (dir != null)
-            {
-                foreach (var fileName in Directory.EnumerateFiles(dir).Where(f => pattern.IsMatch(f)))
-                {
-                    HandleFile(new FileInfo(fileName));
-                    found = true;
-                }
-            }
-        }
+        HandleFile(file);
     }
 }
 
@@ -371,7 +334,7 @@ for (var i = 0; i < configs.Count; i++)
             var dep in lockFile
                 .Targets.FirstOrDefault(dg => dg.TargetFramework.Version.Major <= dotnetMajor)
                 ?.Libraries.Where(n => n.Name?.StartsWith("TopModel.Generator") ?? false)
-                ?? []
+            ?? []
         )
         {
             if (dep.Name == "TopModel.Generator.Core")

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -10,15 +10,15 @@ using TopModel.Utils.Cli;
 
 var excludeOption = new Option<IEnumerable<string>>("--exclude", "-e")
 {
-    Description = "Tag à ignorer lors de la génération.",
+    Description = LocalizeUtils.Localize(GeneratorMessage.ExcludeOptionDescription),
 };
 var updateOption = new Option<string>("--update", "-u")
 {
-    Description = "Met à jour le module de générateurs spécifié (ou tous les modules si 'all').",
+    Description = LocalizeUtils.Localize(GeneratorMessage.UpdateOptionDescription),
 };
 var schemaOption = new Option<bool>("--schema", "-s")
 {
-    Description = "Génère le fichier de schéma JSON du fichier de config.",
+    Description = LocalizeUtils.Localize(GeneratorMessage.SchemaOptionDescription),
 };
 
 var command = new RootCommand("Lance le générateur topmodel.")

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -20,19 +20,11 @@ using TopModel.Core.Loaders;
 using TopModel.Generator;
 using TopModel.Generator.Core;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
-var fileOption = new Option<IEnumerable<FileInfo>>("--file", "-f")
-{
-    Description = "Chemin vers un fichier de config.",
-};
 var excludeOption = new Option<IEnumerable<string>>("--exclude", "-e")
 {
     Description = "Tag à ignorer lors de la génération.",
-};
-var watchOption = new Option<bool>("--watch", "-w") { Description = "Lance le générateur en mode 'watch'" };
-var checkOption = new Option<bool>("--check", "-c")
-{
-    Description = "Vérifie que le code généré est conforme au modèle.",
 };
 var updateOption = new Option<string>("--update", "-u")
 {
@@ -45,10 +37,10 @@ var schemaOption = new Option<bool>("--schema", "-s")
 
 var command = new RootCommand("Lance le générateur topmodel.")
 {
-    fileOption,
+    TopModelCli.FileOption,
     excludeOption,
-    watchOption,
-    checkOption,
+    TopModelCli.WatchOption,
+    TopModelCli.CheckOption,
     updateOption,
     schemaOption,
 };
@@ -63,10 +55,10 @@ if (result.GetResult(helpOption) != null || result.GetResult(versionOption) != n
     return await result.InvokeAsync();
 }
 
-var files = result.GetValue(fileOption) ?? [];
-var watchMode = result.GetValue(watchOption);
+var files = result.GetValue(TopModelCli.FileOption) ?? [];
+var watchMode = result.GetValue(TopModelCli.WatchOption);
 var excludedTags = result.GetValue(excludeOption)?.ToArray() ?? [];
-var checkMode = result.GetValue(checkOption);
+var checkMode = result.GetValue(TopModelCli.CheckOption);
 var updateMode = result.GetValue(updateOption);
 var schemaMode = result.GetValue(schemaOption);
 
@@ -90,86 +82,43 @@ void HandleFile(FileInfo file)
     }
 }
 
-if (files.Any())
+var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
+foreach (var file in TopModelCli.ResolveFiles(files, pattern))
 {
-    foreach (var file in files)
-    {
-        if (!file.Exists)
-        {
-            AnsiConsole.MarkupLine($"[red]{file.FullName}[/]");
-        }
-        else
-        {
-            HandleFile(file);
-        }
-    }
-}
-else
-{
-    foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory()))
-    {
-        HandleFile(file);
-    }
+    HandleFile(file);
 }
 
 if (configs.Count == 0)
 {
-    AnsiConsole.MarkupLine($"[red]Aucun fichier de configuration trouvé.[/]");
+    AnsiConsole.MarkupLine($"[red]{LocalizeUtils.Localize(CliMessage.NoConfigFileFound)}[/]");
     return 1;
 }
 
-var version = Assembly
-    .GetEntryAssembly()!
-    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
-    .InformationalVersion;
-var majorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
-var minorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
+var (version, majorVersion, minorVersion) = await TopModelCli.ShowBannerAsync("TopModel.Generator");
 var prerelease = version.Contains('-');
-
-var colors = new[] { "teal", "olive", "yellow", "aqua" };
-
-AnsiConsole.MarkupLine($"========= TopModel.Generator v{version} =========");
-AnsiConsole.WriteLine();
-
-var latestVersion = await NugetUtils.GetLatestVersionAsync("TopModel.Generator", prerelease: prerelease);
-if (latestVersion != null && latestVersion.Version != version)
-{
-    AnsiConsole.MarkupLine($"[yellow]Nouvelle version disponible : {latestVersion.Version}[/]");
-    AnsiConsole.MarkupLine(
-        "[yellow]Vous pouvez lancer la commande `dotnet tool update -g TopModel.Generator` pour effectuer la mise à jour.[/]"
-    );
-    AnsiConsole.WriteLine();
-}
 
 if (excludedTags.Length > 0)
 {
-    AnsiConsole.MarkupLine($"Tags [teal]exclus[/] de la génération : {string.Join(", ", excludedTags)}.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(GeneratorMessage.ExcludedTags, string.Join(", ", excludedTags)));
 }
 
 if (updateMode != null)
 {
-    AnsiConsole.MarkupLine($"Mode [darkcyan]update[/] activé pour : [gray]{updateMode}[/].");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(GeneratorMessage.UpdateModeEnabled, updateMode));
     await NugetUtils.ClearAsync();
 }
 
 if (watchMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]watch[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.WatchModeEnabled));
 }
 
 if (checkMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]check[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.CheckModeEnabled));
 }
 
-AnsiConsole.WriteLine("Fichiers de configuration trouvés :");
-
-for (var i = 0; i < configs.Count; i++)
-{
-    var fullName = configs.ElementAt(i).Key;
-    var color = colors[i % colors.Length];
-    AnsiConsole.MarkupLine($"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), fullName)}[/]");
-}
+TopModelCli.ListFoundFiles(configs.Keys);
 
 static Type? GetIGenRegInterface(Type t)
 {
@@ -196,7 +145,7 @@ for (var i = 0; i < configs.Count; i++)
 {
     var (fullName, config) = configs.ElementAt(i);
 
-    var storeConfig = new LoggingScope(i + 1, colors[i % colors.Length]);
+    var storeConfig = new LoggingScope(i + 1, TopModelCli.Colors[i % TopModelCli.Colors.Length]);
     var logger = loggerProvider.CreateLogger("TopModel.Generator");
     using var scope = logger.BeginScope(storeConfig);
     var topModelLock = new TopModelLock(config, logger);
@@ -255,7 +204,7 @@ for (var i = 0; i < configs.Count; i++)
             || customHash != customHashLocal
         )
         {
-            logger.LogInformation($"Build de '{cg}' en cours...");
+            logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildInProgress, cg));
             var build = Process.Start(
                 new ProcessStartInfo
                 {
@@ -278,12 +227,12 @@ for (var i = 0; i < configs.Count; i++)
 
             if (build.ExitCode != 0)
             {
-                logger.LogError($"Erreur lors du build de '{cg}'");
+                logger.LogError(LocalizeUtils.Localize(GeneratorMessage.BuildError, cg));
                 logger.LogError((await build.StandardOutput.ReadToEndAsync()).Trim());
                 return 1;
             }
 
-            logger.LogInformation($"Build de '{cg}' terminé.");
+            logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildCompleted, cg));
             topModelLock.Custom ??= new Dictionary<string, string>();
             topModelLock.Custom[cg] = customHash;
             await File.WriteAllTextAsync(customHashLocalFile, topModelLock.Custom[cg]);
@@ -314,7 +263,7 @@ for (var i = 0; i < configs.Count; i++)
 
         if (!Directory.EnumerateFiles(projDir, "*.csproj").Any())
         {
-            logger.LogError($"Aucun fichier csproj trouvé pour le module de générateurs '{cg}'.");
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoCsprojFound, cg));
             returnCode = 1;
             continue;
         }
@@ -323,7 +272,7 @@ for (var i = 0; i < configs.Count; i++)
 
         if (!File.Exists(assetsPath))
         {
-            logger.LogError($"Le module de générateurs '{cg}' n'a pas été buildé correctement...");
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.GeneratorModuleNotBuilt, cg));
             returnCode = 1;
             continue;
         }
@@ -342,7 +291,12 @@ for (var i = 0; i < configs.Count; i++)
                 if (dep.Version?.Major != majorVersion)
                 {
                     logger.LogError(
-                        $"Le module de générateurs '{cg}' ne référence pas la bonne version majeure de TopModel ({dep.Version} < {version})."
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleBadMajorVersion,
+                            cg,
+                            dep.Version?.ToString() ?? string.Empty,
+                            version
+                        )
                     );
                     returnCode = 1;
                     continue;
@@ -350,7 +304,12 @@ for (var i = 0; i < configs.Count; i++)
                 else if (dep.Version?.Minor > minorVersion)
                 {
                     logger.LogError(
-                        $"Le module de générateurs '{cg}' référence une version plus récente de TopModel ({dep.Version} > {version})."
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleNewerVersion,
+                            cg,
+                            dep.Version?.ToString() ?? string.Empty,
+                            version
+                        )
                     );
                     returnCode = 1;
                     continue;
@@ -366,7 +325,13 @@ for (var i = 0; i < configs.Count; i++)
                 else if (ev.Version != dep.Version?.ToString())
                 {
                     logger.LogError(
-                        $"Le module personalisé '{cg}' référence le module '{configKey}' en version '{dep.Version}', ce qui n'est pas la version du lockfile ('{ev}')."
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.CustomModuleWrongLockfileVersion,
+                            cg,
+                            configKey,
+                            dep.Version?.ToString() ?? string.Empty,
+                            ev
+                        )
                     );
                     returnCode = 1;
                     continue;
@@ -422,7 +387,7 @@ for (var i = 0; i < configs.Count; i++)
 
             if (moduleVersion == null)
             {
-                logger.LogError($"Aucun module de générateurs trouvé pour '{configKey}'.");
+                logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoGeneratorModuleFound, configKey));
                 returnCode = 1;
                 continue;
             }
@@ -450,15 +415,29 @@ for (var i = 0; i < configs.Count; i++)
             {
                 if (Directory.Exists(moduleFolder))
                 {
-                    logger.LogInformation($"({dep.ConfigKey}) Module corrompu, réinstallation...");
+                    logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ModuleCorrupted, dep.ConfigKey));
                     Directory.Delete(moduleFolder, recursive: true);
                 }
 
-                logger.LogInformation($"({dep.ConfigKey}) Installation de {dep.FullName}@{depVersion} en cours...");
+                logger.LogInformation(
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleInstallInProgress,
+                        dep.ConfigKey,
+                        dep.FullName,
+                        depVersion
+                    )
+                );
 
                 if (!await NugetUtils.DoesPackageExistsAsync(dep.FullName, depVersion))
                 {
-                    logger.LogError($"({dep.ConfigKey}) Le package {dep.FullName}@{depVersion} est introuvable.");
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.PackageNotFound,
+                            dep.ConfigKey,
+                            dep.FullName,
+                            depVersion
+                        )
+                    );
                     returnCode = 1;
                     continue;
                 }
@@ -537,7 +516,12 @@ for (var i = 0; i < configs.Count; i++)
 
                 hasInstalled = true;
                 logger.LogInformation(
-                    $"({dep.ConfigKey}) Installation de {dep.FullName}@{depVersion} terminée avec succès."
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleInstallCompleted,
+                        dep.ConfigKey,
+                        dep.FullName,
+                        depVersion
+                    )
                 );
                 dep.Version.Hash = GetFolderHash(moduleFolder);
             }
@@ -547,7 +531,7 @@ for (var i = 0; i < configs.Count; i++)
             if (minVersion[0] != majorVersion)
             {
                 logger.LogError(
-                    $"Le module '{dep.ConfigKey}' ne référence pas la bonne version majeure de TopModel ({depVersion} < {version})."
+                    LocalizeUtils.Localize(GeneratorMessage.ModuleBadMajorVersion, dep.ConfigKey, depVersion, version)
                 );
                 returnCode = 1;
                 continue;
@@ -555,7 +539,7 @@ for (var i = 0; i < configs.Count; i++)
             else if (minVersion[1] > minorVersion)
             {
                 logger.LogError(
-                    $"Le module '{dep.ConfigKey}' référence une version plus récente de TopModel ({minVersionText} > {version})."
+                    LocalizeUtils.Localize(GeneratorMessage.ModuleNewerVersion, dep.ConfigKey, minVersionText, version)
                 );
                 returnCode = 1;
                 continue;
@@ -583,23 +567,32 @@ for (var i = 0; i < configs.Count; i++)
     }
 
     logger.LogInformation(
-        $"Générateurs utilisés :{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
+        LocalizeUtils.Localize(
+            GeneratorMessage.GeneratorsInUse,
+            $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
+        )
     );
 
     var depsToUpdate = deps.Where(dep => dep.LatestVersion != null && dep.LatestVersion != dep.Version.Version);
     if (depsToUpdate.Any())
     {
         logger.LogWarning(
-            $"Il existe une mise à jour pour les générateurs suivants :{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
+            LocalizeUtils.Localize(
+                GeneratorMessage.GeneratorUpdatesAvailable,
+                $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
+            )
         );
         logger.LogWarning(
-            $"Vous pouvez lancer la commande `modgen --update {(depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all")}` pour effectuer la mise à jour."
+            LocalizeUtils.Localize(
+                GeneratorMessage.ModgenUpdateCommand,
+                depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all"
+            )
         );
     }
 
     if (schemaMode || hasInstalled)
     {
-        logger.LogInformation("Génération du schéma de configuration...");
+        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.GeneratingConfigSchema));
 
         var schema = JsonNode
             .Parse(
@@ -642,7 +635,7 @@ for (var i = 0; i < configs.Count; i++)
             await File.WriteAllTextAsync(fullName, configFile);
         }
 
-        logger.LogInformation("Schéma de configuration généré avec succès.");
+        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ConfigSchemaGenerated));
     }
 
     var services = new ServiceCollection()
@@ -685,7 +678,9 @@ for (var i = 0; i < configs.Count; i++)
                     }
                     catch (ArgumentException)
                     {
-                        logger.LogError($"Le nom de configuration '{genConfig.Name}' est déjà utilisé.");
+                        logger.LogError(
+                            LocalizeUtils.Localize(GeneratorMessage.ConfigNameAlreadyInUse, genConfig.Name)
+                        );
                         return 1;
                     }
 
@@ -698,7 +693,12 @@ for (var i = 0; i < configs.Count; i++)
                         else
                         {
                             logger.LogWarning(
-                                $"La configuration '{referencedTag.Value}' n'existe pas, le tag référencé '{referencedTag.Key}' pour la config '{genConfig.Name}' sera ignoré."
+                                LocalizeUtils.Localize(
+                                    GeneratorMessage.ReferencedConfigNotFound,
+                                    referencedTag.Value,
+                                    referencedTag.Key,
+                                    genConfig.Name
+                                )
                             );
                         }
                     }
@@ -766,18 +766,11 @@ if (hasErrors.Any(he => he))
 if (checkMode && loggerProvider.Changes > 0)
 {
     AnsiConsole.WriteLine();
-    if (loggerProvider.Changes == 1)
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.[/]"
-        );
-    }
-    else
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]{loggerProvider.Changes} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.[/]"
-        );
-    }
+    AnsiConsole.MarkupLine(
+        loggerProvider.Changes == 1
+            ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
+            : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
+    );
 
     return 1;
 }

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -1,24 +1,10 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Help;
-using System.Diagnostics;
-using System.Reflection;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Castle.DynamicProxy;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NuGet.Common;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.ProjectModel;
 using Spectre.Console;
 using TopModel.Core;
 using TopModel.Core.Loaders;
 using TopModel.Generator;
-using TopModel.Generator.Core;
 using TopModel.Utils;
 using TopModel.Utils.Cli;
 
@@ -62,30 +48,13 @@ var checkMode = result.GetValue(TopModelCli.CheckOption);
 var updateMode = result.GetValue(updateOption);
 var schemaMode = result.GetValue(schemaOption);
 
-var fileChecker = new FileChecker("schema.config.json");
-var configs = new Dictionary<string, ModelConfig>();
-var returnCode = 0;
-
-void HandleFile(FileInfo file)
-{
-    try
-    {
-        fileChecker.CheckConfigFile(file.FullName);
-        using var text = file.OpenText();
-        var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(file.DirectoryName!);
-        configs.Add(file.FullName, config);
-    }
-    catch (ModelException me)
-    {
-        returnCode = 1;
-        AnsiConsole.WriteLine($"[red]{me.Message}[/]");
-    }
-}
-
+using var cts = new CancellationTokenSource();
+await TopModelCli.StartPackage("TopModel.Generator", cts.Token);
+var configs = new List<FileInfo>();
 var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
 foreach (var file in TopModelCli.ResolveFiles(files, pattern))
 {
-    HandleFile(file);
+    configs.Add(file);
 }
 
 if (configs.Count == 0)
@@ -93,9 +62,6 @@ if (configs.Count == 0)
     AnsiConsole.MarkupLine($"[red]{LocalizeUtils.Localize(CliMessage.NoConfigFileFound)}[/]");
     return 1;
 }
-
-var (version, majorVersion, minorVersion) = await TopModelCli.ShowBannerAsync("TopModel.Generator");
-var prerelease = version.Contains('-');
 
 if (excludedTags.Length > 0)
 {
@@ -105,7 +71,7 @@ if (excludedTags.Length > 0)
 if (updateMode != null)
 {
     AnsiConsole.MarkupLine(LocalizeUtils.Localize(GeneratorMessage.UpdateModeEnabled, updateMode));
-    await NugetUtils.ClearAsync();
+    await NugetUtils.ClearAsync(cts.Token);
 }
 
 if (watchMode)
@@ -118,695 +84,67 @@ if (checkMode)
     AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.CheckModeEnabled));
 }
 
-TopModelCli.ListFoundFiles(configs.Keys);
-
-static Type? GetIGenRegInterface(Type t)
-{
-    return t.GetInterfaces()
-        .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IGeneratorRegistration<>));
-}
-
-static (Type Type, string Name) GetIGenRegInterfaceAndName(Type generator)
-{
-    var configType = GetIGenRegInterface(generator)!.GetGenericArguments()[0];
-    var configName = configType.Name.Replace("Config", string.Empty).ToLower();
-    return (configType, configName);
-}
-
-var dotnetMajor = Environment.Version.Major;
-var providers = new List<IDisposable>();
 var loggerProvider = new LoggerProvider();
-var hasErrors = Enumerable.Range(0, configs.Count).Select(_ => false).ToArray();
-var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(a => a.ManifestModule.Name).ToHashSet();
-var proxyGenerator = new ProxyGenerator();
-var interceptor = new ReferencedTagInterceptor();
+Console.CancelKeyPress += (sender, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cts.Cancel();
+};
 
+FileChecker FileChecker = new("schema.config.json");
+
+TopModelWorker CreateWorker(ModelConfig config, FileInfo configInfo, int configIndex)
+{
+    return new TopModelWorker(config, configInfo.FullName, loggerProvider, configIndex, FileChecker)
+    {
+        UpdateMode = updateMode,
+        SchemaMode = schemaMode,
+        WatchMode = watchMode,
+        ExcludedTags = excludedTags,
+    };
+}
+IList<ConfigObserver> ConfigObservers = [];
 for (var i = 0; i < configs.Count; i++)
 {
-    var (fullName, config) = configs.ElementAt(i);
+    var config = configs[i];
+    ConfigObservers.Add(new ConfigObserver(config, FileChecker, i, CreateWorker));
+}
 
-    var storeConfig = new LoggingScope(i + 1, TopModelCli.Colors[i % TopModelCli.Colors.Length]);
-    var logger = loggerProvider.CreateLogger("TopModel.Generator");
-    using var scope = logger.BeginScope(storeConfig);
-    var topModelLock = new TopModelLock(config, logger);
-
-    AnsiConsole.WriteLine();
-
-    var modgenRoot = Path.GetFullPath(".modgen", config.ModelRoot);
-
-    if (updateMode == "all")
+try
+{
+    foreach (var configObserver in ConfigObservers)
     {
-        topModelLock.Modules = new Dictionary<string, TopModelLockModule>();
-
-        if (Directory.Exists(modgenRoot))
-        {
-            Directory.Delete(modgenRoot, recursive: true);
-        }
-    }
-    else if (updateMode != null)
-    {
-        topModelLock.Modules.Remove(updateMode);
-
-        foreach (
-            var module in Directory.GetFileSystemEntries(modgenRoot).Where(p => p.Split('/')[^1].Contains(updateMode))
-        )
-        {
-            Directory.Delete(module, recursive: true);
-        }
+        await configObserver.Start(cts.Token);
     }
 
-    foreach (var cg in config.CustomGenerators)
+    if (watchMode)
     {
-        Directory.CreateDirectory(modgenRoot);
-
-        var customDir = Path.GetFullPath(Path.Combine(new FileInfo(Path.GetFullPath(fullName)).DirectoryName!, cg));
-
-        var customHash =
-            GetHash(
-                Directory
-                    .EnumerateFiles(
-                        Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!),
-                        "*.cs",
-                        SearchOption.AllDirectories
-                    )
-                    .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")),
-                customDir
-            ) ?? string.Empty;
-
-        var customHashLocalFile = Path.Combine(modgenRoot, cg.Replace('/', '-').Replace('\\', '-'));
-        var customHashLocal = File.Exists(customHashLocalFile)
-            ? await File.ReadAllTextAsync(customHashLocalFile)
-            : string.Empty;
-
-        if (
-            !topModelLock.Custom.TryGetValue(cg, out var customLockHash)
-            || customHash != customLockHash
-            || customHash != customHashLocal
-        )
-        {
-            logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildInProgress, cg));
-            var build = Process.Start(
-                new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "dotnet",
-                    Arguments = "build -v q",
-                    WorkingDirectory = customDir,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    StandardOutputEncoding = Encoding.UTF8,
-                    StandardErrorEncoding = Encoding.UTF8,
-                }
-            );
-
-            await build!.StandardOutput.ReadToEndAsync();
-            await build!.StandardError.ReadToEndAsync();
-            await build!.WaitForExitAsync();
-
-            if (build.ExitCode != 0)
-            {
-                logger.LogError(LocalizeUtils.Localize(GeneratorMessage.BuildError, cg));
-                logger.LogError((await build.StandardOutput.ReadToEndAsync()).Trim());
-                return 1;
-            }
-
-            logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildCompleted, cg));
-            topModelLock.Custom ??= new Dictionary<string, string>();
-            topModelLock.Custom[cg] = customHash;
-            await File.WriteAllTextAsync(customHashLocalFile, topModelLock.Custom[cg]);
-        }
+        cts.Token.WaitHandle.WaitOne();
     }
 
-    var generators = new List<Type>();
-    var deps = new List<ModgenDependency>();
-
-    if (Environment.GetEnvironmentVariable("LOCAL_DEV") != null)
+    if (ConfigObservers.Any(w => w.HasError))
     {
-        var generatorsPath = Path.Combine(
-            new FileInfo(Assembly.GetEntryAssembly()!.Location).DirectoryName!,
-            "../../../.."
+        return 1;
+    }
+
+    if (checkMode && loggerProvider.Changes > 0)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine(
+            loggerProvider.Changes == 1
+                ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
+                : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
         );
-        var modules = Directory
-            .GetFileSystemEntries(generatorsPath)
-            .Where(e => e.Contains("TopModel.Generator.") && !e.Contains("TopModel.Generator.Core"));
-        var customGeneratorsToAdd = modules.Select(m =>
-            Path.GetRelativePath(new FileInfo(fullName).DirectoryName!, m).Replace('\\', '/')
-        );
-        config.CustomGenerators.AddRange(customGeneratorsToAdd.Where(cg => !config.CustomGenerators.Contains(cg)));
+
+        return 1;
     }
 
-    foreach (var cg in config.CustomGenerators)
-    {
-        var projDir = Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!);
-
-        if (!Directory.EnumerateFiles(projDir, "*.csproj").Any())
-        {
-            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoCsprojFound, cg));
-            returnCode = 1;
-            continue;
-        }
-
-        var assetsPath = Path.Combine(projDir, "obj", "project.assets.json");
-
-        if (!File.Exists(assetsPath))
-        {
-            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.GeneratorModuleNotBuilt, cg));
-            returnCode = 1;
-            continue;
-        }
-
-        var lockFile = LockFileUtilities.GetLockFile(assetsPath, NullLogger.Instance);
-
-        foreach (
-            var dep in lockFile
-                .Targets.FirstOrDefault(dg => dg.TargetFramework.Version.Major <= dotnetMajor)
-                ?.Libraries.Where(n => n.Name?.StartsWith("TopModel.Generator") ?? false)
-            ?? []
-        )
-        {
-            if (dep.Name == "TopModel.Generator.Core")
-            {
-                if (dep.Version?.Major != majorVersion)
-                {
-                    logger.LogError(
-                        LocalizeUtils.Localize(
-                            GeneratorMessage.GeneratorModuleBadMajorVersion,
-                            cg,
-                            dep.Version?.ToString() ?? string.Empty,
-                            version
-                        )
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-                else if (dep.Version?.Minor > minorVersion)
-                {
-                    logger.LogError(
-                        LocalizeUtils.Localize(
-                            GeneratorMessage.GeneratorModuleNewerVersion,
-                            cg,
-                            dep.Version?.ToString() ?? string.Empty,
-                            version
-                        )
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-            }
-            else
-            {
-                var configKey = dep.Name?.Split('.')[^1].ToLower() ?? string.Empty;
-                if (!topModelLock.Modules.TryGetValue(configKey, out var ev))
-                {
-                    topModelLock.Modules.Add(configKey, new() { Version = dep.Version?.ToString() ?? string.Empty });
-                }
-                else if (ev.Version != dep.Version?.ToString())
-                {
-                    logger.LogError(
-                        LocalizeUtils.Localize(
-                            GeneratorMessage.CustomModuleWrongLockfileVersion,
-                            cg,
-                            configKey,
-                            dep.Version?.ToString() ?? string.Empty,
-                            ev
-                        )
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-            }
-        }
-
-        if (returnCode == 0)
-        {
-            var assemblies = new DirectoryInfo(
-                Path.Combine(Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!), "bin")
-            )
-                .GetFiles($"*.dll", SearchOption.AllDirectories)
-                .Where(f => !f.Name.EndsWith(".resources.dll") && !loadedAssemblies.Contains(f.Name))
-                .DistinctBy(a => a.Name)
-                .Select(f => Assembly.LoadFrom(f.FullName))
-                .ToList();
-            loadedAssemblies.UnionWith(assemblies.Select(a => a.ManifestModule.Name));
-            generators.AddRange(
-                assemblies
-                    .Where(a =>
-                        a.ManifestModule.Name.Equals(
-                            $"{cg.Split('/')[^1].ToLower()}.dll",
-                            StringComparison.CurrentCultureIgnoreCase
-                        )
-                    )
-                    .SelectMany(a => a.GetExportedTypes())
-                    .Where(t => GetIGenRegInterface(t) != null)
-            );
-        }
-    }
-
-    if (returnCode != 0)
-    {
-        continue;
-    }
-
-    var resolvedConfigKeys = new Dictionary<string, string>();
-
-    foreach (var configKey in config.Generators.Keys)
-    {
-        if (generators.Exists(g => GetIGenRegInterfaceAndName(g).Name == configKey))
-        {
-            resolvedConfigKeys.Add(configKey, "custom");
-            continue;
-        }
-
-        var fullModuleName = $"TopModel.Generator.{configKey.ToFirstUpper()}";
-
-        if (!topModelLock.Modules.TryGetValue(configKey, out var moduleVersion))
-        {
-            moduleVersion = await NugetUtils.GetLatestVersionAsync(fullModuleName, forceCheck: true, prerelease);
-
-            if (moduleVersion == null)
-            {
-                logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoGeneratorModuleFound, configKey));
-                returnCode = 1;
-                continue;
-            }
-
-            topModelLock.Modules.Add(configKey, moduleVersion);
-        }
-
-        deps.Add(new(configKey, moduleVersion));
-    }
-
-    var hasInstalled = false;
-
-    if (deps.Count > 0)
-    {
-        Directory.CreateDirectory(modgenRoot);
-
-        foreach (var dep in deps)
-        {
-            var depVersion = dep.Version.Version;
-            var moduleFolder = Path.Combine(modgenRoot, $"{dep.ConfigKey}.{depVersion}");
-
-            var depHash = GetFolderHash(moduleFolder);
-
-            if (depHash == null || depHash != dep.Version.Hash)
-            {
-                if (Directory.Exists(moduleFolder))
-                {
-                    logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ModuleCorrupted, dep.ConfigKey));
-                    Directory.Delete(moduleFolder, recursive: true);
-                }
-
-                logger.LogInformation(
-                    LocalizeUtils.Localize(
-                        GeneratorMessage.ModuleInstallInProgress,
-                        dep.ConfigKey,
-                        dep.FullName,
-                        depVersion
-                    )
-                );
-
-                if (!await NugetUtils.DoesPackageExistsAsync(dep.FullName, depVersion))
-                {
-                    logger.LogError(
-                        LocalizeUtils.Localize(
-                            GeneratorMessage.PackageNotFound,
-                            dep.ConfigKey,
-                            dep.FullName,
-                            depVersion
-                        )
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-
-                Directory.CreateDirectory(moduleFolder);
-
-                using var packageReader = await NugetUtils.DownloadPackageAsync(dep.FullName, depVersion);
-                var nuspecReader = await packageReader.GetNuspecReaderAsync(default);
-
-                var dependencyGroup = nuspecReader
-                    .GetDependencyGroups()
-                    .OrderByDescending(dg => dg.TargetFramework.Version.Major)
-                    .First(dg => dg.TargetFramework.Version.Major <= dotnetMajor);
-
-                var dependencies = dependencyGroup.Packages;
-                var framework = dependencyGroup.TargetFramework.ToString();
-
-                await File.WriteAllTextAsync(
-                    Path.Combine(moduleFolder, "min-version"),
-                    dependencies.Single(d => d.Id == "TopModel.Generator.Core").VersionRange.MinVersion!.ToString()
-                );
-
-                foreach (
-                    var file in (await packageReader.GetFilesAsync(default)).Where(f =>
-                        f == $"lib/{framework}/{dep.FullName}.dll" || f.EndsWith("config.json")
-                    )
-                )
-                {
-                    packageReader.ExtractFile(
-                        file,
-                        Path.Combine(moduleFolder, file.Split('/')[^1]),
-                        NullLogger.Instance
-                    );
-                }
-
-                var installedDependencies = new List<string>();
-                dependencies = dependencies.Where(d => d.Id != "TopModel.Generator.Core");
-
-                while (dependencies.Any())
-                {
-                    var newDeps = new List<PackageDependency>();
-                    foreach (var otherDep in dependencies)
-                    {
-                        using var packageReaderDep = await NugetUtils.DownloadPackageAsync(
-                            otherDep.Id,
-                            otherDep.VersionRange.MinVersion!.ToString()
-                        );
-                        var file = (await packageReaderDep.GetFilesAsync(default)).SingleOrDefault(f =>
-                            f.StartsWith($"lib/{framework}") && f.EndsWith(".dll") && !f.EndsWith(".resources.dll")
-                        );
-                        if (file != null)
-                        {
-                            packageReaderDep.ExtractFile(
-                                file,
-                                Path.Combine(moduleFolder, file.Split('/')[^1]),
-                                NullLogger.Instance
-                            );
-
-                            installedDependencies.Add(otherDep.Id);
-
-                            var nuspecReaderDep = await packageReaderDep.GetNuspecReaderAsync(default);
-                            if (nuspecReaderDep.GetDependencyGroups().Any())
-                            {
-                                newDeps.AddRange(
-                                    nuspecReaderDep
-                                        .GetDependencyGroups()
-                                        .Single(dg => dg.TargetFramework.ToString() == framework)
-                                        .Packages.Where(dep => !installedDependencies.Contains(dep.Id))
-                                );
-                            }
-                        }
-                    }
-
-                    dependencies = newDeps;
-                }
-
-                hasInstalled = true;
-                logger.LogInformation(
-                    LocalizeUtils.Localize(
-                        GeneratorMessage.ModuleInstallCompleted,
-                        dep.ConfigKey,
-                        dep.FullName,
-                        depVersion
-                    )
-                );
-                dep.Version.Hash = GetFolderHash(moduleFolder);
-            }
-
-            var minVersionText = await File.ReadAllTextAsync(Path.Combine(moduleFolder, "min-version"));
-            var minVersion = minVersionText.Split('.').Take(2).Select(int.Parse).ToArray();
-            if (minVersion[0] != majorVersion)
-            {
-                logger.LogError(
-                    LocalizeUtils.Localize(GeneratorMessage.ModuleBadMajorVersion, dep.ConfigKey, depVersion, version)
-                );
-                returnCode = 1;
-                continue;
-            }
-            else if (minVersion[1] > minorVersion)
-            {
-                logger.LogError(
-                    LocalizeUtils.Localize(GeneratorMessage.ModuleNewerVersion, dep.ConfigKey, minVersionText, version)
-                );
-                returnCode = 1;
-                continue;
-            }
-
-            generators.AddRange(
-                Directory
-                    .GetFiles(moduleFolder, "*.dll")
-                    .SelectMany(a => Assembly.LoadFrom(a).GetExportedTypes().Where(t => GetIGenRegInterface(t) != null))
-            );
-            resolvedConfigKeys.Add(dep.ConfigKey, depVersion);
-        }
-    }
-
-    if (returnCode != 0)
-    {
-        continue;
-    }
-
-    topModelLock.Write();
-
-    foreach (var dep in deps)
-    {
-        dep.LatestVersion = (await NugetUtils.GetLatestVersionAsync(dep.FullName, prerelease: prerelease))?.Version;
-    }
-
-    logger.LogInformation(
-        LocalizeUtils.Localize(
-            GeneratorMessage.GeneratorsInUse,
-            $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
-        )
-    );
-
-    var depsToUpdate = deps.Where(dep => dep.LatestVersion != null && dep.LatestVersion != dep.Version.Version);
-    if (depsToUpdate.Any())
-    {
-        logger.LogWarning(
-            LocalizeUtils.Localize(
-                GeneratorMessage.GeneratorUpdatesAvailable,
-                $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
-            )
-        );
-        logger.LogWarning(
-            LocalizeUtils.Localize(
-                GeneratorMessage.ModgenUpdateCommand,
-                depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all"
-            )
-        );
-    }
-
-    if (schemaMode || hasInstalled)
-    {
-        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.GeneratingConfigSchema));
-
-        var schema = JsonNode
-            .Parse(
-                await File.ReadAllTextAsync(
-                    FileChecker.GetFilePath(Assembly.GetExecutingAssembly(), "schema.config.json")
-                )
-            )!
-            .AsObject();
-
-        schema.Remove("additionalProperties");
-        schema.Add("additionalProperties", value: false);
-
-        foreach (var generator in generators)
-        {
-            var (configType, configName) = GetIGenRegInterfaceAndName(generator);
-
-            var configSchema = JsonNode.Parse(@"{""type"": ""array""}")!.AsObject();
-            configSchema.Add(
-                "items",
-                JsonNode.Parse(
-                    await File.ReadAllTextAsync(
-                        FileChecker.GetFilePath(configType.Assembly, $"{configName}.config.json")
-                    )
-                )
-            );
-            schema["properties"]!.AsObject().Add(configName, configSchema);
-        }
-
-        await File.WriteAllTextAsync(
-            fullName + ".schema.json",
-            schema.Root.ToJsonString(
-                new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true }
-            )
-        );
-        var configFile = await File.ReadAllTextAsync(fullName);
-        if (!configFile.StartsWith("# yaml-language-server"))
-        {
-            var relativePath = fullName.ToRelative(config.ConfigRoot);
-            configFile = $"# yaml-language-server: $schema={relativePath}.schema.json \n" + configFile;
-            await File.WriteAllTextAsync(fullName, configFile);
-        }
-
-        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ConfigSchemaGenerated));
-    }
-
-    var services = new ServiceCollection()
-        .AddTransient(typeof(ILogger<>), typeof(Logger<>))
-        .AddTransient<ILoggerFactory, LoggerFactory>()
-        .AddSingleton<ILoggerProvider>(loggerProvider)
-        .AddSingleton<IFileWriterProvider>(new GeneratedFileWriterProvider(config))
-        .AddModelStore(fileChecker, config);
-
-    var hasError = false;
-
-    foreach (var generator in generators)
-    {
-        var (configType, configName) = GetIGenRegInterfaceAndName(generator);
-
-        if (config.Generators.TryGetValue(configName, out var genConfigMaps))
-        {
-            for (var j = 0; j < genConfigMaps.Count(); j++)
-            {
-                var genConfigMap = genConfigMaps.ElementAt(j);
-                var number = j + 1;
-
-                try
-                {
-                    var genConfig = (GeneratorConfigBase)fileChecker.GetGenConfig(configName, configType, genConfigMap);
-                    genConfig.InitVariables(config.App, number);
-
-                    genConfig.ExcludedTags = excludedTags;
-
-                    genConfig.TranslateReferences ??= config.I18n.TranslateReferences;
-                    genConfig.TranslateProperties ??= config.I18n.TranslateProperties;
-
-                    ModelUtils.TrimSlashes(genConfig, c => c.OutputDirectory);
-                    ModelUtils.CombinePath(config.ConfigRoot, genConfig, c => c.OutputDirectory);
-
-                    genConfig.Name ??= $"{configName}@{number}";
-                    try
-                    {
-                        config.Configs.Add(genConfig.Name, genConfig);
-                    }
-                    catch (ArgumentException)
-                    {
-                        logger.LogError(
-                            LocalizeUtils.Localize(GeneratorMessage.ConfigNameAlreadyInUse, genConfig.Name)
-                        );
-                        return 1;
-                    }
-
-                    foreach (var referencedTag in genConfig.ReferencedTags)
-                    {
-                        if (config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
-                        {
-                            genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
-                        }
-                        else
-                        {
-                            logger.LogWarning(
-                                LocalizeUtils.Localize(
-                                    GeneratorMessage.ReferencedConfigNotFound,
-                                    referencedTag.Value,
-                                    referencedTag.Key,
-                                    genConfig.Name
-                                )
-                            );
-                        }
-                    }
-
-                    if (genConfig.ReferencedTagConfigs.Any())
-                    {
-                        genConfig = (GeneratorConfigBase)
-                            proxyGenerator.CreateClassProxyWithTarget(genConfig.GetType(), genConfig, interceptor);
-                    }
-
-                    var instance = Activator.CreateInstance(generator);
-                    instance!.GetType().GetMethod("Register")!.Invoke(instance, [services, genConfig, number]);
-                }
-                catch (ModelException me)
-                {
-                    hasError = true;
-                    returnCode = 1;
-                    AnsiConsole.MarkupLine($"[red]{me.Message.EscapeMarkup()}[/]");
-                    AnsiConsole.WriteLine();
-                }
-            }
-        }
-    }
-
-    if (!hasError)
-    {
-        var provider = services.BuildServiceProvider();
-        providers.Add(provider);
-
-        var modelStore = provider.GetRequiredService<ModelStore>();
-
-        modelStore.DisableLockfile = excludedTags.Length > 0;
-
-        var k = i;
-        modelStore.OnResolve += hasError =>
-        {
-            hasErrors[k] = hasError;
-        };
-
-        await modelStore.LoadFromConfig(watchMode, topModelLock, storeConfig);
-    }
+    return 0;
 }
-
-if (watchMode)
+finally
 {
-    var autoResetEvent = new AutoResetEvent(initialState: false);
-    Console.CancelKeyPress += (sender, eventArgs) =>
+    foreach (var configObserver in ConfigObservers)
     {
-        eventArgs.Cancel = true;
-        autoResetEvent.Set();
-    };
-    autoResetEvent.WaitOne();
-}
-
-foreach (var provider in providers)
-{
-    provider.Dispose();
-}
-
-if (hasErrors.Any(he => he))
-{
-    return 1;
-}
-
-if (checkMode && loggerProvider.Changes > 0)
-{
-    AnsiConsole.WriteLine();
-    AnsiConsole.MarkupLine(
-        loggerProvider.Changes == 1
-            ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
-            : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
-    );
-
-    return 1;
-}
-
-return returnCode;
-
-static string? GetFolderHash(string path)
-{
-    if (!Directory.Exists(path))
-    {
-        return null;
+        configObserver.Dispose();
     }
-
-    return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
-}
-
-static string? GetHash(IEnumerable<string> f, string path)
-{
-    var md5 = MD5.Create();
-    var files = f.Order().ToList();
-    foreach (var file in files)
-    {
-        var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
-        var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
-        md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
-
-        var contentBytes = File.ReadAllBytes(file);
-        if (files.IndexOf(file) == files.Count - 1)
-        {
-            md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
-        }
-        else
-        {
-            md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
-        }
-    }
-
-    return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
 }

--- a/TopModel.Generator/TopModel.Generator.csproj
+++ b/TopModel.Generator/TopModel.Generator.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TopModel.Utils.Cli\TopModel.Utils.Cli.csproj" />
     <ProjectReference Include="..\TopModel.Generator.Core\TopModel.Generator.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/TopModel.Generator/TopModelWorker.cs
+++ b/TopModel.Generator/TopModelWorker.cs
@@ -1,0 +1,726 @@
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Castle.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Spectre.Console;
+using TopModel.Core;
+using TopModel.Core.Loaders;
+using TopModel.Generator;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class TopModelWorker : IDisposable
+{
+    private static readonly ReferencedTagInterceptor interceptor = new();
+    private static readonly ProxyGenerator proxyGenerator = new();
+    private readonly IEnumerable<CustomModule> CustomModules;
+
+    private readonly IList<ModgenDependency> Deps = [];
+    private readonly FileChecker FileChecker;
+
+    private readonly IList<Type> Generators = [];
+    private readonly IList<IDisposable> providers = [];
+    private readonly IDictionary<string, string> resolvedConfigKeys = new Dictionary<string, string>();
+    private readonly IServiceCollection services;
+    private readonly LoggingScope storeConfig;
+
+    private bool HasInstalled = false;
+
+    public TopModelWorker(
+        ModelConfig config,
+        string configFullName,
+        LoggerProvider loggerProvider,
+        int configIndex,
+        FileChecker fileChecker
+    )
+    {
+        FileChecker = fileChecker;
+        storeConfig = new LoggingScope(configIndex + 1, TopModelCli.Colors[configIndex % TopModelCli.Colors.Length]);
+        Config = config;
+        Logger = loggerProvider.CreateLogger("TopModel.Generator");
+        var scope = Logger.BeginScope(storeConfig);
+        if (scope != null)
+        {
+            providers.Add(scope);
+        }
+        TopModelLock = new TopModelLock(config, Logger);
+        ConfigFullName = configFullName;
+        ModgenRoot = Path.GetFullPath(".modgen", config.ModelRoot);
+        AddDevCustomGenerators();
+        CustomModules = Config
+            .CustomGenerators.Select(cg => new CustomModule(cg, ConfigFullName, ModgenRoot, Logger, TopModelLock))
+            .ToList();
+        services = new ServiceCollection()
+            .AddTransient(typeof(ILogger<>), typeof(Logger<>))
+            .AddTransient<ILoggerFactory, LoggerFactory>()
+            .AddSingleton<ILoggerProvider>(loggerProvider)
+            .AddSingleton<IFileWriterProvider>(new GeneratedFileWriterProvider(Config))
+            .AddModelStore(FileChecker, Config);
+    }
+
+    public bool HasError { get; private set; } = false;
+
+    public string? UpdateMode { get; set; }
+    public bool SchemaMode { get; set; }
+    public bool WatchMode { get; set; }
+    public IEnumerable<string> ExcludedTags { get; set; } = [];
+
+    public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    public string ConfigFullName { get; }
+    public string ModgenRoot { get; }
+    public ModelConfig Config { get; }
+    public TopModelLock TopModelLock { get; }
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose()
+    {
+        foreach (var provider in providers)
+        {
+            provider.Dispose();
+        }
+    }
+
+    public async Task LoadModules(CancellationToken cancellationToken)
+    {
+        if (Deps.Count > 0)
+        {
+            Directory.CreateDirectory(ModgenRoot);
+        }
+
+        foreach (var dep in Deps)
+        {
+            await LoadModule(dep, cancellationToken);
+        }
+
+        TopModelLock.Write();
+        if (resolvedConfigKeys.Any())
+        {
+            Logger.LogInformation(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.GeneratorsInUse,
+                    $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
+                )
+            );
+        }
+
+        CheckDependenciesToUpdate();
+    }
+
+    public async Task Run(CancellationToken cancellationToken)
+    {
+        await InitModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+        await PrepareConfiguration();
+        if (HasError)
+        {
+            return;
+        }
+        await RunGeneration(cancellationToken);
+    }
+
+    public async Task WriteSchema(CancellationToken cancellationToken)
+    {
+        Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.GeneratingConfigSchema));
+        var schema = JsonNode
+            .Parse(
+                await File.ReadAllTextAsync(
+                    FileChecker.GetFilePath(Assembly.GetExecutingAssembly(), "schema.config.json"),
+                    cancellationToken
+                )
+            )!
+            .AsObject();
+
+        schema.Remove("additionalProperties");
+        schema.Add("additionalProperties", value: false);
+
+        foreach (var generator in Generators)
+        {
+            var (configType, configName) = ModuleUtils.GetIGenRegInterfaceAndName(generator);
+
+            var configSchema = JsonNode.Parse(@"{""type"": ""array""}")!.AsObject();
+            configSchema.Add(
+                "items",
+                JsonNode.Parse(
+                    await File.ReadAllTextAsync(
+                        FileChecker.GetFilePath(configType.Assembly, $"{configName}.config.json"),
+                        cancellationToken
+                    )
+                )
+            );
+            schema["properties"]!.AsObject().Add(configName, configSchema);
+        }
+
+        await File.WriteAllTextAsync(
+            ConfigFullName + ".schema.json",
+            schema.Root.ToJsonString(
+                new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true }
+            ),
+            cancellationToken
+        );
+        var configFile = await File.ReadAllTextAsync(ConfigFullName, cancellationToken);
+        if (!configFile.StartsWith("# yaml-language-server"))
+        {
+            var relativePath = ConfigFullName.ToRelative(Config.ConfigRoot);
+            configFile = $"# yaml-language-server: $schema={relativePath}.schema.json \n" + configFile;
+            await File.WriteAllTextAsync(ConfigFullName, configFile, cancellationToken);
+        }
+
+        Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ConfigSchemaGenerated));
+    }
+
+    static async Task<List<PackageDependency>> DownloadMissingDependenciesCascade(
+        string moduleFolder,
+        IEnumerable<PackageDependency> dependencies,
+        string framework,
+        CancellationToken cancellationToken
+    )
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return [];
+        }
+
+        var installedDependencies = new List<PackageDependency>();
+        var newDeps = new List<PackageDependency>();
+        foreach (var otherDep in dependencies)
+        {
+            using var packageReaderDep = await NugetUtils.DownloadPackageAsync(
+                otherDep.Id,
+                otherDep.VersionRange.MinVersion!.ToString(),
+                cancellationToken
+            );
+            var file = (await packageReaderDep.GetFilesAsync(cancellationToken)).SingleOrDefault(f =>
+                f.StartsWith($"lib/{framework}") && f.EndsWith(".dll") && !f.EndsWith(".resources.dll")
+            );
+            if (file != null)
+            {
+                packageReaderDep.ExtractFile(
+                    file,
+                    Path.Combine(moduleFolder, file.Split('/')[^1]),
+                    NullLogger.Instance
+                );
+
+                installedDependencies.Add(otherDep);
+
+                var nuspecReaderDep = await packageReaderDep.GetNuspecReaderAsync(cancellationToken);
+                if (nuspecReaderDep.GetDependencyGroups().Any())
+                {
+                    newDeps.AddRange(
+                        nuspecReaderDep
+                            .GetDependencyGroups()
+                            .Single(dg => dg.TargetFramework.ToString() == framework)
+                            .Packages.Where(dep => !installedDependencies.Select(d => d.Id).Contains(dep.Id))
+                    );
+                }
+            }
+        }
+
+        if (newDeps.Count > 0)
+        {
+            installedDependencies.AddRange(
+                await DownloadMissingDependenciesCascade(moduleFolder, newDeps, framework, cancellationToken)
+            );
+        }
+
+        return installedDependencies;
+    }
+
+    static string? GetFolderHash(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return null;
+        }
+
+        return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
+    }
+
+    static string? GetHash(IEnumerable<string> f, string path)
+    {
+        var md5 = MD5.Create();
+        var files = f.Order().ToList();
+        foreach (var file in files)
+        {
+            var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
+            var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
+            md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
+
+            var contentBytes = File.ReadAllBytes(file);
+            if (files.IndexOf(file) == files.Count - 1)
+            {
+                md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
+            }
+            else
+            {
+                md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
+            }
+        }
+
+        return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
+    }
+
+    private void AddDevCustomGenerators()
+    {
+        if (Environment.GetEnvironmentVariable("LOCAL_DEV") != null)
+        {
+            var generatorsPath = Path.GetFullPath(
+                Path.Combine(
+                    new FileInfo(Assembly.GetEntryAssembly()!.Location).DirectoryName!,
+                    Path.Combine("..", "..", "..", "..")
+                )
+            );
+            var modules = Directory
+                .GetFileSystemEntries(generatorsPath)
+                .Where(e => e.Contains("TopModel.Generator.") && !e.Contains("TopModel.Generator.Core"));
+            var customGeneratorsToAdd = modules.Select(m =>
+                Path.GetRelativePath(new FileInfo(ConfigFullName).DirectoryName!, m)
+            );
+
+            Config.CustomGenerators.AddRange(
+                customGeneratorsToAdd.Where(cg =>
+                    !Config.CustomGenerators.Select(c => c.Replace('\\', '/')).Contains(cg.Replace('\\', '/'))
+                )
+            );
+        }
+    }
+
+    private async Task AddRemoteModule(string configKey, CancellationToken cancellationToken)
+    {
+        if (Generators.ToList().Exists(g => ModuleUtils.GetIGenRegInterfaceAndName(g).Name == configKey))
+        {
+            resolvedConfigKeys.Add(configKey, "custom");
+            return;
+        }
+
+        var fullModuleName = $"TopModel.Generator.{configKey.ToFirstUpper()}";
+
+        if (!TopModelLock.Modules.TryGetValue(configKey, out var moduleVersion))
+        {
+            moduleVersion = await NugetUtils.GetLatestVersionAsync(
+                fullModuleName,
+                cancellationToken,
+                forceCheck: true,
+                VersionUtils.Prerelease
+            );
+
+            if (moduleVersion == null)
+            {
+                Logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoGeneratorModuleFound, configKey));
+                HasError = true;
+                return;
+            }
+            TopModelLock.Modules.Add(configKey, new() { Version = moduleVersion.Version });
+        }
+        else if (!await NugetUtils.DoesPackageExistsAsync(fullModuleName, moduleVersion.Version, cancellationToken))
+        {
+            Logger.LogError(
+                LocalizeUtils.Localize(GeneratorMessage.PackageNotFound, fullModuleName, moduleVersion.Version)
+            );
+            HasError = true;
+            return;
+        }
+        Deps.Add(new(configKey, moduleVersion));
+    }
+
+    private async Task AddRemoteModules(CancellationToken cancellationToken)
+    {
+        foreach (var configKey in Config.Generators.Keys)
+        {
+            await AddRemoteModule(configKey, cancellationToken);
+        }
+    }
+
+    private async Task BuildCustomModulesAsync(CancellationToken cancellationToken)
+    {
+        foreach (var customModule in CustomModules)
+        {
+            await customModule.BuildAsync(cancellationToken);
+            if (customModule.HasError)
+            {
+                HasError = true;
+                return;
+            }
+        }
+    }
+
+    private void CheckDependenciesToUpdate()
+    {
+        var depsToUpdate = GetDependenciesToUpdate();
+        if (depsToUpdate.Any())
+        {
+            Logger.LogWarning(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.GeneratorUpdatesAvailable,
+                    $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
+                )
+            );
+            Logger.LogWarning(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.ModgenUpdateCommand,
+                    depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all"
+                )
+            );
+        }
+    }
+
+    private async Task CheckMinVersionAsync(
+        string moduleFolder,
+        string depVersion,
+        ModgenDependency dep,
+        CancellationToken cancellationToken
+    )
+    {
+        var minVersionText = await File.ReadAllTextAsync(Path.Combine(moduleFolder, "min-version"), cancellationToken);
+        if (NuGetVersion.TryParse(minVersionText, out var minNuGetVersion))
+        {
+            if (minNuGetVersion.Major != VersionUtils.MajorVersion)
+            {
+                Logger.LogError(
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleBadMajorVersion,
+                        dep.ConfigKey,
+                        depVersion,
+                        VersionUtils.Version
+                    )
+                );
+                HasError = true;
+            }
+            else if (minNuGetVersion.Minor > VersionUtils.MinorVersion)
+            {
+                Logger.LogError(
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleNewerVersion,
+                        dep.ConfigKey,
+                        minVersionText,
+                        VersionUtils.Version
+                    )
+                );
+                HasError = true;
+            }
+        }
+    }
+
+    private async Task DownloadDependencies(
+        ModgenDependency dep,
+        string moduleFolder,
+        CancellationToken cancellationToken
+    )
+    {
+        var depVersion = dep.Version.Version;
+        if (Directory.Exists(moduleFolder))
+        {
+            Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ModuleCorrupted, dep.FullName));
+            Directory.Delete(moduleFolder, recursive: true);
+        }
+
+        Logger.LogInformation(
+            LocalizeUtils.Localize(GeneratorMessage.ModuleInstallInProgress, dep.FullName, depVersion)
+        );
+
+        Directory.CreateDirectory(moduleFolder);
+
+        using var packageReader = await NugetUtils.DownloadPackageAsync(dep.FullName, depVersion, cancellationToken);
+        var nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
+
+        var dependencyGroup = nuspecReader
+            .GetDependencyGroups()
+            .OrderByDescending(dg => dg.TargetFramework.Version.Major)
+            .First(dg => dg.TargetFramework.Version.Major <= VersionUtils.DotnetMajor);
+
+        var dependencies = dependencyGroup.Packages;
+        var framework = dependencyGroup.TargetFramework.ToString();
+        var coreDep = dependencies.Single(d => d.Id == "TopModel.Generator.Core");
+        await File.WriteAllTextAsync(
+            Path.Combine(moduleFolder, "min-version"),
+            coreDep.VersionRange.MinVersion!.ToString(),
+            cancellationToken
+        );
+
+        foreach (
+            var file in (await packageReader.GetFilesAsync(cancellationToken)).Where(f =>
+                f == $"lib/{framework}/{dep.FullName}.dll" || f.EndsWith("config.json")
+            )
+        )
+        {
+            packageReader.ExtractFile(file, Path.Combine(moduleFolder, file.Split('/')[^1]), NullLogger.Instance);
+        }
+
+        var missingDependencies = dependencies.Where(d => d.Id != "TopModel.Generator.Core").ToList();
+        await DownloadMissingDependenciesCascade(moduleFolder, missingDependencies, framework, cancellationToken);
+
+        Logger.LogInformation(
+            LocalizeUtils.Localize(GeneratorMessage.ModuleInstallCompleted, dep.FullName, depVersion)
+        );
+        dep.Version.Hash = GetFolderHash(moduleFolder);
+    }
+
+    private IEnumerable<ModgenDependency> GetDependenciesToUpdate()
+    {
+        return Deps.Where(dep => dep.LatestVersion != null && dep.LatestVersion != dep.Version.Version);
+    }
+
+    private void HandleUpdate()
+    {
+        if (UpdateMode == null)
+        {
+            return;
+        }
+        var modgenRoot = Path.GetFullPath(".modgen", Config.ModelRoot);
+        if (UpdateMode == "all")
+        {
+            TopModelLock.Modules = new Dictionary<string, TopModelLockModule>();
+
+            if (Directory.Exists(modgenRoot))
+            {
+                Directory.Delete(modgenRoot, recursive: true);
+            }
+        }
+        else if (UpdateMode != null)
+        {
+            TopModelLock.Modules.Remove(UpdateMode);
+
+            foreach (
+                var module in Directory
+                    .GetFileSystemEntries(modgenRoot)
+                    .Where(p => p.Split('/')[^1].Contains(UpdateMode))
+            )
+            {
+                Directory.Delete(module, recursive: true);
+            }
+        }
+    }
+
+    private async Task InitModules(CancellationToken cancellationToken)
+    {
+        AnsiConsole.WriteLine();
+
+        HandleUpdate();
+        if (HasError)
+        {
+            return;
+        }
+
+        await BuildCustomModulesAsync(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        LoadCustomModulesAssemblies();
+        if (HasError)
+        {
+            return;
+        }
+
+        await AddRemoteModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        if (Directory.Exists(ModgenRoot))
+        {
+            var usedPrefixes = Deps.Select(d => $"{d.ConfigKey}.").ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in Directory.GetDirectories(ModgenRoot))
+            {
+                if (!usedPrefixes.Any(p => Path.GetFileName(dir).StartsWith(p)))
+                {
+                    Directory.Delete(dir, recursive: true);
+                    Logger.LogInformation($"Supprimé: {dir.ToRelative()}");
+                }
+            }
+        }
+
+        await LoadModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        if (SchemaMode || HasInstalled)
+        {
+            await WriteSchema(cancellationToken);
+        }
+
+        RemoveUnusedCustomModules();
+    }
+
+    private void LoadCustomModulesAssemblies()
+    {
+        foreach (var customModule in CustomModules)
+        {
+            customModule.LoadAssemblies(ConfigFullName, Generators);
+            if (HasError)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task LoadModule(ModgenDependency dep, CancellationToken cancellationToken)
+    {
+        var depVersion = dep.Version.Version;
+        var moduleFolder = Path.Combine(ModgenRoot, $"{dep.ConfigKey}.{depVersion}");
+
+        var depHash = GetFolderHash(moduleFolder);
+
+        if (depHash == null || depHash != dep.Version.Hash)
+        {
+            await DownloadDependencies(dep, moduleFolder, cancellationToken);
+            HasInstalled = true;
+        }
+        await CheckMinVersionAsync(moduleFolder, depVersion, dep, cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        Generators.AddRange(
+            Directory
+                .GetFiles(moduleFolder, "*.dll")
+                .SelectMany(a =>
+                    Assembly.LoadFrom(a).GetExportedTypes().Where(t => ModuleUtils.GetIGenRegInterface(t) != null)
+                )
+        );
+        resolvedConfigKeys.Add(dep.ConfigKey, depVersion);
+        dep.LatestVersion = (
+            await NugetUtils.GetLatestVersionAsync(dep.FullName, cancellationToken, prerelease: VersionUtils.Prerelease)
+        )?.Version;
+    }
+
+    private async Task PrepareConfiguration()
+    {
+        foreach (var generator in Generators)
+        {
+            var (configType, configName) = ModuleUtils.GetIGenRegInterfaceAndName(generator);
+
+            if (Config.Generators.TryGetValue(configName, out var genConfigMaps))
+            {
+                for (var j = 0; j < genConfigMaps.Count(); j++)
+                {
+                    var genConfigMap = genConfigMaps.ElementAt(j);
+                    var number = j + 1;
+
+                    try
+                    {
+                        var genConfig = (GeneratorConfigBase)
+                            FileChecker.GetGenConfig(configName, configType, genConfigMap);
+                        genConfig.InitVariables(Config.App, number);
+
+                        genConfig.ExcludedTags = ExcludedTags.ToList();
+
+                        genConfig.TranslateReferences ??= Config.I18n.TranslateReferences;
+                        genConfig.TranslateProperties ??= Config.I18n.TranslateProperties;
+
+                        ModelUtils.TrimSlashes(genConfig, c => c.OutputDirectory);
+                        ModelUtils.CombinePath(Config.ConfigRoot, genConfig, c => c.OutputDirectory);
+
+                        genConfig.Name ??= $"{configName}@{number}";
+                        try
+                        {
+                            Config.Configs.Add(genConfig.Name, genConfig);
+                        }
+                        catch (ArgumentException)
+                        {
+                            Logger.LogError(
+                                LocalizeUtils.Localize(GeneratorMessage.ConfigNameAlreadyInUse, genConfig.Name)
+                            );
+                            HasError = true;
+                            return;
+                        }
+
+                        foreach (var referencedTag in genConfig.ReferencedTags)
+                        {
+                            if (Config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
+                            {
+                                genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
+                            }
+                            else
+                            {
+                                Logger.LogWarning(
+                                    LocalizeUtils.Localize(
+                                        GeneratorMessage.ReferencedConfigNotFound,
+                                        referencedTag.Value,
+                                        referencedTag.Key,
+                                        genConfig.Name
+                                    )
+                                );
+                            }
+                        }
+
+                        if (genConfig.ReferencedTagConfigs.Any())
+                        {
+                            genConfig = (GeneratorConfigBase)
+                                proxyGenerator.CreateClassProxyWithTarget(genConfig.GetType(), genConfig, interceptor);
+                        }
+
+                        var instance = Activator.CreateInstance(generator);
+                        instance!.GetType().GetMethod("Register")!.Invoke(instance, [services, genConfig, number]);
+                    }
+                    catch (ModelException me)
+                    {
+                        HasError = true;
+                        AnsiConsole.MarkupLine($"[red]{me.Message.EscapeMarkup()}[/]");
+                        AnsiConsole.WriteLine();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private void RemoveUnusedCustomModules()
+    {
+        var unused = TopModelLock.Custom.Keys.Except(Config.CustomGenerators).ToList();
+        if (unused.Count > 0)
+        {
+            foreach (var key in unused)
+            {
+                TopModelLock.Custom.Remove(key);
+                var hashFile = CustomModule.GetHashFilePath(ModgenRoot, key);
+                if (File.Exists(hashFile))
+                {
+                    File.Delete(hashFile);
+                }
+            }
+
+            TopModelLock.Write();
+        }
+    }
+
+    private async Task RunGeneration(CancellationToken cancellationToken)
+    {
+        var provider = services.BuildServiceProvider();
+        providers.Add(provider);
+
+        var modelStore = provider.GetRequiredService<ModelStore>();
+
+        modelStore.DisableLockfile = ExcludedTags.Any();
+
+        modelStore.OnResolve += he =>
+        {
+            HasError = he;
+        };
+
+        await modelStore.LoadFromConfig(WatchMode, TopModelLock, storeConfig, cancellationToken);
+    }
+}

--- a/TopModel.Generator/VersionUtils.cs
+++ b/TopModel.Generator/VersionUtils.cs
@@ -1,0 +1,16 @@
+using System.Reflection;
+
+namespace TopModel.Generator;
+
+public static class VersionUtils
+{
+    public static readonly int DotnetMajor = Environment.Version.Major;
+    public static readonly int MajorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
+    public static readonly int MinorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
+
+    public static readonly string Version = Assembly
+        .GetEntryAssembly()!
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+        .InformationalVersion;
+    public static bool Prerelease => Version.Contains('-');
+}

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -12,12 +12,8 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace TopModel.LanguageServer;
 
-public class CodeActionHandler(
-    ModelStore modelStore,
-    ILanguageServerFacade facade,
-    ModelFileCache modelFileCache,
-    ModelConfig config
-) : CodeActionHandlerBase
+public class CodeActionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade, ModelFileCache modelFileCache)
+    : CodeActionHandlerBase
 {
     public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
     {
@@ -29,11 +25,17 @@ public class CodeActionHandler(
         CancellationToken cancellationToken
     )
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return CommandOrCodeActionContainer.From(Array.Empty<CommandOrCodeAction>());
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var modelFile = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var modelFile = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         var codeActions = new List<CommandOrCodeAction>();
         if (modelFile != null)
         {
@@ -56,27 +58,39 @@ public class CodeActionHandler(
                 switch (modelErrorType)
                 {
                     case ErrorType.TMD0002:
-                        codeActions.AddRange(GetCodeActionMissingClassImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingClassImport(request, diagnostic, modelFile, modelStore)
+                        );
                         codeActions.AddRange(GetCodeActionAddClass(request, diagnostic, modelFile));
                         break;
                     case ErrorType.TMD0003:
-                        codeActions.AddRange(GetCodeActionCreateDomain(request, diagnostic));
+                        codeActions.AddRange(GetCodeActionCreateDomain(request, diagnostic, modelStore));
                         break;
                     case ErrorType.TMD0005:
-                        codeActions.AddRange(GetCodeActionMissingDecoratorImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingDecoratorImport(request, diagnostic, modelFile, modelStore)
+                        );
                         break;
                     case ErrorType.TMD0006:
-                        codeActions.AddRange(GetCodeActionMissingEndpointImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingEndpointImport(request, diagnostic, modelFile, modelStore)
+                        );
                         break;
                     case ErrorType.TMD2001:
-                        codeActions.AddRange(GetCodeActionMissingAnnotationImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingAnnotationImport(request, diagnostic, modelFile, modelStore)
+                        );
                         codeActions.AddRange(GetCodeActionAddAnnotation(request, diagnostic, modelFile));
                         break;
                     case ErrorType.TMD4002:
-                        codeActions.AddRange(GetCodeActionMissingDataFlowImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingDataFlowImport(request, diagnostic, modelFile, modelStore)
+                        );
                         break;
                     case ErrorType.TMD9008:
-                        codeActions.AddRange(GetCodeActionMissingWithReverseImport(request, diagnostic, modelFile));
+                        codeActions.AddRange(
+                            GetCodeActionMissingWithReverseImport(request, diagnostic, modelFile, modelStore)
+                        );
                         break;
                     default:
                         break;
@@ -94,7 +108,7 @@ public class CodeActionHandler(
     {
         return new()
         {
-            DocumentSelector = config.GetDocumentSelector(),
+            DocumentSelector = registry.GetCombinedDocumentSelector(),
             ResolveProvider = true,
             CodeActionKinds = new List<CodeActionKind>
             {
@@ -134,11 +148,11 @@ public class CodeActionHandler(
                                 NewText =
                                     @$"
 ---
-annotation: 
+annotation:
   name: {annotationName}
-  description: 
+  description:
   target:
-    - 
+    -
 ",
                                 Range = new Range(text.Length, 0, text.Length, 0),
                             },
@@ -177,11 +191,11 @@ annotation:
                                 NewText =
                                     @$"
 ---
-class: 
+class:
   name: {className}
-  comment: 
+  comment:
   properties:
-    - 
+    -
 ",
                                 Range = new Range(text.Length, 0, text.Length, 0),
                             },
@@ -194,7 +208,8 @@ class:
 
     protected IEnumerable<CommandOrCodeAction> GetCodeActionCreateDomain(
         CodeActionParams request,
-        Diagnostic diagnostic
+        Diagnostic diagnostic,
+        ModelStore modelStore
     )
     {
         var text = modelFileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
@@ -227,7 +242,7 @@ class:
 ---
 domain:
   name: {domainName}
-  label: 
+  label:
 ",
                                     },
                                 ],
@@ -298,7 +313,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingAnnotationImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (decoratorName, useIndex) = GetImport(request, diagnostic, modelFile);
@@ -312,7 +328,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingClassImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (className, useIndex) = GetImport(request, diagnostic, modelFile);
@@ -324,7 +341,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDataFlowImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (dataFlowName, useIndex) = GetImport(request, diagnostic, modelFile);
@@ -338,7 +356,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingDecoratorImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (decoratorName, useIndex) = GetImport(request, diagnostic, modelFile);
@@ -352,7 +371,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingEndpointImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (endpointName, useIndex) = GetImport(request, diagnostic, modelFile);
@@ -366,7 +386,8 @@ domain:
     protected IEnumerable<CommandOrCodeAction> GetCodeActionMissingWithReverseImport(
         CodeActionParams request,
         Diagnostic diagnostic,
-        ModelFile modelFile
+        ModelFile modelFile,
+        ModelStore modelStore
     )
     {
         var (_, objet) = modelFile.GetObjetAtPosition(diagnostic.Range.Start);
@@ -389,6 +410,8 @@ domain:
 
     protected CodeAction GetCodeActionOrganizeImports(CodeActionParams request, ModelFile modelFile)
     {
+        var entry = registry.GetPrimaryForFile(request.TextDocument.Uri.GetFileSystemPath())!;
+        var modelStore = entry.Store;
         var uses = modelFile.Uses.Except(modelStore.GetUselessImports(modelFile));
         var start = modelFile.Uses[0].ToRange()!.Start;
         var end = modelFile.Uses[^1].ToRange()!.End;

--- a/TopModel.LanguageServer/CodeActionHandler.cs
+++ b/TopModel.LanguageServer/CodeActionHandler.cs
@@ -2,7 +2,6 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
 using TopModel.Core.Model;
@@ -12,8 +11,7 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace TopModel.LanguageServer;
 
-public class CodeActionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade, ModelFileCache modelFileCache)
-    : CodeActionHandlerBase
+public class CodeActionHandler(ModelStoreRegistry registry, ModelFileCache modelFileCache) : CodeActionHandlerBase
 {
     public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
     {
@@ -35,7 +33,7 @@ public class CodeActionHandler(ModelStoreRegistry registry, ILanguageServerFacad
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var modelFile = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var modelFile = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         var codeActions = new List<CommandOrCodeAction>();
         if (modelFile != null)
         {
@@ -141,7 +139,7 @@ public class CodeActionHandler(ModelStoreRegistry registry, ILanguageServerFacad
                 {
                     Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [new Uri(facade.GetFilePath(modelFile))] =
+                        [new Uri(modelFile.GetFilePath())] =
                         [
                             new()
                             {
@@ -152,7 +150,7 @@ annotation:
   name: {annotationName}
   description:
   target:
-    -
+    - 
 ",
                                 Range = new Range(text.Length, 0, text.Length, 0),
                             },
@@ -184,7 +182,7 @@ annotation:
                 {
                     Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [new Uri(facade.GetFilePath(modelFile))] =
+                        [new Uri(modelFile.GetFilePath())] =
                         [
                             new()
                             {
@@ -195,7 +193,7 @@ class:
   name: {className}
   comment:
   properties:
-    -
+    - 
 ",
                                 Range = new Range(text.Length, 0, text.Length, 0),
                             },
@@ -220,7 +218,7 @@ class:
             .Files.Where(f => f.Domains.Count > 0)
             .Select(f =>
             {
-                var lastLine = File.ReadAllLines(facade.GetFilePath(f)).Length;
+                var lastLine = File.ReadAllLines(f.GetFilePath()).Length;
                 return (CommandOrCodeAction)
                     new CodeAction
                     {
@@ -232,7 +230,7 @@ class:
                         {
                             Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                             {
-                                [new Uri(facade.GetFilePath(f))] =
+                                [new Uri(f.GetFilePath())] =
                                 [
                                     new()
                                     {
@@ -294,7 +292,7 @@ domain:
                 {
                     Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [new Uri(facade.GetFilePath(modelFile))] =
+                        [new Uri(modelFile.GetFilePath())] =
                         [
                             new()
                             {
@@ -398,7 +396,7 @@ domain:
         }
 
         var targetFile = objet.GetFile();
-        var fileText = File.ReadAllLines(facade.GetFilePath(targetFile));
+        var fileText = File.ReadAllLines(targetFile.GetFilePath());
 
         var (className, useIndex) = GetImport(objet.GetName()!, fileText, targetFile);
         return modelStore
@@ -496,7 +494,7 @@ domain:
                 {
                     Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
                     {
-                        [new Uri(facade.GetFilePath(targetFile))] =
+                        [new Uri(targetFile.GetFilePath())] =
                         [
                             new()
                             {

--- a/TopModel.LanguageServer/CodeLensHandler.cs
+++ b/TopModel.LanguageServer/CodeLensHandler.cs
@@ -2,13 +2,11 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    : CodeLensHandlerBase
+public class CodeLensHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : CodeLensHandlerBase
 {
     public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
     {
@@ -17,11 +15,16 @@ public class CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade
 
     public override async Task<CodeLensContainer?> Handle(CodeLensParams request, CancellationToken cancellationToken)
     {
-        await modelStore.WaitForUpdates(cancellationToken);
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return new();
+        }
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var modelStore = entry.Store;
+        await modelStore.WaitForUpdates(cancellationToken);
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file != null)
         {
             return new(
@@ -106,6 +109,6 @@ public class CodeLensHandler(ModelStore modelStore, ILanguageServerFacade facade
         ClientCapabilities clientCapabilities
     )
     {
-        return new CodeLensRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new CodeLensRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/CodeLensHandler.cs
+++ b/TopModel.LanguageServer/CodeLensHandler.cs
@@ -1,12 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class CodeLensHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : CodeLensHandlerBase
+public class CodeLensHandler(ModelStoreRegistry registry) : CodeLensHandlerBase
 {
     public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
     {
@@ -24,7 +23,7 @@ public class CodeLensHandler(ModelStoreRegistry registry, ILanguageServerFacade 
 
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file != null)
         {
             return new(

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -1,15 +1,13 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
 using TopModel.Core.Model;
 
 namespace TopModel.LanguageServer;
 
-public class CompletionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade, ModelFileCache fileCache)
-    : CompletionHandlerBase
+public class CompletionHandler(ModelStoreRegistry registry, ModelFileCache fileCache) : CompletionHandlerBase
 {
     private static readonly char[] Separators =
     [
@@ -55,7 +53,7 @@ public class CompletionHandler(ModelStoreRegistry registry, ILanguageServerFacad
         {
             return new();
         }
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file == null || currentLine == string.Empty)
         {
             return new();

--- a/TopModel.LanguageServer/CompletionHandler.cs
+++ b/TopModel.LanguageServer/CompletionHandler.cs
@@ -8,12 +8,8 @@ using TopModel.Core.Model;
 
 namespace TopModel.LanguageServer;
 
-public class CompletionHandler(
-    ModelStore modelStore,
-    ILanguageServerFacade facade,
-    ModelFileCache fileCache,
-    ModelConfig config
-) : CompletionHandlerBase
+public class CompletionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade, ModelFileCache fileCache)
+    : CompletionHandlerBase
 {
     private static readonly char[] Separators =
     [
@@ -42,19 +38,24 @@ public class CompletionHandler(
 
     public override async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return new();
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var text = fileCache.GetFile(request.TextDocument.Uri.GetFileSystemPath());
+        var text = fileCache.GetFile(filePath);
         var currentLine = text.ElementAtOrDefault(request.Position.Line);
 
         if (currentLine == null)
         {
             return new();
         }
-
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file == null || currentLine == string.Empty)
         {
             return new();
@@ -77,50 +78,50 @@ public class CompletionHandler(
             || rootObject == "converter" && (currentKey == "to" || currentKey == "from")
         )
         {
-            return CompleteDomain(request);
+            return CompleteDomain(request, modelStore);
         }
 
         List<string> classCompleteKeys = ["association", "composition", "class", "extends"];
 
         if (classCompleteKeys.Contains(currentKey) && parentKey != currentKey)
         {
-            return CompleteClass(request, file, useIndex);
+            return CompleteClass(request, file, useIndex, modelStore);
         }
 
         if (currentKey == "endpoint")
         {
-            return CompleteEndpoint(request, file, useIndex);
+            return CompleteEndpoint(request, file, useIndex, modelStore);
         }
 
         // Tags
         if (currentKey == "tags")
         {
-            return CompleteTag(request, file);
+            return CompleteTag(request, file, modelStore);
         }
 
         // Use
         if (currentKey == "uses")
         {
-            return CompleteFile(request, file);
+            return CompleteFile(request, file, modelStore);
         }
         // Décorateur
         else if (currentKey.Contains("decorator"))
         {
-            return CompleteDecorator(request, file, useIndex);
+            return CompleteDecorator(request, file, useIndex, modelStore);
         }
         // Annotation
         else if (currentKey.ToLowerInvariant().Contains("annotation"))
         {
-            return CompleteAnnotation(request, file, useIndex);
+            return CompleteAnnotation(request, file, useIndex, modelStore);
         }
         // DataFlow
         else if (currentKey == "dependsOn")
         {
-            return CompleteDataFlow(request, file, useIndex);
+            return CompleteDataFlow(request, file, useIndex, modelStore);
         }
         else
         {
-            return CompleteProperty(request, text, currentLine, file);
+            return CompleteProperty(request, text, currentLine, file, modelStore);
         }
     }
 
@@ -129,7 +130,7 @@ public class CompletionHandler(
         ClientCapabilities clientCapabilities
     )
     {
-        return new CompletionRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new CompletionRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 
     private static (string Key, int Line, int End, bool IsKey) GetCurrentKey(string[] text, int line, int position)
@@ -337,7 +338,12 @@ public class CompletionHandler(
         return 0;
     }
 
-    private CompletionList CompleteAnnotation(CompletionParams request, ModelFile file, int useIndex)
+    private CompletionList CompleteAnnotation(
+        CompletionParams request,
+        ModelFile file,
+        int useIndex,
+        ModelStore modelStore
+    )
     {
         var searchText = GetSearchText(request);
         var availableAnnotations = new HashSet<Annotation>(modelStore.GetAvailableAnnotations(file));
@@ -379,7 +385,7 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteClass(CompletionParams request, ModelFile file, int useIndex)
+    private CompletionList CompleteClass(CompletionParams request, ModelFile file, int useIndex, ModelStore modelStore)
     {
         var searchText = GetSearchText(request);
         var availableClasses = new HashSet<Class>(modelStore.GetAvailableClasses(file));
@@ -420,7 +426,12 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteDataFlow(CompletionParams request, ModelFile file, int useIndex)
+    private CompletionList CompleteDataFlow(
+        CompletionParams request,
+        ModelFile file,
+        int useIndex,
+        ModelStore modelStore
+    )
     {
         var searchText = GetSearchText(request);
         var availableDataFlows = new HashSet<DataFlow>(modelStore.GetAvailableDataFlows(file));
@@ -461,7 +472,12 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteDecorator(CompletionParams request, ModelFile file, int useIndex)
+    private CompletionList CompleteDecorator(
+        CompletionParams request,
+        ModelFile file,
+        int useIndex,
+        ModelStore modelStore
+    )
     {
         var searchText = GetSearchText(request);
         var availableDecorators = new HashSet<Decorator>(modelStore.GetAvailableDecorators(file));
@@ -503,7 +519,7 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteDomain(CompletionParams request)
+    private CompletionList CompleteDomain(CompletionParams request, ModelStore modelStore)
     {
         var searchText = GetSearchText(request);
         return new(
@@ -521,7 +537,12 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteEndpoint(CompletionParams request, ModelFile file, int useIndex)
+    private CompletionList CompleteEndpoint(
+        CompletionParams request,
+        ModelFile file,
+        int useIndex,
+        ModelStore modelStore
+    )
     {
         var searchText = GetSearchText(request);
         var availableEndpoints = new HashSet<Endpoint>(modelStore.GetAvailableEndpoints(file));
@@ -562,7 +583,7 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteFile(CompletionParams request, ModelFile file)
+    private CompletionList CompleteFile(CompletionParams request, ModelFile file, ModelStore modelStore)
     {
         var searchText = GetSearchText(request);
         return new(
@@ -581,7 +602,13 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteProperty(CompletionParams request, string[] text, string currentLine, ModelFile file)
+    private CompletionList CompleteProperty(
+        CompletionParams request,
+        string[] text,
+        string currentLine,
+        ModelFile file,
+        ModelStore modelStore
+    )
     {
         // Alias, propriété d'association ou propriété de flux de données
         string? className = null;
@@ -783,7 +810,7 @@ public class CompletionHandler(
         );
     }
 
-    private CompletionList CompleteTag(CompletionParams request, ModelFile file)
+    private CompletionList CompleteTag(CompletionParams request, ModelFile file, ModelStore modelStore)
     {
         var searchText = GetSearchText(request);
         return new(

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -1,13 +1,12 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.Model;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class DefinitionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : DefinitionHandlerBase
+public class DefinitionHandler(ModelStoreRegistry registry) : DefinitionHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<LocationOrLocationLinks?> Handle(
@@ -25,7 +24,7 @@ public class DefinitionHandler(ModelStoreRegistry registry, ILanguageServerFacad
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file != null)
         {
             var (reference, objet) = file.GetObjetAtPosition(request.Position);
@@ -59,7 +58,7 @@ public class DefinitionHandler(ModelStoreRegistry registry, ILanguageServerFacad
                             },
                         },
                         TargetSelectionRange = selectionRange,
-                        TargetUri = facade.GetFilePath(objet.GetFile()),
+                        TargetUri = objet.GetFile().GetFilePath(),
                     }
                 );
             }
@@ -87,7 +86,7 @@ public class DefinitionHandler(ModelStoreRegistry registry, ILanguageServerFacad
                                 0,
                                 0
                             ),
-                            TargetUri = facade.GetFilePath(usedFile),
+                            TargetUri = usedFile.GetFilePath(),
                         }
                     );
                 }

--- a/TopModel.LanguageServer/DefinitionHandler.cs
+++ b/TopModel.LanguageServer/DefinitionHandler.cs
@@ -2,14 +2,12 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.Model;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class DefinitionHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    : DefinitionHandlerBase
+public class DefinitionHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : DefinitionHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<LocationOrLocationLinks?> Handle(
@@ -17,11 +15,17 @@ public class DefinitionHandler(ModelStore modelStore, ILanguageServerFacade faca
         CancellationToken cancellationToken
     )
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return new();
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file != null)
         {
             var (reference, objet) = file.GetObjetAtPosition(request.Position);
@@ -98,6 +102,6 @@ public class DefinitionHandler(ModelStore modelStore, ILanguageServerFacade faca
         ClientCapabilities clientCapabilities
     )
     {
-        return new DefinitionRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new DefinitionRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/DocumentLinkHandler.cs
+++ b/TopModel.LanguageServer/DocumentLinkHandler.cs
@@ -1,11 +1,10 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using TopModel.Core;
 
 namespace TopModel.LanguageServer;
 
-public class DocumentLinkHandler(ModelStore modelStore) : DocumentLinkHandlerBase
+public class DocumentLinkHandler(ModelStoreRegistry registry) : DocumentLinkHandlerBase
 {
     public override Task<DocumentLink> Handle(DocumentLink request, CancellationToken cancellationToken)
     {
@@ -17,7 +16,7 @@ public class DocumentLinkHandler(ModelStore modelStore) : DocumentLinkHandlerBas
         CancellationToken cancellationToken
     )
     {
-        await modelStore.WaitForUpdates(cancellationToken);
+        await registry.WaitForAllUpdatesAsync(cancellationToken);
 
         var lockFile = new FileInfo(
             Path.GetFullPath(

--- a/TopModel.LanguageServer/DocumentSymbolHandler.cs
+++ b/TopModel.LanguageServer/DocumentSymbolHandler.cs
@@ -2,12 +2,11 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class DocumentSymbolHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
+public class DocumentSymbolHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
     : DocumentSymbolHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
@@ -16,6 +15,14 @@ public class DocumentSymbolHandler(ModelStore modelStore, ILanguageServerFacade 
         CancellationToken cancellationToken
     )
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return new();
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
         var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri);
@@ -145,6 +152,6 @@ public class DocumentSymbolHandler(ModelStore modelStore, ILanguageServerFacade 
         ClientCapabilities clientCapabilities
     )
     {
-        return new DocumentSymbolRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new DocumentSymbolRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/DocumentSymbolHandler.cs
+++ b/TopModel.LanguageServer/DocumentSymbolHandler.cs
@@ -1,13 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class DocumentSymbolHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
-    : DocumentSymbolHandlerBase
+public class DocumentSymbolHandler(ModelStoreRegistry registry) : DocumentSymbolHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<SymbolInformationOrDocumentSymbolContainer?> Handle(
@@ -25,7 +23,7 @@ public class DocumentSymbolHandler(ModelStoreRegistry registry, ILanguageServerF
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.TextDocument.Uri);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == request.TextDocument.Uri);
         if (file == null)
         {
             return new();

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -1,12 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.Model;
 
 namespace TopModel.LanguageServer;
 
-public class HoverHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : HoverHandlerBase
+public class HoverHandler(ModelStoreRegistry registry) : HoverHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<Hover?> Handle(HoverParams request, CancellationToken cancellationToken)
@@ -21,7 +20,7 @@ public class HoverHandler(ModelStoreRegistry registry, ILanguageServerFacade fac
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file != null)
         {
             var (reference, objet) = file.GetObjetAtPosition(request.Position);

--- a/TopModel.LanguageServer/HoverHandler.cs
+++ b/TopModel.LanguageServer/HoverHandler.cs
@@ -2,21 +2,26 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.Model;
 
 namespace TopModel.LanguageServer;
 
-public class HoverHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config) : HoverHandlerBase
+public class HoverHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : HoverHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<Hover?> Handle(HoverParams request, CancellationToken cancellationToken)
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return null;
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file != null)
         {
             var (reference, objet) = file.GetObjetAtPosition(request.Position);
@@ -57,6 +62,6 @@ public class HoverHandler(ModelStore modelStore, ILanguageServerFacade facade, M
         ClientCapabilities clientCapabilities
     )
     {
-        return new HoverRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new HoverRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/Mermaid.cs
+++ b/TopModel.LanguageServer/Mermaid.cs
@@ -2,4 +2,4 @@
 
 namespace TopModel.LanguageServer;
 
-public record Mermaid(string Diagram, string Module, string FileName, MermaidScope Scope);
+public record Mermaid(string Diagram, string App, string Module, string FileName, MermaidScope Scope);

--- a/TopModel.LanguageServer/MermaidHandler.cs
+++ b/TopModel.LanguageServer/MermaidHandler.cs
@@ -1,43 +1,62 @@
 ﻿using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Utils.Mermaid;
 
 namespace TopModel.LanguageServer;
 
-public class MermaidHandler(ModelStore modelStore, ILanguageServerFacade facade)
+public class MermaidHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
     : IRequestHandler<MermaidRequest, Mermaid>,
         IJsonRpcHandler
 {
     public string GetFileName(string uri)
     {
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
-        if (file is null)
-        {
-            return string.Empty;
-        }
-
-        return file!.Name.Split("/")[^1];
+        var entry = FindEntryForUri(uri);
+        var file = entry?.Store.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
+        return file?.Name.Split("/")[^1] ?? string.Empty;
     }
 
     public string GetModule(string uri)
     {
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
-        if (file is null)
-        {
-            return string.Empty;
-        }
+        var entry = FindEntryForUri(uri);
+        var file = entry?.Store.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
+        return file?.Namespace.Module ?? string.Empty;
+    }
 
-        return file!.Namespace.Module;
+    public string GettApp(string uri)
+    {
+        var entry = FindEntryForUri(uri);
+        return entry?.Config.App ?? string.Empty;
     }
 
     /// <inheritdoc cref="IRequestHandler{TRequest, TResponse}.Handle" />
     public async Task<Mermaid> Handle(MermaidRequest request, CancellationToken cancellationToken)
     {
-        await modelStore.WaitForUpdates(cancellationToken);
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.Uri);
-        var result = MermaidUtils.GetDiagram(modelStore, file, request.Scope);
-        return new Mermaid(result, GetModule(request.Uri), GetFileName(request.Uri), request.Scope);
+        await registry.WaitForAllUpdatesAsync(cancellationToken);
+
+        var entry = FindEntryForUri(request.Uri);
+        var modelStore = entry?.Store;
+        var file = modelStore?.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.Uri);
+        var result = MermaidUtils.GetDiagram(modelStore!, file, request.Scope);
+        return new Mermaid(
+            result,
+            GettApp(request.Uri),
+            GetModule(request.Uri),
+            GetFileName(request.Uri),
+            request.Scope
+        );
+    }
+
+    private ModelStoreEntry? FindEntryForUri(string uri)
+    {
+        foreach (var entry in registry.All)
+        {
+            if (entry.Store.Files.Any(f => facade.GetFilePath(f) == uri))
+            {
+                return entry;
+            }
+        }
+
+        return null;
     }
 }

--- a/TopModel.LanguageServer/MermaidHandler.cs
+++ b/TopModel.LanguageServer/MermaidHandler.cs
@@ -1,25 +1,22 @@
 ﻿using MediatR;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Utils.Mermaid;
 
 namespace TopModel.LanguageServer;
 
-public class MermaidHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
-    : IRequestHandler<MermaidRequest, Mermaid>,
-        IJsonRpcHandler
+public class MermaidHandler(ModelStoreRegistry registry) : IRequestHandler<MermaidRequest, Mermaid>, IJsonRpcHandler
 {
     public string GetFileName(string uri)
     {
         var entry = FindEntryForUri(uri);
-        var file = entry?.Store.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
+        var file = entry?.Store.Files.SingleOrDefault(f => f.GetFilePath() == uri);
         return file?.Name.Split("/")[^1] ?? string.Empty;
     }
 
     public string GetModule(string uri)
     {
         var entry = FindEntryForUri(uri);
-        var file = entry?.Store.Files.SingleOrDefault(f => facade.GetFilePath(f) == uri);
+        var file = entry?.Store.Files.SingleOrDefault(f => f.GetFilePath() == uri);
         return file?.Namespace.Module ?? string.Empty;
     }
 
@@ -36,7 +33,7 @@ public class MermaidHandler(ModelStoreRegistry registry, ILanguageServerFacade f
 
         var entry = FindEntryForUri(request.Uri);
         var modelStore = entry?.Store;
-        var file = modelStore?.Files.SingleOrDefault(f => facade.GetFilePath(f) == request.Uri);
+        var file = modelStore?.Files.SingleOrDefault(f => f.GetFilePath() == request.Uri);
         var result = MermaidUtils.GetDiagram(modelStore!, file, request.Scope);
         return new Mermaid(
             result,
@@ -51,7 +48,7 @@ public class MermaidHandler(ModelStoreRegistry registry, ILanguageServerFacade f
     {
         foreach (var entry in registry.All)
         {
-            if (entry.Store.Files.Any(f => facade.GetFilePath(f) == uri))
+            if (entry.Store.Files.Any(f => f.GetFilePath() == uri))
             {
                 return entry;
             }

--- a/TopModel.LanguageServer/ModelStoreEntry.cs
+++ b/TopModel.LanguageServer/ModelStoreEntry.cs
@@ -1,0 +1,8 @@
+﻿using TopModel.Core;
+
+namespace TopModel.LanguageServer;
+
+/// <summary>
+/// Regroupe le ModelStore et sa ModelConfig associée pour un fichier de configuration topmodel.
+/// </summary>
+public record ModelStoreEntry(ModelStore Store, ModelConfig Config);

--- a/TopModel.LanguageServer/ModelStoreRegistry.cs
+++ b/TopModel.LanguageServer/ModelStoreRegistry.cs
@@ -1,0 +1,65 @@
+﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using TopModel.Core;
+
+namespace TopModel.LanguageServer;
+
+/// <summary>
+/// Registre des ModelStore, un par fichier de configuration topmodel trouvé dans le workspace.
+/// Fournit le routing document → store(s) utilisé par tous les handlers LSP.
+/// </summary>
+public class ModelStoreRegistry
+{
+    private readonly List<ModelStoreEntry> _entries = [];
+
+    public bool IsEmpty => _entries.Count == 0;
+
+    public IReadOnlyList<ModelStoreEntry> All => _entries;
+
+    /// <summary>
+    /// Retourne toutes les entrées dont le ModelRoot couvre un fichier donné.
+    /// Utilisé pour les diagnostics et les références, où un fichier peut appartenir
+    /// à plusieurs configs (racines imbriquées ou identiques).
+    /// </summary>
+    public IEnumerable<ModelStoreEntry> GetAllForFile(string filePath) =>
+        _entries.Where(e =>
+            !Path.GetRelativePath(Path.GetFullPath(e.Config.ModelRoot), Path.GetFullPath(filePath)).StartsWith("..")
+        );
+
+    /// <summary>
+    /// Retourne un DocumentSelector couvrant les globs de tous les configs enregistrés.
+    /// Utilisé dans CreateRegistrationOptions des handlers.
+    /// </summary>
+    public TextDocumentSelector GetCombinedDocumentSelector()
+    {
+        if (_entries.Count == 0)
+        {
+            return TextDocumentSelector.ForPattern("**/*.tmd");
+        }
+
+        var patterns = _entries
+            .SelectMany(e => e.Config.ModelFilePathsGlobs.Select(g => $"{e.Config.ModelRoot}/{g}"))
+            .Distinct()
+            .ToArray();
+
+        return TextDocumentSelector.ForPattern(patterns);
+    }
+
+    /// <summary>
+    /// Retourne l'entrée la plus spécifique pour un fichier donné (prefixe ModelRoot le plus long).
+    /// Utilisé pour les opérations document-scoped : hover, definition, completion, semantic tokens…
+    /// </summary>
+    public ModelStoreEntry? GetPrimaryForFile(string filePath) =>
+        _entries
+            .Where(e =>
+                !Path.GetRelativePath(Path.GetFullPath(e.Config.ModelRoot), Path.GetFullPath(filePath)).StartsWith("..")
+            )
+            .MaxBy(e => Path.GetFullPath(e.Config.ModelRoot).Length);
+
+    public void Register(ModelStoreEntry entry) => _entries.Add(entry);
+
+    /// <summary>
+    /// Attend que tous les stores aient terminé leurs mises à jour en cours.
+    /// </summary>
+    public Task WaitForAllUpdatesAsync(CancellationToken ct) =>
+        Task.WhenAll(_entries.Select(e => e.Store.WaitForUpdates(ct)));
+}

--- a/TopModel.LanguageServer/ModelWatcher.cs
+++ b/TopModel.LanguageServer/ModelWatcher.cs
@@ -44,7 +44,7 @@ public class ModelWatcher(ILanguageServerFacade facade) : IModelWatcher
                 new()
                 {
                     Diagnostics = new Container<Diagnostic>(diagnostics.ToArray()),
-                    Uri = new Uri(facade.GetFilePath(fileErrors.Key)),
+                    Uri = new Uri(fileErrors.Key.GetFilePath()),
                 }
             );
         }

--- a/TopModel.LanguageServer/OmnisharpExtensions.cs
+++ b/TopModel.LanguageServer/OmnisharpExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core;
 using TopModel.Core.FileModel;
 using TopModel.Core.Model;
@@ -9,10 +8,8 @@ namespace TopModel.LanguageServer;
 
 public static class OmnisharpExtensions
 {
-    public static string GetFilePath(this ILanguageServerFacade facade, ModelFile file)
-    {
-        return facade.Workspace.ClientSettings.RootPath + file.Path[1..].Replace('/', Path.DirectorySeparatorChar);
-    }
+    public static string GetFilePath(this ModelFile file) =>
+        Path.GetFullPath(file.Path.Replace('/', Path.DirectorySeparatorChar));
 
     public static string? GetName(this object objet)
     {

--- a/TopModel.LanguageServer/Program.cs
+++ b/TopModel.LanguageServer/Program.cs
@@ -1,3 +1,5 @@
+using System.CommandLine;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -6,6 +8,11 @@ using TopModel.Core;
 using TopModel.Core.Loaders;
 using TopModel.LanguageServer;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+var command = new RootCommand { TopModelCli.FileOption };
+var result = command.Parse(args);
+var filesFromArgs = result.GetValue(TopModelCli.FileOption) ?? [];
 
 var fileChecker = new FileChecker();
 
@@ -47,11 +54,11 @@ var server = await LanguageServer.From(options =>
                 var rootPath = ResolveRootPath(request.RootPath, request.RootUri?.ToString());
 
                 var registry = lspServer.Services.GetRequiredService<ModelStoreRegistry>();
+                var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
 
-                var configFiles =
-                    args.Length > 0
-                        ? [new FileInfo(args[0])]
-                        : ConfigUtils.FindConfigFiles(rootPath ?? Directory.GetCurrentDirectory()).ToArray();
+                var configFiles = filesFromArgs.Any()
+                    ? filesFromArgs.ToArray()
+                    : ConfigUtils.FindConfigFiles(rootPath ?? Directory.GetCurrentDirectory(), pattern).ToArray();
 
                 var sp = lspServer.Services;
                 var loggerFactory = sp.GetRequiredService<ILoggerFactory>();

--- a/TopModel.LanguageServer/Program.cs
+++ b/TopModel.LanguageServer/Program.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
 using TopModel.Core;
 using TopModel.Core.Loaders;
 using TopModel.LanguageServer;
+using TopModel.Utils;
+
+var fileChecker = new FileChecker();
 
 var server = await LanguageServer.From(options =>
     options
@@ -12,48 +16,17 @@ var server = await LanguageServer.From(options =>
         .ConfigureLogging(logging => logging.AddLanguageProtocolLogging().SetMinimumLevel(LogLevel.Information))
         .WithServices(services =>
         {
-            var fileChecker = new FileChecker();
-            var file = new FileInfo(args.Length > 0 ? args[0] : "topmodel.config");
-            using var text = file.OpenText();
-            var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(file.DirectoryName!);
-
-            foreach (var (configName, genConfigMaps) in config.Generators)
-            {
-                for (var j = 0; j < genConfigMaps.Count(); j++)
-                {
-                    var genConfigMap = genConfigMaps.ElementAt(j);
-                    var number = j + 1;
-
-                    var genConfig = fileChecker.GetWatcherConfigBase(genConfigMap);
-                    genConfig.InitVariables(config.App, number);
-                    genConfig.Name ??= $"{configName}@{number}";
-                    try
-                    {
-                        config.Configs.Add(genConfig.Name, genConfig);
-                    }
-                    catch (ArgumentException)
-                    {
-                        // On ignore l'erreur, tant pis si le nom est déjà utilisé.
-                    }
-
-                    foreach (var referencedTag in genConfig.ReferencedTags)
-                    {
-                        if (config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
-                        {
-                            genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
-                        }
-                        else
-                        {
-                            // On ignore l'erreur, tant pis pour la configuration manquante.
-                        }
-                    }
-                }
-            }
-
             services
-                .AddModelStore(fileChecker, config)
-                .AddSingleton<IModelWatcher, ModelWatcher>()
-                .AddSingleton<ModelFileCache>();
+                .AddSingleton<ModelStoreRegistry>()
+                .AddSingleton<ModelFileCache>()
+                .AddSingleton(fileChecker)
+                .AddSingleton<AnnotationLoader>()
+                .AddSingleton<DomainLoader>()
+                .AddSingleton<ConverterLoader>()
+                .AddSingleton<DataFlowLoader>()
+                .AddSingleton<TranslationStore>()
+                .AddSingleton<ModelWatcher>()
+                .AddLocalization();
         })
         .WithHandler<TextDocumentSyncHandler>()
         .WithHandler<HoverHandler>()
@@ -69,14 +42,134 @@ var server = await LanguageServer.From(options =>
         .WithHandler<DocumentLinkHandler>()
         .AddHandler<MermaidHandler>("mermaid")
         .OnInitialize(
-            async (server, _, __) =>
+            async (lspServer, request, ct) =>
             {
-                var modelStore = server.Services.GetRequiredService<ModelStore>();
-                modelStore.KeepFileErrorsInReferenceResolution = true;
-                await modelStore.LoadFromConfig(watch: true, ct: __);
+                var rootPath = ResolveRootPath(request.RootPath, request.RootUri?.ToString());
+
+                var registry = lspServer.Services.GetRequiredService<ModelStoreRegistry>();
+
+                var configFiles =
+                    args.Length > 0
+                        ? [new FileInfo(args[0])]
+                        : ConfigUtils.FindConfigFiles(rootPath ?? Directory.GetCurrentDirectory()).ToArray();
+
+                var sp = lspServer.Services;
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+                var localizer = sp.GetRequiredService<IStringLocalizer<ErrorType>>();
+                var annotationLoader = sp.GetRequiredService<AnnotationLoader>();
+                var domainLoader = sp.GetRequiredService<DomainLoader>();
+                var converterLoader = sp.GetRequiredService<ConverterLoader>();
+                var dataFlowLoader = sp.GetRequiredService<DataFlowLoader>();
+                var translationStore = sp.GetRequiredService<TranslationStore>();
+                var modelWatcher = sp.GetRequiredService<ModelWatcher>();
+                Parallel.ForEach(
+                    configFiles.Where(f => f.Exists),
+                    configFile =>
+                    {
+                        var config = LoadConfig(fileChecker, configFile);
+
+                        var propertyLoader = new PropertyLoader(fileChecker, config);
+                        var classLoader = new ClassLoader(config, fileChecker, propertyLoader);
+                        var decoratorLoader = new DecoratorLoader(fileChecker, propertyLoader);
+                        var endpointLoader = new EndpointLoader(fileChecker, propertyLoader);
+                        var modelFileLoader = new ModelFileLoader(
+                            config,
+                            loggerFactory.CreateLogger<ModelFileLoader>(),
+                            annotationLoader,
+                            classLoader,
+                            dataFlowLoader,
+                            fileChecker,
+                            decoratorLoader,
+                            converterLoader,
+                            endpointLoader,
+                            domainLoader
+                        );
+
+                        var store = new ModelStore(
+                            modelFileLoader,
+                            loggerFactory.CreateLogger<ModelStore>(),
+                            config,
+                            [modelWatcher],
+                            translationStore,
+                            localizer
+                        )
+                        {
+                            KeepFileErrorsInReferenceResolution = true,
+                        };
+
+                        registry.Register(new ModelStoreEntry(store, config));
+                    }
+                );
+            }
+        )
+        .OnInitialized(
+            async (lspServer, _, _, ct) =>
+            {
+                var registry = lspServer.Services.GetRequiredService<ModelStoreRegistry>();
+                await Task.WhenAll(registry.All.Select(entry => entry.Store.LoadFromConfig(watch: true, ct: ct)));
             }
         )
 );
 
 await server.WaitForExit;
 server.Dispose();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static string? ResolveRootPath(string? rootPath, string? rootUri)
+{
+    if (!string.IsNullOrEmpty(rootPath))
+        return rootPath;
+
+    if (!string.IsNullOrEmpty(rootUri))
+    {
+        try
+        {
+            return new Uri(rootUri).LocalPath;
+        }
+        catch
+        { /* uri invalide */
+        }
+    }
+
+    return Directory.GetCurrentDirectory();
+}
+
+static ModelConfig LoadConfig(FileChecker fileChecker, FileInfo configFile)
+{
+    using var text = configFile.OpenText();
+    var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(configFile.DirectoryName!);
+
+    foreach (var (configName, genConfigMaps) in config.Generators)
+    {
+        for (var j = 0; j < genConfigMaps.Count(); j++)
+        {
+            var genConfigMap = genConfigMaps.ElementAt(j);
+            var number = j + 1;
+
+            var genConfig = fileChecker.GetWatcherConfigBase(genConfigMap);
+            genConfig.InitVariables(config.App, number);
+            genConfig.Name ??= $"{configName}@{number}";
+            try
+            {
+                config.Configs.Add(genConfig.Name, genConfig);
+            }
+            catch (ArgumentException)
+            {
+                // Nom déjà utilisé, on ignore.
+            }
+
+            foreach (var referencedTag in genConfig.ReferencedTags)
+            {
+                if (config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
+                {
+                    genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
+                }
+            }
+        }
+    }
+
+    return config;
+}

--- a/TopModel.LanguageServer/ReferencesHandler.cs
+++ b/TopModel.LanguageServer/ReferencesHandler.cs
@@ -2,27 +2,40 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 
 namespace TopModel.LanguageServer;
 
-public class ReferencesHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
-    : ReferencesHandlerBase
+public class ReferencesHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : ReferencesHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<LocationContainer?> Handle(ReferenceParams request, CancellationToken cancellationToken)
     {
-        await modelStore.WaitForUpdates(cancellationToken);
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
-        if (file != null)
+        // Les références sont agrégées depuis tous les stores qui couvrent ce fichier.
+        var entries = registry.GetAllForFile(filePath).ToList();
+        if (entries.Count == 0)
         {
+            return new();
+        }
+
+        await registry.WaitForAllUpdatesAsync(cancellationToken);
+
+        var locations = new List<Location>();
+
+        foreach (var entry in entries)
+        {
+            var modelStore = entry.Store;
+            var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+            if (file == null)
+            {
+                continue;
+            }
+
             var references = modelStore.GetReferencesForPositionInFile(request.Position, file);
             if (references != null)
             {
-                return new(
+                locations.AddRange(
                     references.Select(r => new Location
                     {
                         Uri = new Uri(facade.GetFilePath(r.File)),
@@ -32,7 +45,7 @@ public class ReferencesHandler(ModelStore modelStore, ILanguageServerFacade faca
             }
         }
 
-        return new();
+        return locations.Count > 0 ? new(locations) : new();
     }
 
     protected override ReferenceRegistrationOptions CreateRegistrationOptions(
@@ -40,6 +53,6 @@ public class ReferencesHandler(ModelStore modelStore, ILanguageServerFacade faca
         ClientCapabilities clientCapabilities
     )
     {
-        return new ReferenceRegistrationOptions() { DocumentSelector = config.GetDocumentSelector() };
+        return new ReferenceRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/ReferencesHandler.cs
+++ b/TopModel.LanguageServer/ReferencesHandler.cs
@@ -1,11 +1,10 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace TopModel.LanguageServer;
 
-public class ReferencesHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : ReferencesHandlerBase
+public class ReferencesHandler(ModelStoreRegistry registry) : ReferencesHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<LocationContainer?> Handle(ReferenceParams request, CancellationToken cancellationToken)
@@ -26,7 +25,7 @@ public class ReferencesHandler(ModelStoreRegistry registry, ILanguageServerFacad
         foreach (var entry in entries)
         {
             var modelStore = entry.Store;
-            var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+            var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
             if (file == null)
             {
                 continue;
@@ -38,7 +37,7 @@ public class ReferencesHandler(ModelStoreRegistry registry, ILanguageServerFacad
                 locations.AddRange(
                     references.Select(r => new Location
                     {
-                        Uri = new Uri(facade.GetFilePath(r.File)),
+                        Uri = new Uri(r.File.GetFilePath()),
                         Range = r.Reference.ToRange()!,
                     })
                 );

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -1,12 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class RenameHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : RenameHandlerBase
+public class RenameHandler(ModelStoreRegistry registry) : RenameHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
@@ -21,7 +20,7 @@ public class RenameHandler(ModelStoreRegistry registry, ILanguageServerFacade fa
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file != null)
         {
             var references = modelStore.GetReferencesForPositionInFile(request.Position, file, includeTransitive: true);
@@ -40,7 +39,7 @@ public class RenameHandler(ModelStoreRegistry registry, ILanguageServerFacade fa
                         .Where(r => r.Reference.ReferenceName == references.Objet.GetName())
                         .Select(r => new Location
                         {
-                            Uri = new Uri(facade.GetFilePath(r.File)),
+                            Uri = new Uri(r.File.GetFilePath()),
                             Range = r.Reference.ToRange()!,
                         })
                         .Select(c => new

--- a/TopModel.LanguageServer/RenameHandler.cs
+++ b/TopModel.LanguageServer/RenameHandler.cs
@@ -2,21 +2,26 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class RenameHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config) : RenameHandlerBase
+public class RenameHandler(ModelStoreRegistry registry, ILanguageServerFacade facade) : RenameHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
     {
+        var filePath = request.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return null;
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == request.TextDocument.Uri.GetFileSystemPath()
-        );
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file != null)
         {
             var references = modelStore.GetReferencesForPositionInFile(request.Position, file, includeTransitive: true);
@@ -57,6 +62,6 @@ public class RenameHandler(ModelStore modelStore, ILanguageServerFacade facade, 
         ClientCapabilities clientCapabilities
     )
     {
-        return new RenameRegistrationOptions { DocumentSelector = config.GetDocumentSelector() };
+        return new RenameRegistrationOptions { DocumentSelector = registry.GetCombinedDocumentSelector() };
     }
 }

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -2,12 +2,11 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using TopModel.Core;
 using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade facade, ModelConfig config)
+public class SemanticTokensHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
     : SemanticTokensHandlerBase
 {
     protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(
@@ -17,8 +16,12 @@ public class SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade 
     {
         return new SemanticTokensRegistrationOptions
         {
-            DocumentSelector = config.GetDocumentSelector(),
-            Legend = new() { TokenModifiers = capability.TokenModifiers, TokenTypes = capability.TokenTypes },
+            DocumentSelector = registry.GetCombinedDocumentSelector(),
+            Legend = new()
+            {
+                TokenModifiers = capability?.TokenModifiers ?? [],
+                TokenTypes = capability?.TokenTypes ?? [],
+            },
             Full = new SemanticTokensCapabilityRequestFull { Delta = true },
             Range = true,
         };
@@ -38,11 +41,17 @@ public class SemanticTokensHandler(ModelStore modelStore, ILanguageServerFacade 
         CancellationToken cancellationToken
     )
     {
+        var filePath = identifier.TextDocument.Uri.GetFileSystemPath();
+        var entry = registry.GetPrimaryForFile(filePath);
+        if (entry == null)
+        {
+            return;
+        }
+
+        var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f =>
-            facade.GetFilePath(f) == identifier.TextDocument.Uri.GetFileSystemPath()
-        );
+        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
         if (file != null)
         {
             foreach (var reference in file.Uses)

--- a/TopModel.LanguageServer/SemanticTokensHandler.cs
+++ b/TopModel.LanguageServer/SemanticTokensHandler.cs
@@ -1,13 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using TopModel.Core.FileModel;
 
 namespace TopModel.LanguageServer;
 
-public class SemanticTokensHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
-    : SemanticTokensHandlerBase
+public class SemanticTokensHandler(ModelStoreRegistry registry) : SemanticTokensHandlerBase
 {
     protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(
         SemanticTokensCapability capability,
@@ -51,7 +49,7 @@ public class SemanticTokensHandler(ModelStoreRegistry registry, ILanguageServerF
         var modelStore = entry.Store;
         await modelStore.WaitForUpdates(cancellationToken);
 
-        var file = modelStore.Files.SingleOrDefault(f => facade.GetFilePath(f) == filePath);
+        var file = modelStore.Files.SingleOrDefault(f => f.GetFilePath() == filePath);
         if (file != null)
         {
             foreach (var reference in file.Uses)

--- a/TopModel.LanguageServer/TextDocumentSyncHandler.cs
+++ b/TopModel.LanguageServer/TextDocumentSyncHandler.cs
@@ -4,11 +4,10 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
-using TopModel.Core;
 
 namespace TopModel.LanguageServer;
 
-public class TextDocumentSyncHandler(ModelStore modelStore, ModelFileCache fileCache, ModelConfig config)
+public class TextDocumentSyncHandler(ModelStoreRegistry registry, ModelFileCache fileCache)
     : TextDocumentSyncHandlerBase
 {
     /// <inheritdoc cref="ITextDocumentIdentifier.GetTextDocumentAttributes" />
@@ -28,7 +27,13 @@ public class TextDocumentSyncHandler(ModelStore modelStore, ModelFileCache fileC
         var filePath = request.TextDocument.Uri.GetFileSystemPath();
         var content = request.ContentChanges.Single().Text;
         fileCache.UpdateFile(filePath, content);
-        await modelStore.OnModelFileChange(filePath, content, cancellationToken);
+
+        // Notifie tous les stores qui couvrent ce fichier (racines imbriquées ou identiques).
+        foreach (var entry in registry.GetAllForFile(filePath))
+        {
+            await entry.Store.OnModelFileChange(filePath, content, cancellationToken);
+        }
+
         return Unit.Value;
     }
 
@@ -49,7 +54,7 @@ public class TextDocumentSyncHandler(ModelStore modelStore, ModelFileCache fileC
     {
         return new TextDocumentSyncRegistrationOptions
         {
-            DocumentSelector = config.GetDocumentSelector(),
+            DocumentSelector = registry.GetCombinedDocumentSelector(),
             Change = TextDocumentSyncKind.Full,
             Save = new SaveOptions { IncludeText = true },
         };

--- a/TopModel.LanguageServer/TopModel.LanguageServer.csproj
+++ b/TopModel.LanguageServer/TopModel.LanguageServer.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TopModel.Utils.Cli\TopModel.Utils.Cli.csproj" />
     <ProjectReference Include="..\TopModel.Core\TopModel.Core.csproj" />
     <ProjectReference Include="..\TopModel.Utils.Mermaid\TopModel.Utils.Mermaid.csproj" />
   </ItemGroup>

--- a/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
+++ b/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
@@ -2,12 +2,12 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
-using TopModel.Core;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class WorkspaceSymbolHandler(ModelStore modelStore, ILanguageServerFacade facade) : WorkspaceSymbolsHandlerBase
+public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
+    : WorkspaceSymbolsHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<Container<WorkspaceSymbol>?> Handle(
@@ -15,99 +15,85 @@ public class WorkspaceSymbolHandler(ModelStore modelStore, ILanguageServerFacade
         CancellationToken cancellationToken
     )
     {
-        await modelStore.WaitForUpdates(cancellationToken);
+        await registry.WaitForAllUpdatesAsync(cancellationToken);
 
-        return modelStore
-            .Classes.Select(c =>
-            {
-                return new WorkspaceSymbol
-                {
-                    Kind = SymbolKind.Class,
-                    Name = c.Name,
-                    Location = new Location
-                    {
-                        Range = c.Name.GetLocation().ToRange()!,
-                        Uri = facade.GetFilePath(c.ModelFile),
-                    },
-                };
-            })
-            .Concat(
+        return registry
+            .All.Select(entry => entry.Store)
+            .SelectMany(modelStore =>
                 modelStore
-                    .Files.Where(e => e.Endpoints.Count > 0)
-                    .SelectMany(f => f.Endpoints)
-                    .Select(e =>
+                    .Classes.Select(c => new WorkspaceSymbol
                     {
-                        return new WorkspaceSymbol
+                        Kind = SymbolKind.Class,
+                        Name = c.Name,
+                        Location = new Location
                         {
-                            Kind = SymbolKind.Method,
-                            Name = e.Name,
+                            Range = c.Name.GetLocation().ToRange()!,
+                            Uri = facade.GetFilePath(c.ModelFile),
+                        },
+                    })
+                    .Concat(
+                        modelStore
+                            .Files.Where(e => e.Endpoints.Count > 0)
+                            .SelectMany(f => f.Endpoints)
+                            .Select(e => new WorkspaceSymbol
+                            {
+                                Kind = SymbolKind.Method,
+                                Name = e.Name,
+                                Location = new Location
+                                {
+                                    Range = e.Name.GetLocation()!.ToRange()!,
+                                    Uri = facade.GetFilePath(e.ModelFile),
+                                },
+                            })
+                    )
+                    .Concat(
+                        modelStore.Domains.Select(d => new WorkspaceSymbol
+                        {
+                            Kind = SymbolKind.Struct,
+                            Name = d.Value.Name,
                             Location = new Location
                             {
-                                Range = e.Name.GetLocation()!.ToRange()!,
-                                Uri = facade.GetFilePath(e.ModelFile),
+                                Range = d.Value.GetLocation().ToRange()!,
+                                Uri = facade.GetFilePath(d.Value.GetFile()),
                             },
-                        };
-                    })
-            )
-            .Concat(
-                modelStore.Domains.Select(d =>
-                {
-                    return new WorkspaceSymbol
-                    {
-                        Kind = SymbolKind.Struct,
-                        Name = d.Value.Name,
-                        Location = new Location
+                        })
+                    )
+                    .Concat(
+                        modelStore.Annotations.Select(d => new WorkspaceSymbol
                         {
-                            Range = d.Value.GetLocation().ToRange()!,
-                            Uri = facade.GetFilePath(d.Value.GetFile()),
-                        },
-                    };
-                })
-            )
-            .Concat(
-                modelStore.Annotations.Select(d =>
-                {
-                    return new WorkspaceSymbol
-                    {
-                        Kind = SymbolKind.Interface,
-                        Name = d.Name,
-                        Location = new Location
+                            Kind = SymbolKind.Interface,
+                            Name = d.Name,
+                            Location = new Location
+                            {
+                                Range = d.GetLocation().ToRange()!,
+                                Uri = facade.GetFilePath(d.GetFile()),
+                            },
+                        })
+                    )
+                    .Concat(
+                        modelStore.Decorators.Select(d => new WorkspaceSymbol
                         {
-                            Range = d.GetLocation().ToRange()!,
-                            Uri = facade.GetFilePath(d.GetFile()),
-                        },
-                    };
-                })
-            )
-            .Concat(
-                modelStore.Decorators.Select(d =>
-                {
-                    return new WorkspaceSymbol
-                    {
-                        Kind = SymbolKind.Interface,
-                        Name = d.Name,
-                        Location = new Location
+                            Kind = SymbolKind.Interface,
+                            Name = d.Name,
+                            Location = new Location
+                            {
+                                Range = d.GetLocation().ToRange()!,
+                                Uri = facade.GetFilePath(d.GetFile()),
+                            },
+                        })
+                    )
+                    .Concat(
+                        modelStore.DataFlows.Select(d => new WorkspaceSymbol
                         {
-                            Range = d.GetLocation().ToRange()!,
-                            Uri = facade.GetFilePath(d.GetFile()),
-                        },
-                    };
-                })
-            )
-            .Concat(
-                modelStore.DataFlows.Select(d =>
-                {
-                    return new WorkspaceSymbol
-                    {
-                        Kind = SymbolKind.Operator,
-                        Name = d.Name,
-                        Location = new Location
-                        {
-                            Range = d.GetLocation().ToRange()!,
-                            Uri = facade.GetFilePath(d.GetFile()),
-                        },
-                    };
-                })
+                            Kind = SymbolKind.Operator,
+                            Name = d.Name,
+                            Location = new Location
+                            {
+                                Range = d.GetLocation().ToRange()!,
+                                Uri = facade.GetFilePath(d.GetFile()),
+                            },
+                        })
+                    )
             )
             .Where(s => s.Name.ShouldMatch(request.Query))
             .ToList();

--- a/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
+++ b/TopModel.LanguageServer/WorkspaceSymbolHandler.cs
@@ -1,13 +1,11 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using TopModel.Core.Utils;
 
 namespace TopModel.LanguageServer;
 
-public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServerFacade facade)
-    : WorkspaceSymbolsHandlerBase
+public class WorkspaceSymbolHandler(ModelStoreRegistry registry) : WorkspaceSymbolsHandlerBase
 {
     /// <inheritdoc cref="MediatR.IRequestHandler{TRequest, TResponse}.Handle" />
     public override async Task<Container<WorkspaceSymbol>?> Handle(
@@ -28,7 +26,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                         Location = new Location
                         {
                             Range = c.Name.GetLocation().ToRange()!,
-                            Uri = facade.GetFilePath(c.ModelFile),
+                            Uri = c.ModelFile.GetFilePath(),
                         },
                     })
                     .Concat(
@@ -42,7 +40,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                                 Location = new Location
                                 {
                                     Range = e.Name.GetLocation()!.ToRange()!,
-                                    Uri = facade.GetFilePath(e.ModelFile),
+                                    Uri = e.ModelFile.GetFilePath(),
                                 },
                             })
                     )
@@ -54,7 +52,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                             Location = new Location
                             {
                                 Range = d.Value.GetLocation().ToRange()!,
-                                Uri = facade.GetFilePath(d.Value.GetFile()),
+                                Uri = d.Value.GetFile().GetFilePath(),
                             },
                         })
                     )
@@ -66,7 +64,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                             Location = new Location
                             {
                                 Range = d.GetLocation().ToRange()!,
-                                Uri = facade.GetFilePath(d.GetFile()),
+                                Uri = d.GetFile().GetFilePath(),
                             },
                         })
                     )
@@ -78,7 +76,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                             Location = new Location
                             {
                                 Range = d.GetLocation().ToRange()!,
-                                Uri = facade.GetFilePath(d.GetFile()),
+                                Uri = d.GetFile().GetFilePath(),
                             },
                         })
                     )
@@ -90,7 +88,7 @@ public class WorkspaceSymbolHandler(ModelStoreRegistry registry, ILanguageServer
                             Location = new Location
                             {
                                 Range = d.GetLocation().ToRange()!,
-                                Uri = facade.GetFilePath(d.GetFile()),
+                                Uri = d.GetFile().GetFilePath(),
                             },
                         })
                     )

--- a/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
 namespace TopModel.ModelGenerator.Database;
 
@@ -45,8 +46,8 @@ public abstract class DatabaseTmdGenerator(
     )
     {
         InitConnection();
-        logger.LogInformation($"Connexion à la base de données {config.Source.DbName} réussie !");
-        logger.LogInformation($"Génération en cours, veuillez patienter...");
+        logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.DbConnectionSuccess, config.Source.DbName));
+        logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.GeneratingPleaseWait));
         var columns = await GetColumns();
         var classGroups = columns.GroupBy(c => c.TableName);
 
@@ -541,13 +542,16 @@ public abstract class DatabaseTmdGenerator(
         try
         {
             _connection = GetConnection();
-            logger.LogInformation($"Connexion à la base de données {config.Source.DbName}...");
+            logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.ConnectingToDb, config.Source.DbName));
             _connection.Open();
         }
         catch (Exception)
         {
             logger.LogInformation(
-                $"Mot de passe{(password != null ? " erroné" : string.Empty)} pour l'utilisateur {config.Source.User}:  "
+                LocalizeUtils.Localize(
+                    password != null ? ModelGeneratorMessage.WrongPasswordPrompt : ModelGeneratorMessage.PasswordPrompt,
+                    config.Source.User ?? string.Empty
+                )
             );
             Passwords.Remove(config.Source.DbName);
             while (true)

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.cs
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.cs
@@ -1,0 +1,12 @@
+namespace TopModel.ModelGenerator;
+
+public enum ModelGeneratorMessage
+{
+    RegisteredGenerators,
+    UpdateCompleted,
+    DbConnectionSuccess,
+    GeneratingPleaseWait,
+    ConnectingToDb,
+    PasswordPrompt,
+    WrongPasswordPrompt,
+}

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.fr.resx
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.fr.resx
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisteredGenerators" xml:space="preserve">
+    <value>Générateurs enregistrés :{0}</value>
+  </data>
+  <data name="UpdateCompleted" xml:space="preserve">
+    <value>Mise à jour terminée avec succès.</value>
+  </data>
+  <data name="DbConnectionSuccess" xml:space="preserve">
+    <value>Connexion à la base de données {0} réussie !</value>
+  </data>
+  <data name="GeneratingPleaseWait" xml:space="preserve">
+    <value>Génération en cours, veuillez patienter...</value>
+  </data>
+  <data name="ConnectingToDb" xml:space="preserve">
+    <value>Connexion à la base de données {0}...</value>
+  </data>
+  <data name="PasswordPrompt" xml:space="preserve">
+    <value>Mot de passe pour l'utilisateur {0} : </value>
+  </data>
+  <data name="WrongPasswordPrompt" xml:space="preserve">
+    <value>Mot de passe erroné pour l'utilisateur {0} : </value>
+  </data>
+</root>

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.resx
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.resx
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisteredGenerators" xml:space="preserve">
+    <value>Registered generators:{0}</value>
+  </data>
+  <data name="UpdateCompleted" xml:space="preserve">
+    <value>Update completed successfully.</value>
+  </data>
+  <data name="DbConnectionSuccess" xml:space="preserve">
+    <value>Connected to database {0}!</value>
+  </data>
+  <data name="GeneratingPleaseWait" xml:space="preserve">
+    <value>Generating, please wait...</value>
+  </data>
+  <data name="ConnectingToDb" xml:space="preserve">
+    <value>Connecting to database {0}...</value>
+  </data>
+  <data name="PasswordPrompt" xml:space="preserve">
+    <value>Password for user {0}: </value>
+  </data>
+  <data name="WrongPasswordPrompt" xml:space="preserve">
+    <value>Wrong password for user {0}: </value>
+  </data>
+</root>

--- a/TopModel.ModelGenerator/Program.cs
+++ b/TopModel.ModelGenerator/Program.cs
@@ -1,12 +1,14 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Help;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SharpYaml.Serialization;
 using Spectre.Console;
+using TopModel.Core;
 using TopModel.ModelGenerator;
 using TopModel.ModelGenerator.Database;
 using TopModel.ModelGenerator.OpenApi;
@@ -62,32 +64,10 @@ if (files.Any())
 }
 else
 {
-    var dir = Directory.GetCurrentDirectory();
-    var pattern = "tmdgen*.config";
-    foreach (var fileName in Directory.GetFiles(dir, pattern, SearchOption.AllDirectories))
+    var tmdgenPattern = new Regex(@"tmdgen[^/\\]*\.config$");
+    foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory(), tmdgenPattern))
     {
-        var foundFile = new FileInfo(fileName);
-        if (foundFile != null)
-        {
-            HandleFile(foundFile);
-        }
-    }
-
-    if (!configs.Any())
-    {
-        var found = false;
-        while (!found && dir != null)
-        {
-            dir = Directory.GetParent(dir)?.FullName;
-            if (dir != null)
-            {
-                foreach (var fileName in Directory.GetFiles(dir, pattern))
-                {
-                    HandleFile(new FileInfo(fileName));
-                    found = true;
-                }
-            }
-        }
+        HandleFile(file);
     }
 }
 

--- a/TopModel.ModelGenerator/Program.cs
+++ b/TopModel.ModelGenerator/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Help;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,18 +12,14 @@ using TopModel.ModelGenerator;
 using TopModel.ModelGenerator.Database;
 using TopModel.ModelGenerator.OpenApi;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
-var fileOption = new Option<IEnumerable<FileInfo>>("--file", "-f")
+var command = new RootCommand("Lance le générateur de fichiers tmd.")
 {
-    Description = "Chemin vers un fichier de config.",
+    TopModelCli.FileOption,
+    TopModelCli.WatchOption,
+    TopModelCli.CheckOption,
 };
-var watchOption = new Option<bool>("--watch", "-w") { Description = "Lance le générateur en mode 'watch'" };
-var checkOption = new Option<bool>("--check", "-c")
-{
-    Description = "Vérifie que le modèle généré est conforme aux sources.",
-};
-
-var command = new RootCommand("Lance le générateur de fichiers tmd.") { fileOption, watchOption, checkOption };
 
 var helpOption = command.Options.OfType<HelpOption>().Single();
 var versionOption = command.Options.OfType<VersionOption>().Single();
@@ -36,9 +31,9 @@ if (result.GetResult(helpOption) != null || result.GetResult(versionOption) != n
     return await result.InvokeAsync();
 }
 
-var files = result.GetValue(fileOption) ?? [];
-var watchMode = result.GetValue(watchOption);
-var checkMode = result.GetValue(checkOption);
+var files = result.GetValue(TopModelCli.FileOption) ?? [];
+var watchMode = result.GetValue(TopModelCli.WatchOption);
+var checkMode = result.GetValue(TopModelCli.CheckOption);
 
 var configs = new List<(string FullPath, string DirectoryName)>();
 var serializer = new Serializer(new() { NamingConvention = new CamelCaseNamingConvention() });
@@ -48,63 +43,31 @@ void HandleFile(FileInfo file)
     configs.Add((file.FullName, file.DirectoryName!));
 }
 
-if (files.Any())
+var tmdgenPattern = new Regex(@"tmdgen[^/\\]*\.config$");
+foreach (var file in TopModelCli.ResolveFiles(files, tmdgenPattern))
 {
-    foreach (var file in files)
-    {
-        if (!file.Exists)
-        {
-            AnsiConsole.MarkupLine($"[red]Le fichier '{file.FullName}' est introuvable.[/]");
-        }
-        else
-        {
-            HandleFile(file);
-        }
-    }
-}
-else
-{
-    var tmdgenPattern = new Regex(@"tmdgen[^/\\]*\.config$");
-    foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory(), tmdgenPattern))
-    {
-        HandleFile(file);
-    }
+    HandleFile(file);
 }
 
 if (!configs.Any())
 {
-    AnsiConsole.MarkupLine($"[red]Aucun fichier de configuration trouvé.[/]");
+    AnsiConsole.MarkupLine($"[red]{LocalizeUtils.Localize(CliMessage.NoConfigFileFound)}[/]");
     return 1;
 }
 
-var version = Assembly
-    .GetEntryAssembly()!
-    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
-    .InformationalVersion;
-
-var colors = new[] { "teal", "olive", "yellow", "aqua" };
-
-AnsiConsole.MarkupLine($"========= TopModel.ModelGenerator v{version} =========");
-AnsiConsole.WriteLine();
+await TopModelCli.ShowBannerAsync("TopModel.ModelGenerator");
 
 if (watchMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]watch[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.WatchModeEnabled));
 }
 
 if (checkMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]check[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.CheckModeEnabled));
 }
 
-AnsiConsole.WriteLine("Fichiers de configuration trouvés :");
-
-for (var i = 0; i < configs.Count; i++)
-{
-    var (fullName, _) = configs[i];
-    var color = colors[i % colors.Length];
-    AnsiConsole.MarkupLine($"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), fullName)}[/]");
-}
+TopModelCli.ListFoundFiles(configs.Select(c => c.FullPath));
 
 var disposables = new List<IDisposable>();
 var loggerProvider = new LoggerProvider();
@@ -208,13 +171,16 @@ async Task StartGeneration(string filePath, string directoryName, int i)
     using var provider = services.BuildServiceProvider();
 
     var mainLogger = provider.GetRequiredService<ILogger<TmdGenerator>>();
-    var loggingScope = new LoggingScope(i + 1, colors[i]);
+    var loggingScope = new LoggingScope(i + 1, TopModelCli.Colors[i % TopModelCli.Colors.Length]);
     using var scope = mainLogger.BeginScope(loggingScope);
 
     var generators = provider.GetRequiredService<IEnumerable<TmdGenerator>>();
 
     mainLogger.LogInformation(
-        $"Générateurs enregistrés :\n                          {string.Join("\n                          ", generators.Select(g => $"- {g.Name}@{{{g.Number}}}"))}"
+        LocalizeUtils.Localize(
+            ModelGeneratorMessage.RegisteredGenerators,
+            $"\n                          {string.Join("\n                          ", generators.Select(g => $"- {g.Name}@{{{g.Number}}}"))}"
+        )
     );
 
     var tmdLock = new TopModelLock(config, mainLogger);
@@ -227,7 +193,7 @@ async Task StartGeneration(string filePath, string directoryName, int i)
 
     tmdLock.UpdateFiles(generatedFiles);
 
-    mainLogger.LogInformation("Mise à jour terminée avec succès.");
+    mainLogger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.UpdateCompleted));
 }
 
 foreach (var config in configs)
@@ -283,20 +249,12 @@ if (watchMode)
 
 if (checkMode && loggerProvider.Changes > 0)
 {
-    Console.ForegroundColor = ConsoleColor.Red;
     AnsiConsole.WriteLine();
-    if (loggerProvider.Changes == 1)
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.[/]"
-        );
-    }
-    else
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]{loggerProvider.Changes} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.[/]"
-        );
-    }
+    AnsiConsole.MarkupLine(
+        loggerProvider.Changes == 1
+            ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
+            : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
+    );
 
     return 1;
 }

--- a/TopModel.ModelGenerator/Program.cs
+++ b/TopModel.ModelGenerator/Program.cs
@@ -55,7 +55,7 @@ if (!configs.Any())
     return 1;
 }
 
-await TopModelCli.ShowBannerAsync("TopModel.ModelGenerator");
+await TopModelCli.StartPackage("TopModel.ModelGenerator", CancellationToken.None);
 
 if (watchMode)
 {

--- a/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
+++ b/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TopModel.Utils.Cli\TopModel.Utils.Cli.csproj" />
     <ProjectReference Include="..\TopModel.Utils\TopModel.Utils.csproj" />
+    <ProjectReference Include="..\TopModel.Core\TopModel.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/TopModel.Utils.Cli/CliMessage.cs
+++ b/TopModel.Utils.Cli/CliMessage.cs
@@ -1,0 +1,17 @@
+namespace TopModel.Utils.Cli;
+
+public enum CliMessage
+{
+    ConfigFileNotFound,
+    ConfigFilesFound,
+    NoConfigFileFound,
+    NewVersionAvailable,
+    DotnetUpdateCommand,
+    WatchModeEnabled,
+    CheckModeEnabled,
+    OneFileModifiedInCheckMode,
+    MultipleFilesModifiedInCheckMode,
+    FileOptionDescription,
+    WatchOptionDescription,
+    CheckOptionDescription,
+}

--- a/TopModel.Utils.Cli/CliMessage.fr.resx
+++ b/TopModel.Utils.Cli/CliMessage.fr.resx
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigFileNotFound" xml:space="preserve">
+    <value>Le fichier de configuration '{0}' est introuvable.</value>
+  </data>
+  <data name="ConfigFilesFound" xml:space="preserve">
+    <value>Fichiers de configuration trouvés :</value>
+  </data>
+  <data name="NoConfigFileFound" xml:space="preserve">
+    <value>Aucun fichier de configuration trouvé.</value>
+  </data>
+  <data name="NewVersionAvailable" xml:space="preserve">
+    <value>Nouvelle version disponible : {0}</value>
+  </data>
+  <data name="DotnetUpdateCommand" xml:space="preserve">
+    <value>Vous pouvez lancer la commande `dotnet tool update -g {0}` pour effectuer la mise à jour.</value>
+  </data>
+  <data name="WatchModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]watch[/] activé.</value>
+  </data>
+  <data name="CheckModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]check[/] activé.</value>
+  </data>
+  <data name="OneFileModifiedInCheckMode" xml:space="preserve">
+    <value>1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.</value>
+  </data>
+  <data name="MultipleFilesModifiedInCheckMode" xml:space="preserve">
+    <value>{0} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.</value>
+  </data>
+  <data name="FileOptionDescription" xml:space="preserve">
+    <value>Chemin vers un fichier de config.</value>
+  </data>
+  <data name="WatchOptionDescription" xml:space="preserve">
+    <value>Lance le générateur en mode 'watch'.</value>
+  </data>
+  <data name="CheckOptionDescription" xml:space="preserve">
+    <value>Vérifie que la génération est à jour (aucun fichier ne doit être généré).</value>
+  </data>
+</root>

--- a/TopModel.Utils.Cli/CliMessage.resx
+++ b/TopModel.Utils.Cli/CliMessage.resx
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigFileNotFound" xml:space="preserve">
+    <value>Config file '{0}' not found.</value>
+  </data>
+  <data name="ConfigFilesFound" xml:space="preserve">
+    <value>Config files found:</value>
+  </data>
+  <data name="NoConfigFileFound" xml:space="preserve">
+    <value>No config file found.</value>
+  </data>
+  <data name="NewVersionAvailable" xml:space="preserve">
+    <value>New version available: {0}</value>
+  </data>
+  <data name="DotnetUpdateCommand" xml:space="preserve">
+    <value>You can run `dotnet tool update -g {0}` to update.</value>
+  </data>
+  <data name="WatchModeEnabled" xml:space="preserve">
+    <value>[darkcyan]watch[/] mode enabled.</value>
+  </data>
+  <data name="CheckModeEnabled" xml:space="preserve">
+    <value>[darkcyan]check[/] mode enabled.</value>
+  </data>
+  <data name="OneFileModifiedInCheckMode" xml:space="preserve">
+    <value>1 generated file was modified or deleted. Generated code was not up to date.</value>
+  </data>
+  <data name="MultipleFilesModifiedInCheckMode" xml:space="preserve">
+    <value>{0} generated files were modified or deleted. Generated code was not up to date.</value>
+  </data>
+  <data name="FileOptionDescription" xml:space="preserve">
+    <value>Path to a config file.</value>
+  </data>
+  <data name="WatchOptionDescription" xml:space="preserve">
+    <value>Runs the generator in 'watch' mode.</value>
+  </data>
+  <data name="CheckOptionDescription" xml:space="preserve">
+    <value>Checks that the generation is up to date (no file should be generated).</value>
+  </data>
+</root>

--- a/TopModel.Utils.Cli/ConfigUtils.cs
+++ b/TopModel.Utils.Cli/ConfigUtils.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace TopModel.Core;
+namespace TopModel.Utils.Cli;
 
 /// <summary>
 /// Localise les fichiers de configuration TopModel dans un répertoire.
@@ -8,17 +8,14 @@ namespace TopModel.Core;
 /// </summary>
 public static partial class ConfigUtils
 {
-    private static readonly Regex ModgenPattern = new("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
-
     /// <summary>
     /// Cherche les fichiers de config depuis un répertoire racine.
     /// Stratégie :
     ///   1. Descend récursivement jusqu'à profondeur 3.
     ///   2. Si rien trouvé, remonte l'arbre jusqu'au premier niveau qui en contient.
     /// </summary>
-    public static IEnumerable<FileInfo> FindConfigFiles(string rootPath, Regex? pattern = null)
+    public static IEnumerable<FileInfo> FindConfigFiles(string rootPath, Regex pattern)
     {
-        pattern ??= ModgenPattern;
         var found = new List<FileInfo>();
 
         SearchDescending(pattern, rootPath, found, depth: 0);

--- a/TopModel.Utils.Cli/LocalizeUtils.cs
+++ b/TopModel.Utils.Cli/LocalizeUtils.cs
@@ -1,0 +1,20 @@
+using System.Resources;
+
+namespace TopModel.Utils.Cli;
+
+public static class LocalizeUtils
+{
+    public static string Localize<T>(T messageType, params object[] args)
+        where T : struct, Enum
+    {
+        var format =
+            ResourceManagerCache<T>.Instance.GetString(Enum.GetName(messageType)!) ?? Enum.GetName(messageType)!;
+        return args.Length > 0 ? string.Format(format, args) : format;
+    }
+
+    private static class ResourceManagerCache<T>
+        where T : struct, Enum
+    {
+        public static readonly ResourceManager Instance = new(typeof(T));
+    }
+}

--- a/TopModel.Utils.Cli/LogUtils.cs
+++ b/TopModel.Utils.Cli/LogUtils.cs
@@ -1,0 +1,38 @@
+using Spectre.Console;
+
+namespace TopModel.Utils.Cli;
+
+public static class LogUtils
+{
+    public static readonly string[] Colors = ["teal", "olive", "yellow", "aqua"];
+
+    public static void Log<T>(T key, string color, params object[] args)
+        where T : struct, Enum
+    {
+        AnsiConsole.MarkupLine($"[{color}]{LocalizeUtils.Localize(key, args)}[/]");
+    }
+
+    public static void LogError<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "red", args);
+    }
+
+    public static void LogInformation<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "white", args);
+    }
+
+    public static void LogSuccess<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "green", args);
+    }
+
+    public static void LogWarning<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "yellow", args);
+    }
+}

--- a/TopModel.Utils.Cli/NugetUtils.cs
+++ b/TopModel.Utils.Cli/NugetUtils.cs
@@ -4,8 +4,9 @@ using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using TopModel.Utils;
 
-namespace TopModel.Utils;
+namespace TopModel.Utils.Cli;
 
 public static class NugetUtils
 {

--- a/TopModel.Utils.Cli/NugetUtils.cs
+++ b/TopModel.Utils.Cli/NugetUtils.cs
@@ -14,7 +14,6 @@ public static class NugetUtils
         NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
         "topmodel-cache.json"
     );
-    private static readonly CancellationToken Ct = CancellationToken.None;
     private static readonly SourceCacheContext NugetCache = new();
     private static readonly Dictionary<string, ModuleLatestVersion> Versions = [];
 
@@ -31,15 +30,15 @@ public static class NugetUtils
         }
     }
 
-    public static async Task ClearAsync()
+    public static async Task ClearAsync(CancellationToken Ct)
     {
         Versions.Clear();
-        await WriteAsync();
+        await WriteAsync(Ct);
     }
 
-    public static async Task<bool> DoesPackageExistsAsync(string id, string version)
+    public static async Task<bool> DoesPackageExistsAsync(string id, string version, CancellationToken Ct)
     {
-        var nugetResource = await GetNugetResourceAsync();
+        var nugetResource = await GetNugetResourceAsync(Ct);
         return await nugetResource.DoesPackageExistAsync(
             id,
             new NuGetVersion(version),
@@ -49,9 +48,9 @@ public static class NugetUtils
         );
     }
 
-    public static async Task<PackageArchiveReader> DownloadPackageAsync(string id, string version)
+    public static async Task<PackageArchiveReader> DownloadPackageAsync(string id, string version, CancellationToken Ct)
     {
-        var nugetResource = await GetNugetResourceAsync();
+        var nugetResource = await GetNugetResourceAsync(Ct);
         var packageStream = new MemoryStream();
         await nugetResource.CopyNupkgToStreamAsync(
             id,
@@ -66,6 +65,7 @@ public static class NugetUtils
 
     public static async Task<TopModelLockModule?> GetLatestVersionAsync(
         string id,
+        CancellationToken Ct,
         bool forceCheck = false,
         bool prerelease = false
     )
@@ -96,8 +96,16 @@ public static class NugetUtils
 
         try
         {
-            var nugetResource = await GetNugetResourceAsync();
-            var moduleVersions = await nugetResource.GetAllVersionsAsync(id, NugetCache, NullLogger.Instance, Ct);
+            var nugetResource = await GetNugetResourceAsync(Ct);
+            IEnumerable<NuGetVersion> moduleVersions;
+            try
+            {
+                moduleVersions = await nugetResource.GetAllVersionsAsync(id, NugetCache, NullLogger.Instance, Ct);
+            }
+            catch (InvalidPackageIdException)
+            {
+                return null;
+            }
 
             if (!moduleVersions.Any())
             {
@@ -110,7 +118,7 @@ public static class NugetUtils
             };
 
             Versions[id] = new(version.Version, DateTime.UtcNow);
-            await WriteAsync();
+            await WriteAsync(Ct);
             return version;
         }
         catch (FatalProtocolException)
@@ -118,12 +126,12 @@ public static class NugetUtils
             // Si on a pas internet par exemple.
             _cantCheckVersion = true;
             Versions[id] = new(Version: null, DateTime.UtcNow);
-            await WriteAsync();
+            await WriteAsync(Ct);
             return null;
         }
     }
 
-    private static async Task<FindPackageByIdResource> GetNugetResourceAsync()
+    private static async Task<FindPackageByIdResource> GetNugetResourceAsync(CancellationToken Ct)
     {
         if (_nugetResource == null)
         {
@@ -134,7 +142,7 @@ public static class NugetUtils
         return _nugetResource;
     }
 
-    private static async Task WriteAsync()
+    private static async Task WriteAsync(CancellationToken Ct)
     {
         await File.WriteAllTextAsync(CacheFile, JsonSerializer.Serialize(Versions), Ct);
     }

--- a/TopModel.Utils.Cli/TopModel.Utils.Cli.csproj
+++ b/TopModel.Utils.Cli/TopModel.Utils.Cli.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>4.2.5</Version>
+    <Description>Utilitaires CLI TopModel.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.Cli" />
+    <PackageReference Include="NuGet.Commands" />
+    <ProjectReference Include="..\TopModel.Utils\TopModel.Utils.csproj" />
+  </ItemGroup>
+</Project>

--- a/TopModel.Utils.Cli/TopModelCli.cs
+++ b/TopModel.Utils.Cli/TopModelCli.cs
@@ -1,0 +1,85 @@
+using System.CommandLine;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace TopModel.Utils.Cli;
+
+public static class TopModelCli
+{
+    public static Option<IEnumerable<FileInfo>> FileOption { get; } =
+        new("--file", "-f") { Description = LocalizeUtils.Localize(CliMessage.FileOptionDescription) };
+
+    public static Option<bool> WatchOption { get; } =
+        new("--watch", "-w") { Description = LocalizeUtils.Localize(CliMessage.WatchOptionDescription) };
+
+    public static Option<bool> CheckOption { get; } =
+        new("--check", "-c") { Description = LocalizeUtils.Localize(CliMessage.CheckOptionDescription) };
+
+    public static string[] Colors => LogUtils.Colors;
+
+    public static void ListFoundFiles(IEnumerable<string> filePaths)
+    {
+        LogUtils.LogInformation(CliMessage.ConfigFilesFound);
+        var i = 0;
+        foreach (var path in filePaths)
+        {
+            var color = LogUtils.Colors[i % LogUtils.Colors.Length];
+            AnsiConsole.MarkupLine(
+                $"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), path)}[/]"
+            );
+            i++;
+        }
+    }
+
+    public static IEnumerable<FileInfo> ResolveFiles(IEnumerable<FileInfo> files, Regex pattern)
+    {
+        if (files.Any())
+        {
+            foreach (var file in files)
+            {
+                if (!file.Exists)
+                {
+                    LogUtils.LogError(CliMessage.ConfigFileNotFound, file.FullName);
+                }
+                else
+                {
+                    yield return file;
+                }
+            }
+        }
+        else
+        {
+            foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory(), pattern))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    public static async Task<(string Version, int MajorVersion, int MinorVersion)> ShowBannerAsync(
+        string nugetPackageName
+    )
+    {
+        var version = Assembly
+            .GetEntryAssembly()!
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
+        var majorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
+        var minorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
+        var prerelease = version.Contains('-');
+
+        AnsiConsole.MarkupLine($"========= {nugetPackageName} v{version} =========");
+        AnsiConsole.WriteLine();
+
+        var latestVersion = await NugetUtils.GetLatestVersionAsync(nugetPackageName, prerelease: prerelease);
+        if (latestVersion != null && latestVersion.Version != version)
+        {
+            LogUtils.LogWarning(CliMessage.NewVersionAvailable, latestVersion.Version!);
+            LogUtils.LogWarning(CliMessage.DotnetUpdateCommand, nugetPackageName);
+            AnsiConsole.WriteLine();
+        }
+
+        return (version, majorVersion, minorVersion);
+    }
+}

--- a/TopModel.Utils.Cli/TopModelCli.cs
+++ b/TopModel.Utils.Cli/TopModelCli.cs
@@ -57,29 +57,27 @@ public static class TopModelCli
         }
     }
 
-    public static async Task<(string Version, int MajorVersion, int MinorVersion)> ShowBannerAsync(
-        string nugetPackageName
-    )
+    public static async Task StartPackage(string nugetPackageName, CancellationToken cancellationToken)
     {
         var version = Assembly
             .GetEntryAssembly()!
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
             .InformationalVersion;
-        var majorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
-        var minorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
-        var prerelease = version.Contains('-');
 
         AnsiConsole.MarkupLine($"========= {nugetPackageName} v{version} =========");
         AnsiConsole.WriteLine();
 
-        var latestVersion = await NugetUtils.GetLatestVersionAsync(nugetPackageName, prerelease: prerelease);
+        var prerelease = version.Contains('-');
+        var latestVersion = await NugetUtils.GetLatestVersionAsync(
+            nugetPackageName,
+            cancellationToken,
+            prerelease: prerelease
+        );
         if (latestVersion != null && latestVersion.Version != version)
         {
             LogUtils.LogWarning(CliMessage.NewVersionAvailable, latestVersion.Version!);
             LogUtils.LogWarning(CliMessage.DotnetUpdateCommand, nugetPackageName);
             AnsiConsole.WriteLine();
         }
-
-        return (version, majorVersion, minorVersion);
     }
 }

--- a/TopModel.Utils/ConfigUtils.cs
+++ b/TopModel.Utils/ConfigUtils.cs
@@ -1,0 +1,69 @@
+﻿using System.Text.RegularExpressions;
+
+namespace TopModel.Core;
+
+/// <summary>
+/// Localise les fichiers de configuration TopModel dans un répertoire.
+/// Logique partagée entre TopModel.Generator et TopModel.LanguageServer.
+/// </summary>
+public static partial class ConfigUtils
+{
+    private static readonly Regex ModgenPattern = new("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
+
+    /// <summary>
+    /// Cherche les fichiers de config depuis un répertoire racine.
+    /// Stratégie :
+    ///   1. Descend récursivement jusqu'à profondeur 3.
+    ///   2. Si rien trouvé, remonte l'arbre jusqu'au premier niveau qui en contient.
+    /// </summary>
+    public static IEnumerable<FileInfo> FindConfigFiles(string rootPath, Regex? pattern = null)
+    {
+        pattern ??= ModgenPattern;
+        var found = new List<FileInfo>();
+
+        SearchDescending(pattern, rootPath, found, depth: 0);
+
+        if (found.Count == 0)
+        {
+            var dir = rootPath;
+            while (dir != null)
+            {
+                dir = Directory.GetParent(dir)?.FullName;
+                if (dir == null)
+                    break;
+
+                var matches = Directory
+                    .EnumerateFiles(dir)
+                    .Where(f => pattern.IsMatch(f))
+                    .Select(f => new FileInfo(f))
+                    .ToList();
+
+                if (matches.Count > 0)
+                {
+                    found.AddRange(matches);
+                    break;
+                }
+            }
+        }
+
+        return found;
+    }
+
+    private static void SearchDescending(Regex configPattern, string dirName, List<FileInfo> found, int depth)
+    {
+        if (depth > 3)
+            return;
+
+        foreach (var entryName in Directory.EnumerateFileSystemEntries(dirName))
+        {
+            if (Directory.Exists(entryName))
+            {
+                SearchDescending(configPattern, entryName, found, depth + 1);
+            }
+            else if (configPattern.IsMatch(entryName))
+            {
+                found.Add(new FileInfo(entryName));
+            }
+        }
+    }
+}

--- a/TopModel.Utils/ErrorType.fr.resx
+++ b/TopModel.Utils/ErrorType.fr.resx
@@ -207,4 +207,5 @@
   <data name="TMD9013" xml:space="preserve">
     <value>Il est impossible de définir une valeur pour l'association '{0}' de la classe '{1}' car elle est multiple ou ne cible pas une classe enum readonly.</value>
   </data>
+
 </root>

--- a/TopModel.Utils/ErrorType.resx
+++ b/TopModel.Utils/ErrorType.resx
@@ -207,4 +207,5 @@
   <data name="TMD9013" xml:space="preserve">
     <value>Cannot define value on association '{0}' of class '{1}' because it is multiple or doesn't target a readonly enum class. </value>
   </data>
+
 </root>

--- a/TopModel.Utils/TopModel.Utils.csproj
+++ b/TopModel.Utils/TopModel.Utils.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Meziantou.Framework.Globbing" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="NuGet.Commands" />
+    <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Spectre.Console.Cli" />
     <PackageReference Include="YamlDotNet" />

--- a/TopModel.VSCode/src/application.ts
+++ b/TopModel.VSCode/src/application.ts
@@ -2,16 +2,29 @@ import Ajv from "ajv";
 import { readFile } from "fs/promises";
 import { load } from "js-yaml";
 import { makeAutoObservable } from "mobx";
-import { ExtensionContext, Terminal, Uri, window, workspace } from "vscode";
-import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
+import { ExtensionContext, Terminal, window, workspace } from "vscode";
 
-import { SERVER_EXE } from "./const";
 import { TopModelConfig } from "./types";
 import path = require("path");
+
 export class Application {
     private _terminal?: Terminal;
-    public client?: LanguageClient;
-    public modelRoot?: string;
+    public status: "LOADING" | "STARTED" | "ERROR" = "LOADING";
+
+    constructor(
+        public readonly _configPath: string,
+        public readonly config: TopModelConfig,
+        public readonly extensionContext: ExtensionContext,
+    ) {
+        makeAutoObservable(this);
+        window.onDidCloseTerminal((terminal) => {
+            if (terminal.name === this._terminal?.name) {
+                this._terminal = undefined;
+            }
+        });
+        this.start();
+    }
+
     public get terminal(): Terminal {
         if (!this._terminal) {
             this._terminal = window.createTerminal({
@@ -23,48 +36,12 @@ export class Application {
         return this._terminal;
     }
 
-    public status: "LOADING" | "STARTED" | "ERROR" = "LOADING";
-    constructor(
-        public readonly _configPath: string,
-        public readonly config: TopModelConfig,
-        public readonly extensionContext: ExtensionContext,
-        configs: { config: TopModelConfig; file: Uri }[],
-    ) {
-        makeAutoObservable(this);
-        this.status = "LOADING";
-        window.onDidCloseTerminal((terminal) => {
-            if (terminal.name === this._terminal?.name) {
-                this._terminal = undefined;
-            }
-        });
-        const shouldStartLanguageServer =
-            configs.find(
-                (c) =>
-                    path.resolve(this.extensionContext.asAbsolutePath(c.file.path), c.config.modelRoot ?? "./") ===
-                    this.modelRootPath,
-            )?.config === config;
-        this.start(shouldStartLanguageServer);
-
-        if (shouldStartLanguageServer) {
-            workspace.onDidSaveTextDocument(async (event) => {
-                if (event.uri.fsPath.toLowerCase() === this._configPath.toLowerCase()) {
-                    if (await this.validateConfigFile()) {
-                        await this.client?.stop();
-                        this.status = "LOADING";
-                        this.startLanguageServer();
-                    }
-                }
-            });
-        }
-    }
-
-    public get modelRootPath() {
-        const cp = this.extensionContext.asAbsolutePath(this._configPath);
-        return path.resolve(cp, this.config.modelRoot ?? "./");
+    public get modelRoot(): string {
+        return this.config.modelRoot ?? this.configFolder;
     }
 
     public get modelRootFolder() {
-        return path.dirname(path.resolve(this._configPath, this.config.modelRoot ?? "./"));
+        return path.dirname(path.resolve(this._configPath, this.modelRoot ?? "./"));
     }
 
     public get configPath() {
@@ -79,6 +56,16 @@ export class Application {
         return workspace.workspaceFolders?.find((w) => {
             return this._configPath.toLowerCase().includes(w.uri.fsPath.toLowerCase());
         });
+    }
+
+    public async start() {
+        this.status = (await this.validateConfigFile()) ? "STARTED" : "ERROR";
+    }
+
+    public startModgen(watch: boolean) {
+        let p = this._configPath;
+        this.terminal.sendText(`modgen -f ${p}` + (watch ? " --watch" : ""));
+        this.terminal.show();
     }
 
     public async validateConfigFile() {
@@ -109,39 +96,5 @@ export class Application {
         }
 
         return true;
-    }
-
-    public async start(shouldStartLanguageServer: boolean) {
-        if (shouldStartLanguageServer && (await this.validateConfigFile())) {
-            this.startLanguageServer();
-        } else {
-            this.status = "STARTED";
-        }
-    }
-
-    public startModgen(watch: boolean) {
-        let path = this._configPath;
-        this.terminal.sendText(`modgen -f ${path}` + (watch ? " --watch" : ""));
-        this.terminal.show();
-    }
-
-    private async startLanguageServer() {
-        const args = [
-            this.extensionContext.asAbsolutePath(path.join(`./language-server`, `TopModel.LanguageServer.dll`)),
-        ];
-        args.push(this._configPath);
-        let serverOptions: ServerOptions = {
-            run: { command: SERVER_EXE, args },
-            debug: { command: SERVER_EXE, args },
-        };
-        this.modelRoot = this.config.modelRoot ?? this.configFolder;
-        this.client = new LanguageClient(
-            `TopModel - ${this.config.app}`,
-            `TopModel - ${this.config.app}`,
-            serverOptions,
-            { workspaceFolder: this.workspaceFolder },
-        );
-        await this.client.start();
-        this.status = "STARTED";
     }
 }

--- a/TopModel.VSCode/src/application.ts
+++ b/TopModel.VSCode/src/application.ts
@@ -22,7 +22,7 @@ export class Application {
                 this._terminal = undefined;
             }
         });
-        this.start();
+        this.refreshConfig();
     }
 
     public get terminal(): Terminal {
@@ -58,7 +58,8 @@ export class Application {
         });
     }
 
-    public async start() {
+    public async refreshConfig() {
+        this.status = "LOADING";
         this.status = (await this.validateConfigFile()) ? "STARTED" : "ERROR";
     }
 

--- a/TopModel.VSCode/src/extension.ts
+++ b/TopModel.VSCode/src/extension.ts
@@ -23,12 +23,26 @@ export async function activate(ctx: ExtensionContext) {
             state = new State(ctx);
             state.applications.push(...confs.map((conf) => new Application(conf.file.fsPath, conf.config, ctx)));
 
-            if (confs.length > 0) {
-                await state.startLanguageServer();
+            if (state.applications.length > 0) {
+                const validConfigs: string[] = [];
+                for (const app of state.applications) {
+                    const isValid = await app.validateConfigFile();
+                    if (isValid) {
+                        validConfigs.push(app.configPath);
+                    }
+                }
+                await state.startLanguageServer(validConfigs);
 
                 workspace.onDidSaveTextDocument(async (event) => {
-                    if (confs.some((c) => c.file.fsPath.toLowerCase() === event.uri.fsPath.toLowerCase())) {
-                        state.client?.restart();
+                    for (const app of state.applications) {
+                        if (app.configPath.toLowerCase() === event.uri.fsPath.toLowerCase()) {
+                            const isValid = await app.validateConfigFile();
+                            if (isValid) {
+                                state.lspStatus = "LOADING";
+                                await state.client?.restart();
+                                state.lspStatus = "READY";
+                            }
+                        }
                     }
                 });
             }

--- a/TopModel.VSCode/src/extension.ts
+++ b/TopModel.VSCode/src/extension.ts
@@ -20,9 +20,18 @@ export async function activate(ctx: ExtensionContext) {
         const installed = await checkDotnetInstall();
         if (installed) {
             const confs = await findConfFiles();
-            const applications = confs.map((conf) => new Application(conf.file.fsPath, conf.config, ctx, confs));
             state = new State(ctx);
-            state.applications.push(...applications);
+            state.applications.push(...confs.map((conf) => new Application(conf.file.fsPath, conf.config, ctx)));
+
+            if (confs.length > 0) {
+                await state.startLanguageServer();
+
+                workspace.onDidSaveTextDocument(async (event) => {
+                    if (confs.some((c) => c.file.fsPath.toLowerCase() === event.uri.fsPath.toLowerCase())) {
+                        state.client?.restart();
+                    }
+                });
+            }
         }
     } catch (error: any) {
         handleError(error);

--- a/TopModel.VSCode/src/preview.ts
+++ b/TopModel.VSCode/src/preview.ts
@@ -13,9 +13,9 @@ import {
     Position,
     Range,
 } from "vscode";
-import { Application } from "./application";
 import { Mermaid } from "./types";
 import { t } from "./i18n";
+import { LanguageClient } from "vscode-languageclient/node";
 
 export class TopModelPreviewPanel {
     private readonly diagramMap: Record<string, Mermaid> = {};
@@ -29,7 +29,7 @@ export class TopModelPreviewPanel {
 
     constructor(
         context: ExtensionContext,
-        private readonly applications: Application[],
+        private readonly client?: LanguageClient,
     ) {
         makeAutoObservable(this);
         autorun(() => this.refresh());
@@ -85,19 +85,6 @@ export class TopModelPreviewPanel {
         );
     }
 
-    get currentApplication(): Application {
-        if (this.currentFsPath) {
-            return (
-                this.applications.find((c) => {
-                    if (this.currentFsPath.includes(c.modelRootFolder || "")) {
-                        return c;
-                    }
-                }) ?? this.applications[0]
-            );
-        }
-        return this.applications[0];
-    }
-
     async handleMessage(message: any) {
         if (message.type === "update:matrix") {
             this.matrix = message.matrix;
@@ -108,7 +95,7 @@ export class TopModelPreviewPanel {
         if (message.type === "click:class") {
             const className = message.className;
             const symbolInformations: SymbolInformation[] =
-                (await this.currentApplication?.client?.sendRequest("workspace/symbol", {
+                (await this.client?.sendRequest("workspace/symbol", {
                     query: className,
                 })) ?? [];
             const symbol = symbolInformations.find((s) => s.name === className);
@@ -128,8 +115,8 @@ export class TopModelPreviewPanel {
     }
 
     async refresh() {
-        if (this.currentApplication?.client) {
-            const data = await this.currentApplication.client.sendRequest("mermaid", {
+        if (this.client) {
+            const data = await this.client.sendRequest("mermaid", {
                 uri: this.currentFsPath,
                 scope: this.currentScope,
             });
@@ -139,7 +126,7 @@ export class TopModelPreviewPanel {
     }
 
     get webviewContent() {
-        if (!(this.diagramMap[this.currentFsPath] && this.currentApplication)) {
+        if (!(this.diagramMap[this.currentFsPath] && this.client)) {
             return "";
         }
         return `<!DOCTYPE html>
@@ -296,7 +283,7 @@ export class TopModelPreviewPanel {
     }
 
     get appTitle() {
-        return "[" + this.currentApplication.config.app + "]";
+        return `[${this.diagramMap[this.currentFsPath].app}]`;
     }
 
     get moduleTitle() {

--- a/TopModel.VSCode/src/state.ts
+++ b/TopModel.VSCode/src/state.ts
@@ -1,5 +1,5 @@
 import { autorun, makeAutoObservable } from "mobx";
-import { commands, ExtensionContext, Position, StatusBarAlignment, StatusBarItem, window } from "vscode";
+import { commands, ExtensionContext, Position, StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import { Application } from "./application";
 import { COMMANDS, COMMANDS_OPTIONS, SERVER_EXE } from "./const";
@@ -109,10 +109,13 @@ export class State {
         return "READY";
     }
 
-    async startLanguageServer(): Promise<void> {
+    async startLanguageServer(configFiles: string[]): Promise<void> {
         this.lspStatus = "LOADING";
         try {
-            const args = [this.context.asAbsolutePath(path.join("./language-server", "TopModel.LanguageServer.dll"))];
+            const args = [
+                this.context.asAbsolutePath(path.join("./language-server", "TopModel.LanguageServer.dll")),
+                ...configFiles.flatMap((f) => ["-f", f]),
+            ];
             const serverOptions: ServerOptions = {
                 run: { command: SERVER_EXE, args },
                 debug: { command: SERVER_EXE, args },

--- a/TopModel.VSCode/src/state.ts
+++ b/TopModel.VSCode/src/state.ts
@@ -1,11 +1,13 @@
 import { autorun, makeAutoObservable } from "mobx";
 import { commands, ExtensionContext, Position, StatusBarAlignment, StatusBarItem, window } from "vscode";
+import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import { Application } from "./application";
-import { COMMANDS, COMMANDS_OPTIONS } from "./const";
+import { COMMANDS, COMMANDS_OPTIONS, SERVER_EXE } from "./const";
 import { t } from "./i18n";
 import { TopModelPreviewPanel } from "./preview";
 import { TmdTool } from "./tool";
 import { Status } from "./types";
+import path = require("path");
 
 const open = require("open");
 
@@ -16,6 +18,8 @@ export class State {
     };
     topModelStatusBar: StatusBarItem;
     applications: Application[] = [];
+    _client?: LanguageClient;
+    lspStatus: "LOADING" | "READY" | "ERROR" = "LOADING";
     error?: string;
     preview?: TopModelPreviewPanel;
     constructor(public readonly context: ExtensionContext) {
@@ -25,6 +29,10 @@ export class State {
         autorun(() => this.updateStatusBar());
         this.initTools();
         this.registerCommands();
+    }
+
+    get client() {
+        return this._client;
     }
 
     get status(): Status {
@@ -96,11 +104,25 @@ export class State {
     }
 
     get appStatus(): Status {
-        return this.applications.some((a) => a.status === "ERROR")
-            ? "ERROR"
-            : this.applications.some((a) => a.status === "LOADING")
-              ? "LOADING"
-              : "READY";
+        if (this.applications.some((a) => a.status === "ERROR") || this.lspStatus === "ERROR") return "ERROR";
+        if (this.applications.some((a) => a.status === "LOADING") || this.lspStatus === "LOADING") return "LOADING";
+        return "READY";
+    }
+
+    async startLanguageServer(): Promise<void> {
+        this.lspStatus = "LOADING";
+        try {
+            const args = [this.context.asAbsolutePath(path.join("./language-server", "TopModel.LanguageServer.dll"))];
+            const serverOptions: ServerOptions = {
+                run: { command: SERVER_EXE, args },
+                debug: { command: SERVER_EXE, args },
+            };
+            this._client = new LanguageClient("TopModel", "TopModel", serverOptions, {});
+            await this._client.start();
+            this.lspStatus = "READY";
+        } catch {
+            this.lspStatus = "ERROR";
+        }
     }
 
     get toolsStatus(): Status {
@@ -142,7 +164,7 @@ export class State {
     private registerPreviewCommand() {
         commands.registerCommand(COMMANDS.preview, () => {
             if (!this.preview) {
-                this.preview = new TopModelPreviewPanel(this.context, this.applications);
+                this.preview = new TopModelPreviewPanel(this.context, this.client);
                 this.preview.panel.onDidDispose(
                     () => (this.preview = undefined),
                     undefined,

--- a/TopModel.VSCode/src/types.ts
+++ b/TopModel.VSCode/src/types.ts
@@ -4,10 +4,11 @@ export type TopModelConfig = {
 };
 
 export class TopModelException {
-    constructor(public readonly message: string) { }
+    constructor(public readonly message: string) {}
 }
 
 export type Mermaid = {
+    app: string;
     diagram: string;
     module: string;
     fileName: string;

--- a/TopModel.slnx
+++ b/TopModel.slnx
@@ -16,5 +16,6 @@
   <Project Path="TopModel.LanguageServer/TopModel.LanguageServer.csproj" />
   <Project Path="TopModel.ModelGenerator/TopModel.ModelGenerator.csproj" />
   <Project Path="TopModel.Utils/TopModel.Utils.csproj" />
+  <Project Path="TopModel.Utils.Cli/TopModel.Utils.Cli.csproj" />
   <Project Path="TopModel.Utils.Mermaid/TopModel.Utils.Mermaid.csproj" />
 </Solution>

--- a/docs/docs/tmdgen.md
+++ b/docs/docs/tmdgen.md
@@ -57,6 +57,7 @@ tmdgen
 
 - **`--file`**/**`-f`** : Précise le fichier de configuration à utiliser. Par défaut, l'outil cherchera tous les fichiers de configuration au format `tmdgen*.config`.
 - **`--watch`**/**`-w`** : Permet de surveiller les modifications du fichier de configuration `tmdgen.config` et de relancer la génération automatiquement. À la différence de `modgen`, cette option ne permet de suivre les modifications que du fichier de configuration.
+- **`--check`**/**`-c`** : Vérifie que la génération est à jour (aucun fichier ne doit être généré). Retourne un code de sortie `1` si des fichiers ont été créés, modifiés ou supprimés. Utile en CI/CD pour s'assurer que les fichiers `.tmd` sont bien synchronisés avec leur source.
 
 ### Exemples d'utilisation
 
@@ -69,4 +70,7 @@ tmdgen --watch
 
 # Génération d'un fichier de configuration spécifique
 tmdgen --file tmdgen.config
+
+# Vérification que la génération est à jour (CI/CD)
+tmdgen --check
 ```

--- a/tests/model/topmodel.lock
+++ b/tests/model/topmodel.lock
@@ -6,7 +6,7 @@ version: 4.2.4
 custom:
   ../../TopModel.Generator.Csharp: f1991d14810bb39e9bcaf2bc73931878
   ../../TopModel.Generator.Javascript: 03f0545430c92a60e75e455a4d82813c
-  ../../TopModel.Generator.Jpa: 0079e1a6a189cd0bfaa4d810b78563d1
+  ../../TopModel.Generator.Jpa: 72cd3f53a220124ea27220d736df6c1d
   ../../TopModel.Generator.Sql: bdc0e49e9a9aa3b3abd9c69fbbe5f0d4
   ../../TopModel.Generator.Translation: 37bcf602b3079fdf3556fff547655e8f
   ../../TopModel.Generator.Documentation: 950cd4b8b59bcf41532329bb1556984d


### PR DESCRIPTION
Pour permettre l'intégration du LS dans une plus grande variété de clients, il est nécessaire de le rendre plus robuste et plus autonome (vis-à-vis notamment de l'extension VSCode).

Dans cette PR : 

- Gestion des multiples configurations dans le LS
- Découverte des configurations (code mutualisé avec modgen). A voir s'il faut augmenter la profondeur de recherche pour le LS
- Fix bugs capabilities absentes à l'initialisation du Langage Server
  - La requête initiale du client peut ne pas envoyer toutes les capabilities, ce que nous ne gérions pas 
- Simplification du client vscode qui ne doit plus gérer le multiconfig, la tâche étant déléguée au langage Server

RAF : Nous avions déjà discuté de la publication du langage server indépendamment de l'extension VSCode. C'est ce que font les autres langages en tout cas