### PR TITLE
[TopModel.Generator] Refactorisation de modgen

### DIFF
--- a/TopModel.Core/Loaders/ModelFileLoader.cs
+++ b/TopModel.Core/Loaders/ModelFileLoader.cs
@@ -141,6 +141,7 @@ public class ModelFileLoader(
             if (fw.Configs.Count == 0)
             {
                 fw.FileWatcher.Dispose();
+                FileWatchers.Remove(config.ModelRoot);
             }
         };
     }

--- a/TopModel.Generator.Jpa/JavaLanguage/JavaEnum.cs
+++ b/TopModel.Generator.Jpa/JavaLanguage/JavaEnum.cs
@@ -1,5 +1,3 @@
-using NuGet.Packaging;
-
 namespace TopModel.Generator.Jpa;
 
 public class JavaEnum : JavaClass
@@ -15,7 +13,10 @@ public class JavaEnum : JavaClass
     public JavaEnum Add(JavaEnumValue javaEnumValue)
     {
         Values.Add(javaEnumValue);
-        Imports.AddRange(javaEnumValue.Imports);
+        foreach (var import in javaEnumValue.Imports)
+        {
+            Imports.Add(import);
+        }
         return this;
     }
 

--- a/TopModel.Generator/AssembliesUtils.cs
+++ b/TopModel.Generator/AssembliesUtils.cs
@@ -1,0 +1,34 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace TopModel.Generator;
+
+public static class AssembliesUtils
+{
+    private static readonly Dictionary<string, Assembly> loadedAssemblies = AppDomain
+        .CurrentDomain.GetAssemblies()
+        .ToDictionary(a => a.ManifestModule.Name);
+    public static ISet<string> LoadedAssemblies => loadedAssemblies.Keys.ToImmutableHashSet();
+
+    public static IEnumerable<Assembly> LoadAssemblies(IEnumerable<FileInfo> fileInfos)
+    {
+        var assembliesToLoad = fileInfos.Where(f => !f.Name.EndsWith(".resources.dll")).DistinctBy(a => a.Name);
+
+        foreach (var assembly in assembliesToLoad)
+        {
+            if (LoadedAssemblies.Contains(assembly.Name))
+            {
+                yield return loadedAssemblies[assembly.Name];
+                continue;
+            }
+            yield return LoadAssemblyFromFileInfo(assembly);
+        }
+    }
+
+    private static Assembly LoadAssemblyFromFileInfo(FileInfo fileInfo)
+    {
+        var assemblyLoaded = Assembly.LoadFrom(fileInfo.FullName);
+        loadedAssemblies.Add(assemblyLoaded.ManifestModule.Name, assemblyLoaded);
+        return assemblyLoaded;
+    }
+}

--- a/TopModel.Generator/ConfigObserver.cs
+++ b/TopModel.Generator/ConfigObserver.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using Spectre.Console;
+using TopModel.Core;
+using TopModel.Core.Loaders;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class ConfigObserver(
+    FileInfo configInfo,
+    FileChecker fileChecker,
+    int configIndex,
+    Func<ModelConfig, FileInfo, int, TopModelWorker> createWorker
+) : IDisposable
+{
+    private readonly MemoryCache fsCache = new(new MemoryCacheOptions());
+    private FileSystemWatcher? ConfigWatcher;
+    private TopModelWorker? Worker;
+
+    public bool HasError => Worker?.HasError ?? true;
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose()
+    {
+        Worker?.Dispose();
+        ConfigWatcher?.Dispose();
+        fsCache.Dispose();
+    }
+
+    public async Task Start(CancellationToken cancellationToken)
+    {
+        LogConfigFound();
+        StartWatchConfig(cancellationToken);
+        await Run(cancellationToken);
+    }
+
+    private void LogConfigFound()
+    {
+        var color = LogUtils.Colors[configIndex % LogUtils.Colors.Length];
+        AnsiConsole.MarkupLine(
+            $"[{color}]#{configIndex + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), configInfo.FullName)}[/]"
+        );
+    }
+
+    private async Task ReadConfig(CancellationToken cancellationToken)
+    {
+        try
+        {
+            fileChecker.CheckConfigFile(configInfo.FullName);
+            using var text = configInfo.OpenText();
+            var config = fileChecker
+                .DeserializeConfig(await text.ReadToEndAsync(cancellationToken))
+                .Init(configInfo.DirectoryName!);
+            Worker = createWorker(config, configInfo, configIndex);
+        }
+        catch (ModelException me)
+        {
+            AnsiConsole.WriteLine($"[red]{me.Message}[/]");
+        }
+    }
+
+    private async Task Restart(CancellationToken cancellationToken)
+    {
+        Worker?.Dispose();
+        Worker = null;
+        await Run(cancellationToken);
+    }
+
+    private async Task Run(CancellationToken cancellationToken)
+    {
+        await ReadConfig(cancellationToken);
+        if (Worker != null)
+        {
+            await Worker.Run(cancellationToken);
+        }
+    }
+
+    private void StartWatchConfig(CancellationToken cancellationToken)
+    {
+        var fsWatcher = new FileSystemWatcher(configInfo.DirectoryName!, configInfo.Name);
+        fsWatcher.Changed += (sender, args) =>
+        {
+            fsCache.Set(
+                args.FullPath,
+                args,
+                new MemoryCacheEntryOptions()
+                    .AddExpirationToken(
+                        new CancellationChangeToken(new CancellationTokenSource(TimeSpan.FromMilliseconds(500)).Token)
+                    )
+                    .RegisterPostEvictionCallback(
+                        async (k, v, r, a) =>
+                        {
+                            if (r != EvictionReason.TokenExpired)
+                            {
+                                return;
+                            }
+
+                            await Restart(cancellationToken);
+                        }
+                    )
+            );
+        };
+        fsWatcher.IncludeSubdirectories = true;
+        fsWatcher.EnableRaisingEvents = true;
+        ConfigWatcher = fsWatcher;
+    }
+}

--- a/TopModel.Generator/CustomModule.cs
+++ b/TopModel.Generator/CustomModule.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using TopModel.Core;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class CustomModule(
+    string customGenerator,
+    string fullName,
+    string modgenRoot,
+    Microsoft.Extensions.Logging.ILogger logger,
+    TopModelLock topModelLock
+)
+{
+    public bool HasError { get; private set; } = false;
+
+    public static string GetHashFilePath(string modgenRoot, string customGenerator)
+    {
+        return Path.Combine(modgenRoot, customGenerator.Replace('/', '-').Replace('\\', '-'));
+    }
+
+    public async Task BuildAsync(CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(modgenRoot);
+
+        var customDir = Path.GetFullPath(
+            Path.Combine(new FileInfo(Path.GetFullPath(fullName)).DirectoryName!, customGenerator)
+        );
+
+        var customHash =
+            ModuleUtils.GetHash(
+                Directory
+                    .EnumerateFiles(
+                        Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!),
+                        "*.cs",
+                        SearchOption.AllDirectories
+                    )
+                    .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")),
+                customDir
+            ) ?? string.Empty;
+
+        var customHashLocalFile = GetHashFilePath(modgenRoot, customGenerator);
+        var customHashLocal = File.Exists(customHashLocalFile)
+            ? await File.ReadAllTextAsync(customHashLocalFile, cancellationToken)
+            : string.Empty;
+
+        if (
+            !topModelLock.Custom.TryGetValue(customGenerator, out var customLockHash)
+            || customHash != customLockHash
+            || customHash != customHashLocal
+        )
+        {
+            var expectedDll = $"{customGenerator.Replace('\\', '/').Split('/')[^1].ToLower()}.dll";
+            if (!AssembliesUtils.LoadedAssemblies.Contains(expectedDll, StringComparer.CurrentCultureIgnoreCase))
+            {
+                await BuildCSharpProject(customDir, cancellationToken);
+                if (HasError)
+                {
+                    return;
+                }
+
+                logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildCompleted, customGenerator));
+            }
+
+            topModelLock.Custom ??= new Dictionary<string, string>();
+            topModelLock.Custom[customGenerator] = customHash;
+            await File.WriteAllTextAsync(customHashLocalFile, topModelLock.Custom[customGenerator], cancellationToken);
+        }
+    }
+
+    public void Check(TopModelLock topModelLock, Microsoft.Extensions.Logging.ILogger logger)
+    {
+        var projDir = Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!);
+        if (!Directory.EnumerateFiles(projDir, "*.csproj").Any())
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoCsprojFound, customGenerator));
+            HasError = true;
+            return;
+        }
+
+        var assetsPath = Path.Combine(projDir, "obj", "project.assets.json");
+        if (!File.Exists(assetsPath))
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.GeneratorModuleNotBuilt, customGenerator));
+            HasError = true;
+            return;
+        }
+
+        var lockFile = LockFileUtilities.GetLockFile(assetsPath, NullLogger.Instance);
+
+        foreach (
+            var dep in lockFile
+                .Targets.FirstOrDefault(dg => dg.TargetFramework.Version.Major <= VersionUtils.DotnetMajor)
+                ?.Libraries.Where(n => n.Name?.StartsWith("TopModel.Generator") ?? false)
+            ?? []
+        )
+        {
+            if (dep.Name == "TopModel.Generator.Core")
+            {
+                if (dep.Version?.Major != VersionUtils.MajorVersion)
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleBadMajorVersion,
+                            customGenerator,
+                            dep.Version?.ToString() ?? string.Empty,
+                            VersionUtils.Version
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+                else if (dep.Version?.Minor > VersionUtils.MinorVersion)
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.GeneratorModuleNewerVersion,
+                            customGenerator,
+                            dep.Version?.ToString() ?? string.Empty,
+                            VersionUtils.Version
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+            }
+            else
+            {
+                var configKey = dep.Name?.Split('.')[^1].ToLower() ?? string.Empty;
+                if (!topModelLock.Modules.TryGetValue(configKey, out var ev))
+                {
+                    topModelLock.Modules.Add(configKey, new() { Version = dep.Version?.ToString() ?? string.Empty });
+                }
+                else if (ev.Version != dep.Version?.ToString())
+                {
+                    logger.LogError(
+                        LocalizeUtils.Localize(
+                            GeneratorMessage.CustomModuleWrongLockfileVersion,
+                            customGenerator,
+                            configKey,
+                            dep.Version?.ToString() ?? string.Empty,
+                            ev
+                        )
+                    );
+                    HasError = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    public void LoadAssemblies(string fullName, IList<Type> generators)
+    {
+        Check(topModelLock, logger);
+        if (HasError)
+        {
+            return;
+        }
+
+        var files = new DirectoryInfo(
+            Path.Combine(Path.GetFullPath(customGenerator, new FileInfo(fullName).DirectoryName!), "bin")
+        ).GetFiles($"*.dll", SearchOption.AllDirectories);
+        var assemblies = AssembliesUtils.LoadAssemblies(files);
+        if (HasError)
+        {
+            return;
+        }
+
+        var assemblyModule = assemblies.Where(a =>
+            a.ManifestModule.Name.Equals(
+                $"{customGenerator
+                .Replace('\\', '/')
+                .Split('/')[^1].ToLower()}.dll",
+                StringComparison.CurrentCultureIgnoreCase
+            )
+        );
+        var moduleExportedTypes = assemblyModule.SelectMany(a => a.GetExportedTypes());
+        var generatorTypes = moduleExportedTypes.Where(t => ModuleUtils.GetIGenRegInterface(t) != null);
+        generators.AddRange(generatorTypes);
+        return;
+    }
+
+    private async Task BuildCSharpProject(string customDir, CancellationToken cancellationToken)
+    {
+        logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.BuildInProgress, customGenerator));
+        var build = Process.Start(
+            new ProcessStartInfo
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                FileName = "dotnet",
+                Arguments = "build -v q",
+                WorkingDirectory = customDir,
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8,
+            }
+        );
+        string stdout;
+        try
+        {
+            await using var registration = cancellationToken.Register(() => build?.Kill());
+            var stdoutTask = build!.StandardOutput.ReadToEndAsync(cancellationToken);
+            await build!.WaitForExitAsync(cancellationToken);
+            stdout = await stdoutTask;
+        }
+        catch (OperationCanceledException)
+        {
+            HasError = true;
+            return;
+        }
+
+        if (build.ExitCode != 0)
+        {
+            logger.LogError(LocalizeUtils.Localize(GeneratorMessage.BuildError, customGenerator));
+            var output = stdout.Trim();
+            if (!string.IsNullOrEmpty(output))
+            {
+                logger.LogError(output);
+            }
+            HasError = true;
+            return;
+        }
+    }
+}

--- a/TopModel.Generator/GeneratorMessage.cs
+++ b/TopModel.Generator/GeneratorMessage.cs
@@ -1,0 +1,33 @@
+namespace TopModel.Generator;
+
+public enum GeneratorMessage
+{
+    ExcludedTags,
+    UpdateModeEnabled,
+    BuildInProgress,
+    BuildError,
+    BuildCompleted,
+    NoCsprojFound,
+    GeneratorModuleNotBuilt,
+    GeneratorModuleBadMajorVersion,
+    GeneratorModuleNewerVersion,
+    CustomModuleWrongLockfileVersion,
+    NoGeneratorModuleFound,
+    ModuleCorrupted,
+    ModuleInstallInProgress,
+    PackageNotFound,
+    ModuleInstallCompleted,
+    ModuleBadMajorVersion,
+    ModuleNewerVersion,
+    GeneratorsInUse,
+    GeneratorUpdatesAvailable,
+    ModgenUpdateCommand,
+    GeneratingConfigSchema,
+    ConfigSchemaGenerated,
+    ConfigNameAlreadyInUse,
+    ReferencedConfigNotFound,
+    ExcludeOptionDescription,
+    UpdateOptionDescription,
+    SchemaOptionDescription,
+    RootCommandDescription,
+}

--- a/TopModel.Generator/GeneratorMessage.fr.resx
+++ b/TopModel.Generator/GeneratorMessage.fr.resx
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExcludedTags" xml:space="preserve">
+    <value>Tags [teal]exclus[/] de la génération : {0}.</value>
+  </data>
+  <data name="UpdateModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]update[/] activé pour : [gray]{0}[/].</value>
+  </data>
+  <data name="BuildInProgress" xml:space="preserve">
+    <value>Build de '{0}' en cours...</value>
+  </data>
+  <data name="BuildError" xml:space="preserve">
+    <value>Erreur lors du build de '{0}'</value>
+  </data>
+  <data name="BuildCompleted" xml:space="preserve">
+    <value>Build de '{0}' terminé.</value>
+  </data>
+  <data name="NoCsprojFound" xml:space="preserve">
+    <value>Aucun fichier csproj trouvé pour le module de générateurs '{0}'.</value>
+  </data>
+  <data name="GeneratorModuleNotBuilt" xml:space="preserve">
+    <value>Le module de générateurs '{0}' n'a pas été buildé correctement...</value>
+  </data>
+  <data name="GeneratorModuleBadMajorVersion" xml:space="preserve">
+    <value>Le module de générateurs '{0}' ne référence pas la bonne version majeure de TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="GeneratorModuleNewerVersion" xml:space="preserve">
+    <value>Le module de générateurs '{0}' référence une version plus récente de TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="CustomModuleWrongLockfileVersion" xml:space="preserve">
+    <value>Le module personalisé '{0}' référence le module '{1}' en version '{2}', ce qui n'est pas la version du lockfile ('{3}').</value>
+  </data>
+  <data name="NoGeneratorModuleFound" xml:space="preserve">
+    <value>Aucun module de générateurs trouvé pour '{0}'.</value>
+  </data>
+  <data name="ModuleCorrupted" xml:space="preserve">
+    <value>Module {0} corrompu, suppression...</value>
+  </data>
+  <data name="ModuleInstallInProgress" xml:space="preserve">
+    <value>Installation de {0}@{1} en cours...</value>
+  </data>
+  <data name="PackageNotFound" xml:space="preserve">
+    <value>Le package {0}@{1} est introuvable.</value>
+  </data>
+  <data name="ModuleInstallCompleted" xml:space="preserve">
+    <value>Installation de {0}@{1} terminée.</value>
+  </data>
+  <data name="ModuleBadMajorVersion" xml:space="preserve">
+    <value>Le module '{0}' ne référence pas la bonne version majeure de TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="ModuleNewerVersion" xml:space="preserve">
+    <value>Le module '{0}' référence une version plus récente de TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="GeneratorsInUse" xml:space="preserve">
+    <value>Générateurs utilisés :{0}</value>
+  </data>
+  <data name="GeneratorUpdatesAvailable" xml:space="preserve">
+    <value>Il existe une mise à jour pour les générateurs suivants :{0}</value>
+  </data>
+  <data name="ModgenUpdateCommand" xml:space="preserve">
+    <value>Vous pouvez lancer la commande `modgen --update {0}` pour effectuer la mise à jour.</value>
+  </data>
+  <data name="GeneratingConfigSchema" xml:space="preserve">
+    <value>Génération du schéma de configuration...</value>
+  </data>
+  <data name="ConfigSchemaGenerated" xml:space="preserve">
+    <value>Schéma de configuration généré avec succès.</value>
+  </data>
+  <data name="ConfigNameAlreadyInUse" xml:space="preserve">
+    <value>Le nom de configuration '{0}' est déjà utilisé.</value>
+  </data>
+  <data name="ReferencedConfigNotFound" xml:space="preserve">
+    <value>La configuration '{0}' n'existe pas, le tag référencé '{1}' pour la config '{2}' sera ignoré.</value>
+  </data>
+  <data name="ExcludeOptionDescription" xml:space="preserve">
+    <value>Tag à ignorer lors de la génération.</value>
+  </data>
+  <data name="UpdateOptionDescription" xml:space="preserve">
+    <value>Met à jour le module de générateurs spécifié (ou tous les modules si 'all').</value>
+  </data>
+  <data name="SchemaOptionDescription" xml:space="preserve">
+    <value>Génère le fichier de schéma JSON du fichier de config.</value>
+  </data>
+  <data name="RootCommandDescription" xml:space="preserve">
+    <value>Lance le générateur topmodel.</value>
+  </data>
+</root>

--- a/TopModel.Generator/GeneratorMessage.resx
+++ b/TopModel.Generator/GeneratorMessage.resx
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExcludedTags" xml:space="preserve">
+    <value>Generation [teal]excluded[/] tags: {0}.</value>
+  </data>
+  <data name="UpdateModeEnabled" xml:space="preserve">
+    <value>[darkcyan]update[/] mode enabled for: [gray]{0}[/].</value>
+  </data>
+  <data name="BuildInProgress" xml:space="preserve">
+    <value>Building '{0}'...</value>
+  </data>
+  <data name="BuildError" xml:space="preserve">
+    <value>Error building '{0}'</value>
+  </data>
+  <data name="BuildCompleted" xml:space="preserve">
+    <value>Build of '{0}' completed.</value>
+  </data>
+  <data name="NoCsprojFound" xml:space="preserve">
+    <value>No csproj file found for generator module '{0}'.</value>
+  </data>
+  <data name="GeneratorModuleNotBuilt" xml:space="preserve">
+    <value>Generator module '{0}' was not built correctly...</value>
+  </data>
+  <data name="GeneratorModuleBadMajorVersion" xml:space="preserve">
+    <value>Generator module '{0}' does not reference the correct major version of TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="GeneratorModuleNewerVersion" xml:space="preserve">
+    <value>Generator module '{0}' references a newer version of TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="CustomModuleWrongLockfileVersion" xml:space="preserve">
+    <value>Custom module '{0}' references module '{1}' in version '{2}', which does not match the lockfile version ('{3}').</value>
+  </data>
+  <data name="NoGeneratorModuleFound" xml:space="preserve">
+    <value>No generator module found for '{0}'.</value>
+  </data>
+  <data name="ModuleCorrupted" xml:space="preserve">
+    <value>Module {0} corrupted, deleting...</value>
+  </data>
+  <data name="ModuleInstallInProgress" xml:space="preserve">
+    <value>Installing {0}@{1}...</value>
+  </data>
+  <data name="PackageNotFound" xml:space="preserve">
+    <value>Package {0}@{1} not found.</value>
+  </data>
+  <data name="ModuleInstallCompleted" xml:space="preserve">
+    <value>Installation of {0}@{1} completed successfully.</value>
+  </data>
+  <data name="ModuleBadMajorVersion" xml:space="preserve">
+    <value>Module '{0}' does not reference the correct major version of TopModel ({1} &lt; {2}).</value>
+  </data>
+  <data name="ModuleNewerVersion" xml:space="preserve">
+    <value>Module '{0}' references a newer version of TopModel ({1} &gt; {2}).</value>
+  </data>
+  <data name="GeneratorsInUse" xml:space="preserve">
+    <value>Generators in use:{0}</value>
+  </data>
+  <data name="GeneratorUpdatesAvailable" xml:space="preserve">
+    <value>Updates available for the following generators:{0}</value>
+  </data>
+  <data name="ModgenUpdateCommand" xml:space="preserve">
+    <value>You can run `modgen --update {0}` to update.</value>
+  </data>
+  <data name="GeneratingConfigSchema" xml:space="preserve">
+    <value>Generating configuration schema...</value>
+  </data>
+  <data name="ConfigSchemaGenerated" xml:space="preserve">
+    <value>Configuration schema generated successfully.</value>
+  </data>
+  <data name="ConfigNameAlreadyInUse" xml:space="preserve">
+    <value>Configuration name '{0}' is already in use.</value>
+  </data>
+  <data name="ReferencedConfigNotFound" xml:space="preserve">
+    <value>Configuration '{0}' does not exist, referenced tag '{1}' for config '{2}' will be ignored.</value>
+  </data>
+  <data name="ExcludeOptionDescription" xml:space="preserve">
+    <value>Tag to ignore during generation.</value>
+  </data>
+  <data name="UpdateOptionDescription" xml:space="preserve">
+    <value>Updates the specified generator module (or all modules if 'all').</value>
+  </data>
+  <data name="SchemaOptionDescription" xml:space="preserve">
+    <value>Generates the JSON schema file for the config file.</value>
+  </data>
+  <data name="RootCommandDescription" xml:space="preserve">
+    <value>Launches the topmodel generator.</value>
+  </data>
+</root>

--- a/TopModel.Generator/ModuleUtils.cs
+++ b/TopModel.Generator/ModuleUtils.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using TopModel.Generator.Core;
+
+namespace TopModel.Generator;
+
+public static class ModuleUtils
+{
+    public static string? GetFolderHash(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return null;
+        }
+
+        return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
+    }
+
+    public static string? GetHash(IEnumerable<string> f, string path)
+    {
+        var md5 = MD5.Create();
+        var files = f.Order().ToList();
+        foreach (var file in files)
+        {
+            var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
+            var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
+            md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
+
+            var contentBytes = File.ReadAllBytes(file);
+            if (files.IndexOf(file) == files.Count - 1)
+            {
+                md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
+            }
+            else
+            {
+                md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
+            }
+        }
+
+        return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
+    }
+
+    public static Type? GetIGenRegInterface(Type t)
+    {
+        return t.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IGeneratorRegistration<>));
+    }
+
+    public static (Type Type, string Name) GetIGenRegInterfaceAndName(Type generator)
+    {
+        var configType = GetIGenRegInterface(generator)!.GetGenericArguments()[0];
+        var configName = configType.Name.Replace("Config", string.Empty).ToLower();
+        return (configType, configName);
+    }
+}

--- a/TopModel.Generator/Program.cs
+++ b/TopModel.Generator/Program.cs
@@ -1,54 +1,32 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Help;
-using System.Diagnostics;
-using System.Reflection;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Castle.DynamicProxy;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NuGet.Common;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.ProjectModel;
 using Spectre.Console;
 using TopModel.Core;
 using TopModel.Core.Loaders;
 using TopModel.Generator;
-using TopModel.Generator.Core;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
-var fileOption = new Option<IEnumerable<FileInfo>>("--file", "-f")
-{
-    Description = "Chemin vers un fichier de config.",
-};
 var excludeOption = new Option<IEnumerable<string>>("--exclude", "-e")
 {
-    Description = "Tag à ignorer lors de la génération.",
-};
-var watchOption = new Option<bool>("--watch", "-w") { Description = "Lance le générateur en mode 'watch'" };
-var checkOption = new Option<bool>("--check", "-c")
-{
-    Description = "Vérifie que le code généré est conforme au modèle.",
+    Description = LocalizeUtils.Localize(GeneratorMessage.ExcludeOptionDescription),
 };
 var updateOption = new Option<string>("--update", "-u")
 {
-    Description = "Met à jour le module de générateurs spécifié (ou tous les modules si 'all').",
+    Description = LocalizeUtils.Localize(GeneratorMessage.UpdateOptionDescription),
 };
 var schemaOption = new Option<bool>("--schema", "-s")
 {
-    Description = "Génère le fichier de schéma JSON du fichier de config.",
+    Description = LocalizeUtils.Localize(GeneratorMessage.SchemaOptionDescription),
 };
 
-var command = new RootCommand("Lance le générateur topmodel.")
+var command = new RootCommand(LocalizeUtils.Localize(GeneratorMessage.RootCommandDescription))
 {
-    fileOption,
+    TopModelCli.FileOption,
     excludeOption,
-    watchOption,
-    checkOption,
+    TopModelCli.WatchOption,
+    TopModelCli.CheckOption,
     updateOption,
     schemaOption,
 };
@@ -63,794 +41,110 @@ if (result.GetResult(helpOption) != null || result.GetResult(versionOption) != n
     return await result.InvokeAsync();
 }
 
-var files = result.GetValue(fileOption) ?? [];
-var watchMode = result.GetValue(watchOption);
+var files = result.GetValue(TopModelCli.FileOption) ?? [];
+var watchMode = result.GetValue(TopModelCli.WatchOption);
 var excludedTags = result.GetValue(excludeOption)?.ToArray() ?? [];
-var checkMode = result.GetValue(checkOption);
+var checkMode = result.GetValue(TopModelCli.CheckOption);
 var updateMode = result.GetValue(updateOption);
 var schemaMode = result.GetValue(schemaOption);
 
-var fileChecker = new FileChecker("schema.config.json");
-var configs = new Dictionary<string, ModelConfig>();
-var returnCode = 0;
-
-void HandleFile(FileInfo file)
+using var cts = new CancellationTokenSource();
+await TopModelCli.StartPackage("TopModel.Generator", cts.Token);
+var configs = new List<FileInfo>();
+var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
+foreach (var file in TopModelCli.ResolveFiles(files, pattern))
 {
-    try
-    {
-        fileChecker.CheckConfigFile(file.FullName);
-        using var text = file.OpenText();
-        var config = fileChecker.DeserializeConfig(text.ReadToEnd()).Init(file.DirectoryName!);
-        configs.Add(file.FullName, config);
-    }
-    catch (ModelException me)
-    {
-        returnCode = 1;
-        AnsiConsole.WriteLine($"[red]{me.Message}[/]");
-    }
-}
-
-if (files.Any())
-{
-    foreach (var file in files)
-    {
-        if (!file.Exists)
-        {
-            AnsiConsole.MarkupLine($"[red]{file.FullName}[/]");
-        }
-        else
-        {
-            HandleFile(file);
-        }
-    }
-}
-else
-{
-    var dir = Directory.GetCurrentDirectory();
-    var pattern = new Regex("topmodel\\.?([a-zA-Z-_.]*)\\.config$");
-
-    void SearchConfigFile(string dirName, int depth = 0)
-    {
-        if (depth > 3)
-        {
-            return;
-        }
-
-        foreach (var entryName in Directory.EnumerateFileSystemEntries(dirName))
-        {
-            if (Directory.Exists(entryName))
-            {
-                SearchConfigFile(entryName, depth + 1);
-            }
-            else if (pattern.IsMatch(entryName))
-            {
-                HandleFile(new FileInfo(entryName));
-            }
-        }
-    }
-
-    SearchConfigFile(dir);
-
-    if (configs.Count == 0)
-    {
-        var found = false;
-        while (!found && dir != null)
-        {
-            dir = Directory.GetParent(dir)?.FullName;
-            if (dir != null)
-            {
-                foreach (var fileName in Directory.EnumerateFiles(dir).Where(f => pattern.IsMatch(f)))
-                {
-                    HandleFile(new FileInfo(fileName));
-                    found = true;
-                }
-            }
-        }
-    }
+    configs.Add(file);
 }
 
 if (configs.Count == 0)
 {
-    AnsiConsole.MarkupLine($"[red]Aucun fichier de configuration trouvé.[/]");
+    AnsiConsole.MarkupLine($"[red]{LocalizeUtils.Localize(CliMessage.NoConfigFileFound)}[/]");
     return 1;
-}
-
-var version = Assembly
-    .GetEntryAssembly()!
-    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
-    .InformationalVersion;
-var majorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
-var minorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
-var prerelease = version.Contains('-');
-
-var colors = new[] { "teal", "olive", "yellow", "aqua" };
-
-AnsiConsole.MarkupLine($"========= TopModel.Generator v{version} =========");
-AnsiConsole.WriteLine();
-
-var latestVersion = await NugetUtils.GetLatestVersionAsync("TopModel.Generator", prerelease: prerelease);
-if (latestVersion != null && latestVersion.Version != version)
-{
-    AnsiConsole.MarkupLine($"[yellow]Nouvelle version disponible : {latestVersion.Version}[/]");
-    AnsiConsole.MarkupLine(
-        "[yellow]Vous pouvez lancer la commande `dotnet tool update -g TopModel.Generator` pour effectuer la mise à jour.[/]"
-    );
-    AnsiConsole.WriteLine();
 }
 
 if (excludedTags.Length > 0)
 {
-    AnsiConsole.MarkupLine($"Tags [teal]exclus[/] de la génération : {string.Join(", ", excludedTags)}.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(GeneratorMessage.ExcludedTags, string.Join(", ", excludedTags)));
 }
 
 if (updateMode != null)
 {
-    AnsiConsole.MarkupLine($"Mode [darkcyan]update[/] activé pour : [gray]{updateMode}[/].");
-    await NugetUtils.ClearAsync();
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(GeneratorMessage.UpdateModeEnabled, updateMode));
+    await NugetUtils.ClearAsync(cts.Token);
 }
 
 if (watchMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]watch[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.WatchModeEnabled));
 }
 
 if (checkMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]check[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.CheckModeEnabled));
 }
 
-AnsiConsole.WriteLine("Fichiers de configuration trouvés :");
-
-for (var i = 0; i < configs.Count; i++)
-{
-    var fullName = configs.ElementAt(i).Key;
-    var color = colors[i % colors.Length];
-    AnsiConsole.MarkupLine($"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), fullName)}[/]");
-}
-
-static Type? GetIGenRegInterface(Type t)
-{
-    return t.GetInterfaces()
-        .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IGeneratorRegistration<>));
-}
-
-static (Type Type, string Name) GetIGenRegInterfaceAndName(Type generator)
-{
-    var configType = GetIGenRegInterface(generator)!.GetGenericArguments()[0];
-    var configName = configType.Name.Replace("Config", string.Empty).ToLower();
-    return (configType, configName);
-}
-
-var dotnetMajor = Environment.Version.Major;
-var providers = new List<IDisposable>();
 var loggerProvider = new LoggerProvider();
-var hasErrors = Enumerable.Range(0, configs.Count).Select(_ => false).ToArray();
-var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(a => a.ManifestModule.Name).ToHashSet();
-var proxyGenerator = new ProxyGenerator();
-var interceptor = new ReferencedTagInterceptor();
+Console.CancelKeyPress += (sender, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cts.Cancel();
+};
 
+FileChecker FileChecker = new("schema.config.json");
+
+TopModelWorker CreateWorker(ModelConfig config, FileInfo configInfo, int configIndex)
+{
+    return new TopModelWorker(config, configInfo.FullName, loggerProvider, configIndex, FileChecker)
+    {
+        UpdateMode = updateMode,
+        SchemaMode = schemaMode,
+        WatchMode = watchMode,
+        ExcludedTags = excludedTags,
+    };
+}
+IList<ConfigObserver> ConfigObservers = [];
 for (var i = 0; i < configs.Count; i++)
 {
-    var (fullName, config) = configs.ElementAt(i);
-
-    var storeConfig = new LoggingScope(i + 1, colors[i % colors.Length]);
-    var logger = loggerProvider.CreateLogger("TopModel.Generator");
-    using var scope = logger.BeginScope(storeConfig);
-    var topModelLock = new TopModelLock(config, logger);
-
-    AnsiConsole.WriteLine();
-
-    var modgenRoot = Path.GetFullPath(".modgen", config.ModelRoot);
-
-    if (updateMode == "all")
-    {
-        topModelLock.Modules = new Dictionary<string, TopModelLockModule>();
-
-        if (Directory.Exists(modgenRoot))
-        {
-            Directory.Delete(modgenRoot, recursive: true);
-        }
-    }
-    else if (updateMode != null)
-    {
-        topModelLock.Modules.Remove(updateMode);
-
-        foreach (
-            var module in Directory.GetFileSystemEntries(modgenRoot).Where(p => p.Split('/')[^1].Contains(updateMode))
-        )
-        {
-            Directory.Delete(module, recursive: true);
-        }
-    }
-
-    foreach (var cg in config.CustomGenerators)
-    {
-        Directory.CreateDirectory(modgenRoot);
-
-        var customDir = Path.GetFullPath(Path.Combine(new FileInfo(Path.GetFullPath(fullName)).DirectoryName!, cg));
-
-        var customHash =
-            GetHash(
-                Directory
-                    .EnumerateFiles(
-                        Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!),
-                        "*.cs",
-                        SearchOption.AllDirectories
-                    )
-                    .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")),
-                customDir
-            ) ?? string.Empty;
-
-        var customHashLocalFile = Path.Combine(modgenRoot, cg.Replace('/', '-').Replace('\\', '-'));
-        var customHashLocal = File.Exists(customHashLocalFile)
-            ? await File.ReadAllTextAsync(customHashLocalFile)
-            : string.Empty;
-
-        if (
-            !topModelLock.Custom.TryGetValue(cg, out var customLockHash)
-            || customHash != customLockHash
-            || customHash != customHashLocal
-        )
-        {
-            logger.LogInformation($"Build de '{cg}' en cours...");
-            var build = Process.Start(
-                new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "dotnet",
-                    Arguments = "build -v q",
-                    WorkingDirectory = customDir,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    StandardOutputEncoding = Encoding.UTF8,
-                    StandardErrorEncoding = Encoding.UTF8,
-                }
-            );
-
-            await build!.StandardOutput.ReadToEndAsync();
-            await build!.StandardError.ReadToEndAsync();
-            await build!.WaitForExitAsync();
-
-            if (build.ExitCode != 0)
-            {
-                logger.LogError($"Erreur lors du build de '{cg}'");
-                logger.LogError((await build.StandardOutput.ReadToEndAsync()).Trim());
-                return 1;
-            }
-
-            logger.LogInformation($"Build de '{cg}' terminé.");
-            topModelLock.Custom ??= new Dictionary<string, string>();
-            topModelLock.Custom[cg] = customHash;
-            await File.WriteAllTextAsync(customHashLocalFile, topModelLock.Custom[cg]);
-        }
-    }
-
-    var generators = new List<Type>();
-    var deps = new List<ModgenDependency>();
-
-    if (Environment.GetEnvironmentVariable("LOCAL_DEV") != null)
-    {
-        var generatorsPath = Path.Combine(
-            new FileInfo(Assembly.GetEntryAssembly()!.Location).DirectoryName!,
-            "../../../.."
-        );
-        var modules = Directory
-            .GetFileSystemEntries(generatorsPath)
-            .Where(e => e.Contains("TopModel.Generator.") && !e.Contains("TopModel.Generator.Core"));
-        var customGeneratorsToAdd = modules.Select(m =>
-            Path.GetRelativePath(new FileInfo(fullName).DirectoryName!, m).Replace('\\', '/')
-        );
-        config.CustomGenerators.AddRange(customGeneratorsToAdd.Where(cg => !config.CustomGenerators.Contains(cg)));
-    }
-
-    foreach (var cg in config.CustomGenerators)
-    {
-        var projDir = Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!);
-
-        if (!Directory.EnumerateFiles(projDir, "*.csproj").Any())
-        {
-            logger.LogError($"Aucun fichier csproj trouvé pour le module de générateurs '{cg}'.");
-            returnCode = 1;
-            continue;
-        }
-
-        var assetsPath = Path.Combine(projDir, "obj", "project.assets.json");
-
-        if (!File.Exists(assetsPath))
-        {
-            logger.LogError($"Le module de générateurs '{cg}' n'a pas été buildé correctement...");
-            returnCode = 1;
-            continue;
-        }
-
-        var lockFile = LockFileUtilities.GetLockFile(assetsPath, NullLogger.Instance);
-
-        foreach (
-            var dep in lockFile
-                .Targets.FirstOrDefault(dg => dg.TargetFramework.Version.Major <= dotnetMajor)
-                ?.Libraries.Where(n => n.Name?.StartsWith("TopModel.Generator") ?? false)
-                ?? []
-        )
-        {
-            if (dep.Name == "TopModel.Generator.Core")
-            {
-                if (dep.Version?.Major != majorVersion)
-                {
-                    logger.LogError(
-                        $"Le module de générateurs '{cg}' ne référence pas la bonne version majeure de TopModel ({dep.Version} < {version})."
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-                else if (dep.Version?.Minor > minorVersion)
-                {
-                    logger.LogError(
-                        $"Le module de générateurs '{cg}' référence une version plus récente de TopModel ({dep.Version} > {version})."
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-            }
-            else
-            {
-                var configKey = dep.Name?.Split('.')[^1].ToLower() ?? string.Empty;
-                if (!topModelLock.Modules.TryGetValue(configKey, out var ev))
-                {
-                    topModelLock.Modules.Add(configKey, new() { Version = dep.Version?.ToString() ?? string.Empty });
-                }
-                else if (ev.Version != dep.Version?.ToString())
-                {
-                    logger.LogError(
-                        $"Le module personalisé '{cg}' référence le module '{configKey}' en version '{dep.Version}', ce qui n'est pas la version du lockfile ('{ev}')."
-                    );
-                    returnCode = 1;
-                    continue;
-                }
-            }
-        }
-
-        if (returnCode == 0)
-        {
-            var assemblies = new DirectoryInfo(
-                Path.Combine(Path.GetFullPath(cg, new FileInfo(fullName).DirectoryName!), "bin")
-            )
-                .GetFiles($"*.dll", SearchOption.AllDirectories)
-                .Where(f => !f.Name.EndsWith(".resources.dll") && !loadedAssemblies.Contains(f.Name))
-                .DistinctBy(a => a.Name)
-                .Select(f => Assembly.LoadFrom(f.FullName))
-                .ToList();
-            loadedAssemblies.UnionWith(assemblies.Select(a => a.ManifestModule.Name));
-            generators.AddRange(
-                assemblies
-                    .Where(a =>
-                        a.ManifestModule.Name.Equals(
-                            $"{cg.Split('/')[^1].ToLower()}.dll",
-                            StringComparison.CurrentCultureIgnoreCase
-                        )
-                    )
-                    .SelectMany(a => a.GetExportedTypes())
-                    .Where(t => GetIGenRegInterface(t) != null)
-            );
-        }
-    }
-
-    if (returnCode != 0)
-    {
-        continue;
-    }
-
-    var resolvedConfigKeys = new Dictionary<string, string>();
-
-    foreach (var configKey in config.Generators.Keys)
-    {
-        if (generators.Exists(g => GetIGenRegInterfaceAndName(g).Name == configKey))
-        {
-            resolvedConfigKeys.Add(configKey, "custom");
-            continue;
-        }
-
-        var fullModuleName = $"TopModel.Generator.{configKey.ToFirstUpper()}";
-
-        if (!topModelLock.Modules.TryGetValue(configKey, out var moduleVersion))
-        {
-            moduleVersion = await NugetUtils.GetLatestVersionAsync(fullModuleName, forceCheck: true, prerelease);
-
-            if (moduleVersion == null)
-            {
-                logger.LogError($"Aucun module de générateurs trouvé pour '{configKey}'.");
-                returnCode = 1;
-                continue;
-            }
-
-            topModelLock.Modules.Add(configKey, moduleVersion);
-        }
-
-        deps.Add(new(configKey, moduleVersion));
-    }
-
-    var hasInstalled = false;
-
-    if (deps.Count > 0)
-    {
-        Directory.CreateDirectory(modgenRoot);
-
-        foreach (var dep in deps)
-        {
-            var depVersion = dep.Version.Version;
-            var moduleFolder = Path.Combine(modgenRoot, $"{dep.ConfigKey}.{depVersion}");
-
-            var depHash = GetFolderHash(moduleFolder);
-
-            if (depHash == null || depHash != dep.Version.Hash)
-            {
-                if (Directory.Exists(moduleFolder))
-                {
-                    logger.LogInformation($"({dep.ConfigKey}) Module corrompu, réinstallation...");
-                    Directory.Delete(moduleFolder, recursive: true);
-                }
-
-                logger.LogInformation($"({dep.ConfigKey}) Installation de {dep.FullName}@{depVersion} en cours...");
-
-                if (!await NugetUtils.DoesPackageExistsAsync(dep.FullName, depVersion))
-                {
-                    logger.LogError($"({dep.ConfigKey}) Le package {dep.FullName}@{depVersion} est introuvable.");
-                    returnCode = 1;
-                    continue;
-                }
-
-                Directory.CreateDirectory(moduleFolder);
-
-                using var packageReader = await NugetUtils.DownloadPackageAsync(dep.FullName, depVersion);
-                var nuspecReader = await packageReader.GetNuspecReaderAsync(default);
-
-                var dependencyGroup = nuspecReader
-                    .GetDependencyGroups()
-                    .OrderByDescending(dg => dg.TargetFramework.Version.Major)
-                    .First(dg => dg.TargetFramework.Version.Major <= dotnetMajor);
-
-                var dependencies = dependencyGroup.Packages;
-                var framework = dependencyGroup.TargetFramework.ToString();
-
-                await File.WriteAllTextAsync(
-                    Path.Combine(moduleFolder, "min-version"),
-                    dependencies.Single(d => d.Id == "TopModel.Generator.Core").VersionRange.MinVersion!.ToString()
-                );
-
-                foreach (
-                    var file in (await packageReader.GetFilesAsync(default)).Where(f =>
-                        f == $"lib/{framework}/{dep.FullName}.dll" || f.EndsWith("config.json")
-                    )
-                )
-                {
-                    packageReader.ExtractFile(
-                        file,
-                        Path.Combine(moduleFolder, file.Split('/')[^1]),
-                        NullLogger.Instance
-                    );
-                }
-
-                var installedDependencies = new List<string>();
-                dependencies = dependencies.Where(d => d.Id != "TopModel.Generator.Core");
-
-                while (dependencies.Any())
-                {
-                    var newDeps = new List<PackageDependency>();
-                    foreach (var otherDep in dependencies)
-                    {
-                        using var packageReaderDep = await NugetUtils.DownloadPackageAsync(
-                            otherDep.Id,
-                            otherDep.VersionRange.MinVersion!.ToString()
-                        );
-                        var file = (await packageReaderDep.GetFilesAsync(default)).SingleOrDefault(f =>
-                            f.StartsWith($"lib/{framework}") && f.EndsWith(".dll") && !f.EndsWith(".resources.dll")
-                        );
-                        if (file != null)
-                        {
-                            packageReaderDep.ExtractFile(
-                                file,
-                                Path.Combine(moduleFolder, file.Split('/')[^1]),
-                                NullLogger.Instance
-                            );
-
-                            installedDependencies.Add(otherDep.Id);
-
-                            var nuspecReaderDep = await packageReaderDep.GetNuspecReaderAsync(default);
-                            if (nuspecReaderDep.GetDependencyGroups().Any())
-                            {
-                                newDeps.AddRange(
-                                    nuspecReaderDep
-                                        .GetDependencyGroups()
-                                        .Single(dg => dg.TargetFramework.ToString() == framework)
-                                        .Packages.Where(dep => !installedDependencies.Contains(dep.Id))
-                                );
-                            }
-                        }
-                    }
-
-                    dependencies = newDeps;
-                }
-
-                hasInstalled = true;
-                logger.LogInformation(
-                    $"({dep.ConfigKey}) Installation de {dep.FullName}@{depVersion} terminée avec succès."
-                );
-                dep.Version.Hash = GetFolderHash(moduleFolder);
-            }
-
-            var minVersionText = await File.ReadAllTextAsync(Path.Combine(moduleFolder, "min-version"));
-            var minVersion = minVersionText.Split('.').Take(2).Select(int.Parse).ToArray();
-            if (minVersion[0] != majorVersion)
-            {
-                logger.LogError(
-                    $"Le module '{dep.ConfigKey}' ne référence pas la bonne version majeure de TopModel ({depVersion} < {version})."
-                );
-                returnCode = 1;
-                continue;
-            }
-            else if (minVersion[1] > minorVersion)
-            {
-                logger.LogError(
-                    $"Le module '{dep.ConfigKey}' référence une version plus récente de TopModel ({minVersionText} > {version})."
-                );
-                returnCode = 1;
-                continue;
-            }
-
-            generators.AddRange(
-                Directory
-                    .GetFiles(moduleFolder, "*.dll")
-                    .SelectMany(a => Assembly.LoadFrom(a).GetExportedTypes().Where(t => GetIGenRegInterface(t) != null))
-            );
-            resolvedConfigKeys.Add(dep.ConfigKey, depVersion);
-        }
-    }
-
-    if (returnCode != 0)
-    {
-        continue;
-    }
-
-    topModelLock.Write();
-
-    foreach (var dep in deps)
-    {
-        dep.LatestVersion = (await NugetUtils.GetLatestVersionAsync(dep.FullName, prerelease: prerelease))?.Version;
-    }
-
-    logger.LogInformation(
-        $"Générateurs utilisés :{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
-    );
-
-    var depsToUpdate = deps.Where(dep => dep.LatestVersion != null && dep.LatestVersion != dep.Version.Version);
-    if (depsToUpdate.Any())
-    {
-        logger.LogWarning(
-            $"Il existe une mise à jour pour les générateurs suivants :{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
-        );
-        logger.LogWarning(
-            $"Vous pouvez lancer la commande `modgen --update {(depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all")}` pour effectuer la mise à jour."
-        );
-    }
-
-    if (schemaMode || hasInstalled)
-    {
-        logger.LogInformation("Génération du schéma de configuration...");
-
-        var schema = JsonNode
-            .Parse(
-                await File.ReadAllTextAsync(
-                    FileChecker.GetFilePath(Assembly.GetExecutingAssembly(), "schema.config.json")
-                )
-            )!
-            .AsObject();
-
-        schema.Remove("additionalProperties");
-        schema.Add("additionalProperties", value: false);
-
-        foreach (var generator in generators)
-        {
-            var (configType, configName) = GetIGenRegInterfaceAndName(generator);
-
-            var configSchema = JsonNode.Parse(@"{""type"": ""array""}")!.AsObject();
-            configSchema.Add(
-                "items",
-                JsonNode.Parse(
-                    await File.ReadAllTextAsync(
-                        FileChecker.GetFilePath(configType.Assembly, $"{configName}.config.json")
-                    )
-                )
-            );
-            schema["properties"]!.AsObject().Add(configName, configSchema);
-        }
-
-        await File.WriteAllTextAsync(
-            fullName + ".schema.json",
-            schema.Root.ToJsonString(
-                new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true }
-            )
-        );
-        var configFile = await File.ReadAllTextAsync(fullName);
-        if (!configFile.StartsWith("# yaml-language-server"))
-        {
-            var relativePath = fullName.ToRelative(config.ConfigRoot);
-            configFile = $"# yaml-language-server: $schema={relativePath}.schema.json \n" + configFile;
-            await File.WriteAllTextAsync(fullName, configFile);
-        }
-
-        logger.LogInformation("Schéma de configuration généré avec succès.");
-    }
-
-    var services = new ServiceCollection()
-        .AddTransient(typeof(ILogger<>), typeof(Logger<>))
-        .AddTransient<ILoggerFactory, LoggerFactory>()
-        .AddSingleton<ILoggerProvider>(loggerProvider)
-        .AddSingleton<IFileWriterProvider>(new GeneratedFileWriterProvider(config))
-        .AddModelStore(fileChecker, config);
-
-    var hasError = false;
-
-    foreach (var generator in generators)
-    {
-        var (configType, configName) = GetIGenRegInterfaceAndName(generator);
-
-        if (config.Generators.TryGetValue(configName, out var genConfigMaps))
-        {
-            for (var j = 0; j < genConfigMaps.Count(); j++)
-            {
-                var genConfigMap = genConfigMaps.ElementAt(j);
-                var number = j + 1;
-
-                try
-                {
-                    var genConfig = (GeneratorConfigBase)fileChecker.GetGenConfig(configName, configType, genConfigMap);
-                    genConfig.InitVariables(config.App, number);
-
-                    genConfig.ExcludedTags = excludedTags;
-
-                    genConfig.TranslateReferences ??= config.I18n.TranslateReferences;
-                    genConfig.TranslateProperties ??= config.I18n.TranslateProperties;
-
-                    ModelUtils.TrimSlashes(genConfig, c => c.OutputDirectory);
-                    ModelUtils.CombinePath(config.ConfigRoot, genConfig, c => c.OutputDirectory);
-
-                    genConfig.Name ??= $"{configName}@{number}";
-                    try
-                    {
-                        config.Configs.Add(genConfig.Name, genConfig);
-                    }
-                    catch (ArgumentException)
-                    {
-                        logger.LogError($"Le nom de configuration '{genConfig.Name}' est déjà utilisé.");
-                        return 1;
-                    }
-
-                    foreach (var referencedTag in genConfig.ReferencedTags)
-                    {
-                        if (config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
-                        {
-                            genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
-                        }
-                        else
-                        {
-                            logger.LogWarning(
-                                $"La configuration '{referencedTag.Value}' n'existe pas, le tag référencé '{referencedTag.Key}' pour la config '{genConfig.Name}' sera ignoré."
-                            );
-                        }
-                    }
-
-                    if (genConfig.ReferencedTagConfigs.Any())
-                    {
-                        genConfig = (GeneratorConfigBase)
-                            proxyGenerator.CreateClassProxyWithTarget(genConfig.GetType(), genConfig, interceptor);
-                    }
-
-                    var instance = Activator.CreateInstance(generator);
-                    instance!.GetType().GetMethod("Register")!.Invoke(instance, [services, genConfig, number]);
-                }
-                catch (ModelException me)
-                {
-                    hasError = true;
-                    returnCode = 1;
-                    AnsiConsole.MarkupLine($"[red]{me.Message.EscapeMarkup()}[/]");
-                    AnsiConsole.WriteLine();
-                }
-            }
-        }
-    }
-
-    if (!hasError)
-    {
-        var provider = services.BuildServiceProvider();
-        providers.Add(provider);
-
-        var modelStore = provider.GetRequiredService<ModelStore>();
-
-        modelStore.DisableLockfile = excludedTags.Length > 0;
-
-        var k = i;
-        modelStore.OnResolve += hasError =>
-        {
-            hasErrors[k] = hasError;
-        };
-
-        await modelStore.LoadFromConfig(watchMode, topModelLock, storeConfig);
-    }
+    var config = configs[i];
+    ConfigObservers.Add(new ConfigObserver(config, FileChecker, i, CreateWorker));
 }
 
-if (watchMode)
+try
 {
-    var autoResetEvent = new AutoResetEvent(initialState: false);
-    Console.CancelKeyPress += (sender, eventArgs) =>
+    foreach (var configObserver in ConfigObservers)
     {
-        eventArgs.Cancel = true;
-        autoResetEvent.Set();
-    };
-    autoResetEvent.WaitOne();
-}
+        await configObserver.Start(cts.Token);
+    }
 
-foreach (var provider in providers)
-{
-    provider.Dispose();
-}
-
-if (hasErrors.Any(he => he))
-{
-    return 1;
-}
-
-if (checkMode && loggerProvider.Changes > 0)
-{
-    AnsiConsole.WriteLine();
-    if (loggerProvider.Changes == 1)
+    if (watchMode)
     {
+        cts.Token.WaitHandle.WaitOne();
+    }
+
+    if (ConfigObservers.Any(w => w.HasError))
+    {
+        return 1;
+    }
+
+    if (checkMode && loggerProvider.Changes > 0)
+    {
+        AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine(
-            $"[red]1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.[/]"
+            loggerProvider.Changes == 1
+                ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
+                : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
         );
-    }
-    else
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]{loggerProvider.Changes} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.[/]"
-        );
+
+        return 1;
     }
 
-    return 1;
+    return 0;
 }
-
-return returnCode;
-
-static string? GetFolderHash(string path)
+finally
 {
-    if (!Directory.Exists(path))
+    foreach (var configObserver in ConfigObservers)
     {
-        return null;
+        configObserver.Dispose();
     }
-
-    return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
-}
-
-static string? GetHash(IEnumerable<string> f, string path)
-{
-    var md5 = MD5.Create();
-    var files = f.Order().ToList();
-    foreach (var file in files)
-    {
-        var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
-        var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
-        md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
-
-        var contentBytes = File.ReadAllBytes(file);
-        if (files.IndexOf(file) == files.Count - 1)
-        {
-            md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
-        }
-        else
-        {
-            md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
-        }
-    }
-
-    return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
 }

--- a/TopModel.Generator/TopModel.Generator.csproj
+++ b/TopModel.Generator/TopModel.Generator.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TopModel.Utils.Cli\TopModel.Utils.Cli.csproj" />
     <ProjectReference Include="..\TopModel.Generator.Core\TopModel.Generator.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/TopModel.Generator/TopModelWorker.cs
+++ b/TopModel.Generator/TopModelWorker.cs
@@ -1,0 +1,726 @@
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Castle.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Spectre.Console;
+using TopModel.Core;
+using TopModel.Core.Loaders;
+using TopModel.Generator;
+using TopModel.Generator.Core;
+using TopModel.Utils;
+using TopModel.Utils.Cli;
+
+namespace TopModel.Generator;
+
+public class TopModelWorker : IDisposable
+{
+    private static readonly ReferencedTagInterceptor interceptor = new();
+    private static readonly ProxyGenerator proxyGenerator = new();
+    private readonly IEnumerable<CustomModule> CustomModules;
+
+    private readonly IList<ModgenDependency> Deps = [];
+    private readonly FileChecker FileChecker;
+
+    private readonly IList<Type> Generators = [];
+    private readonly IList<IDisposable> providers = [];
+    private readonly IDictionary<string, string> resolvedConfigKeys = new Dictionary<string, string>();
+    private readonly IServiceCollection services;
+    private readonly LoggingScope storeConfig;
+
+    private bool HasInstalled = false;
+
+    public TopModelWorker(
+        ModelConfig config,
+        string configFullName,
+        LoggerProvider loggerProvider,
+        int configIndex,
+        FileChecker fileChecker
+    )
+    {
+        FileChecker = fileChecker;
+        storeConfig = new LoggingScope(configIndex + 1, TopModelCli.Colors[configIndex % TopModelCli.Colors.Length]);
+        Config = config;
+        Logger = loggerProvider.CreateLogger("TopModel.Generator");
+        var scope = Logger.BeginScope(storeConfig);
+        if (scope != null)
+        {
+            providers.Add(scope);
+        }
+        TopModelLock = new TopModelLock(config, Logger);
+        ConfigFullName = configFullName;
+        ModgenRoot = Path.GetFullPath(".modgen", config.ModelRoot);
+        AddDevCustomGenerators();
+        CustomModules = Config
+            .CustomGenerators.Select(cg => new CustomModule(cg, ConfigFullName, ModgenRoot, Logger, TopModelLock))
+            .ToList();
+        services = new ServiceCollection()
+            .AddTransient(typeof(ILogger<>), typeof(Logger<>))
+            .AddTransient<ILoggerFactory, LoggerFactory>()
+            .AddSingleton<ILoggerProvider>(loggerProvider)
+            .AddSingleton<IFileWriterProvider>(new GeneratedFileWriterProvider(Config))
+            .AddModelStore(FileChecker, Config);
+    }
+
+    public bool HasError { get; private set; } = false;
+
+    public string? UpdateMode { get; set; }
+    public bool SchemaMode { get; set; }
+    public bool WatchMode { get; set; }
+    public IEnumerable<string> ExcludedTags { get; set; } = [];
+
+    public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    public string ConfigFullName { get; }
+    public string ModgenRoot { get; }
+    public ModelConfig Config { get; }
+    public TopModelLock TopModelLock { get; }
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose()
+    {
+        foreach (var provider in providers)
+        {
+            provider.Dispose();
+        }
+    }
+
+    public async Task LoadModules(CancellationToken cancellationToken)
+    {
+        if (Deps.Count > 0)
+        {
+            Directory.CreateDirectory(ModgenRoot);
+        }
+
+        foreach (var dep in Deps)
+        {
+            await LoadModule(dep, cancellationToken);
+        }
+
+        TopModelLock.Write();
+        if (resolvedConfigKeys.Any())
+        {
+            Logger.LogInformation(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.GeneratorsInUse,
+                    $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", resolvedConfigKeys.Select(rck => $"- {rck.Key}: {rck.Value}"))}"
+                )
+            );
+        }
+
+        CheckDependenciesToUpdate();
+    }
+
+    public async Task Run(CancellationToken cancellationToken)
+    {
+        await InitModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+        await PrepareConfiguration();
+        if (HasError)
+        {
+            return;
+        }
+        await RunGeneration(cancellationToken);
+    }
+
+    public async Task WriteSchema(CancellationToken cancellationToken)
+    {
+        Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.GeneratingConfigSchema));
+        var schema = JsonNode
+            .Parse(
+                await File.ReadAllTextAsync(
+                    FileChecker.GetFilePath(Assembly.GetExecutingAssembly(), "schema.config.json"),
+                    cancellationToken
+                )
+            )!
+            .AsObject();
+
+        schema.Remove("additionalProperties");
+        schema.Add("additionalProperties", value: false);
+
+        foreach (var generator in Generators)
+        {
+            var (configType, configName) = ModuleUtils.GetIGenRegInterfaceAndName(generator);
+
+            var configSchema = JsonNode.Parse(@"{""type"": ""array""}")!.AsObject();
+            configSchema.Add(
+                "items",
+                JsonNode.Parse(
+                    await File.ReadAllTextAsync(
+                        FileChecker.GetFilePath(configType.Assembly, $"{configName}.config.json"),
+                        cancellationToken
+                    )
+                )
+            );
+            schema["properties"]!.AsObject().Add(configName, configSchema);
+        }
+
+        await File.WriteAllTextAsync(
+            ConfigFullName + ".schema.json",
+            schema.Root.ToJsonString(
+                new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true }
+            ),
+            cancellationToken
+        );
+        var configFile = await File.ReadAllTextAsync(ConfigFullName, cancellationToken);
+        if (!configFile.StartsWith("# yaml-language-server"))
+        {
+            var relativePath = ConfigFullName.ToRelative(Config.ConfigRoot);
+            configFile = $"# yaml-language-server: $schema={relativePath}.schema.json \n" + configFile;
+            await File.WriteAllTextAsync(ConfigFullName, configFile, cancellationToken);
+        }
+
+        Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ConfigSchemaGenerated));
+    }
+
+    static async Task<List<PackageDependency>> DownloadMissingDependenciesCascade(
+        string moduleFolder,
+        IEnumerable<PackageDependency> dependencies,
+        string framework,
+        CancellationToken cancellationToken
+    )
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return [];
+        }
+
+        var installedDependencies = new List<PackageDependency>();
+        var newDeps = new List<PackageDependency>();
+        foreach (var otherDep in dependencies)
+        {
+            using var packageReaderDep = await NugetUtils.DownloadPackageAsync(
+                otherDep.Id,
+                otherDep.VersionRange.MinVersion!.ToString(),
+                cancellationToken
+            );
+            var file = (await packageReaderDep.GetFilesAsync(cancellationToken)).SingleOrDefault(f =>
+                f.StartsWith($"lib/{framework}") && f.EndsWith(".dll") && !f.EndsWith(".resources.dll")
+            );
+            if (file != null)
+            {
+                packageReaderDep.ExtractFile(
+                    file,
+                    Path.Combine(moduleFolder, file.Split('/')[^1]),
+                    NullLogger.Instance
+                );
+
+                installedDependencies.Add(otherDep);
+
+                var nuspecReaderDep = await packageReaderDep.GetNuspecReaderAsync(cancellationToken);
+                if (nuspecReaderDep.GetDependencyGroups().Any())
+                {
+                    newDeps.AddRange(
+                        nuspecReaderDep
+                            .GetDependencyGroups()
+                            .Single(dg => dg.TargetFramework.ToString() == framework)
+                            .Packages.Where(dep => !installedDependencies.Select(d => d.Id).Contains(dep.Id))
+                    );
+                }
+            }
+        }
+
+        if (newDeps.Count > 0)
+        {
+            installedDependencies.AddRange(
+                await DownloadMissingDependenciesCascade(moduleFolder, newDeps, framework, cancellationToken)
+            );
+        }
+
+        return installedDependencies;
+    }
+
+    static string? GetFolderHash(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return null;
+        }
+
+        return GetHash(Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories), path);
+    }
+
+    static string? GetHash(IEnumerable<string> f, string path)
+    {
+        var md5 = MD5.Create();
+        var files = f.Order().ToList();
+        foreach (var file in files)
+        {
+            var relativePath = Path.GetRelativePath(path, file).Replace('\\', '/');
+            var pathBytes = Encoding.UTF8.GetBytes(relativePath.ToLower());
+            md5.TransformBlock(pathBytes, 0, pathBytes.Length, pathBytes, 0);
+
+            var contentBytes = File.ReadAllBytes(file);
+            if (files.IndexOf(file) == files.Count - 1)
+            {
+                md5.TransformFinalBlock(contentBytes, 0, contentBytes.Length);
+            }
+            else
+            {
+                md5.TransformBlock(contentBytes, 0, contentBytes.Length, contentBytes, 0);
+            }
+        }
+
+        return md5.Hash != null ? BitConverter.ToString(md5.Hash).Replace("-", string.Empty).ToLower() : null;
+    }
+
+    private void AddDevCustomGenerators()
+    {
+        if (Environment.GetEnvironmentVariable("LOCAL_DEV") != null)
+        {
+            var generatorsPath = Path.GetFullPath(
+                Path.Combine(
+                    new FileInfo(Assembly.GetEntryAssembly()!.Location).DirectoryName!,
+                    Path.Combine("..", "..", "..", "..")
+                )
+            );
+            var modules = Directory
+                .GetFileSystemEntries(generatorsPath)
+                .Where(e => e.Contains("TopModel.Generator.") && !e.Contains("TopModel.Generator.Core"));
+            var customGeneratorsToAdd = modules.Select(m =>
+                Path.GetRelativePath(new FileInfo(ConfigFullName).DirectoryName!, m)
+            );
+
+            Config.CustomGenerators.AddRange(
+                customGeneratorsToAdd.Where(cg =>
+                    !Config.CustomGenerators.Select(c => c.Replace('\\', '/')).Contains(cg.Replace('\\', '/'))
+                )
+            );
+        }
+    }
+
+    private async Task AddRemoteModule(string configKey, CancellationToken cancellationToken)
+    {
+        if (Generators.ToList().Exists(g => ModuleUtils.GetIGenRegInterfaceAndName(g).Name == configKey))
+        {
+            resolvedConfigKeys.Add(configKey, "custom");
+            return;
+        }
+
+        var fullModuleName = $"TopModel.Generator.{configKey.ToFirstUpper()}";
+
+        if (!TopModelLock.Modules.TryGetValue(configKey, out var moduleVersion))
+        {
+            moduleVersion = await NugetUtils.GetLatestVersionAsync(
+                fullModuleName,
+                cancellationToken,
+                forceCheck: true,
+                VersionUtils.Prerelease
+            );
+
+            if (moduleVersion == null)
+            {
+                Logger.LogError(LocalizeUtils.Localize(GeneratorMessage.NoGeneratorModuleFound, configKey));
+                HasError = true;
+                return;
+            }
+            TopModelLock.Modules.Add(configKey, new() { Version = moduleVersion.Version });
+        }
+        else if (!await NugetUtils.DoesPackageExistsAsync(fullModuleName, moduleVersion.Version, cancellationToken))
+        {
+            Logger.LogError(
+                LocalizeUtils.Localize(GeneratorMessage.PackageNotFound, fullModuleName, moduleVersion.Version)
+            );
+            HasError = true;
+            return;
+        }
+        Deps.Add(new(configKey, moduleVersion));
+    }
+
+    private async Task AddRemoteModules(CancellationToken cancellationToken)
+    {
+        foreach (var configKey in Config.Generators.Keys)
+        {
+            await AddRemoteModule(configKey, cancellationToken);
+        }
+    }
+
+    private async Task BuildCustomModulesAsync(CancellationToken cancellationToken)
+    {
+        foreach (var customModule in CustomModules)
+        {
+            await customModule.BuildAsync(cancellationToken);
+            if (customModule.HasError)
+            {
+                HasError = true;
+                return;
+            }
+        }
+    }
+
+    private void CheckDependenciesToUpdate()
+    {
+        var depsToUpdate = GetDependenciesToUpdate();
+        if (depsToUpdate.Any())
+        {
+            Logger.LogWarning(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.GeneratorUpdatesAvailable,
+                    $"{Environment.NewLine}                          {string.Join($"{Environment.NewLine}                          ", depsToUpdate.Select(dep => $"- {dep.ConfigKey}: {dep.Version.Version} -> {dep.LatestVersion}"))}"
+                )
+            );
+            Logger.LogWarning(
+                LocalizeUtils.Localize(
+                    GeneratorMessage.ModgenUpdateCommand,
+                    depsToUpdate.Count() == 1 ? depsToUpdate.Single().ConfigKey : "all"
+                )
+            );
+        }
+    }
+
+    private async Task CheckMinVersionAsync(
+        string moduleFolder,
+        string depVersion,
+        ModgenDependency dep,
+        CancellationToken cancellationToken
+    )
+    {
+        var minVersionText = await File.ReadAllTextAsync(Path.Combine(moduleFolder, "min-version"), cancellationToken);
+        if (NuGetVersion.TryParse(minVersionText, out var minNuGetVersion))
+        {
+            if (minNuGetVersion.Major != VersionUtils.MajorVersion)
+            {
+                Logger.LogError(
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleBadMajorVersion,
+                        dep.ConfigKey,
+                        depVersion,
+                        VersionUtils.Version
+                    )
+                );
+                HasError = true;
+            }
+            else if (minNuGetVersion.Minor > VersionUtils.MinorVersion)
+            {
+                Logger.LogError(
+                    LocalizeUtils.Localize(
+                        GeneratorMessage.ModuleNewerVersion,
+                        dep.ConfigKey,
+                        minVersionText,
+                        VersionUtils.Version
+                    )
+                );
+                HasError = true;
+            }
+        }
+    }
+
+    private async Task DownloadDependencies(
+        ModgenDependency dep,
+        string moduleFolder,
+        CancellationToken cancellationToken
+    )
+    {
+        var depVersion = dep.Version.Version;
+        if (Directory.Exists(moduleFolder))
+        {
+            Logger.LogInformation(LocalizeUtils.Localize(GeneratorMessage.ModuleCorrupted, dep.FullName));
+            Directory.Delete(moduleFolder, recursive: true);
+        }
+
+        Logger.LogInformation(
+            LocalizeUtils.Localize(GeneratorMessage.ModuleInstallInProgress, dep.FullName, depVersion)
+        );
+
+        Directory.CreateDirectory(moduleFolder);
+
+        using var packageReader = await NugetUtils.DownloadPackageAsync(dep.FullName, depVersion, cancellationToken);
+        var nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
+
+        var dependencyGroup = nuspecReader
+            .GetDependencyGroups()
+            .OrderByDescending(dg => dg.TargetFramework.Version.Major)
+            .First(dg => dg.TargetFramework.Version.Major <= VersionUtils.DotnetMajor);
+
+        var dependencies = dependencyGroup.Packages;
+        var framework = dependencyGroup.TargetFramework.ToString();
+        var coreDep = dependencies.Single(d => d.Id == "TopModel.Generator.Core");
+        await File.WriteAllTextAsync(
+            Path.Combine(moduleFolder, "min-version"),
+            coreDep.VersionRange.MinVersion!.ToString(),
+            cancellationToken
+        );
+
+        foreach (
+            var file in (await packageReader.GetFilesAsync(cancellationToken)).Where(f =>
+                f == $"lib/{framework}/{dep.FullName}.dll" || f.EndsWith("config.json")
+            )
+        )
+        {
+            packageReader.ExtractFile(file, Path.Combine(moduleFolder, file.Split('/')[^1]), NullLogger.Instance);
+        }
+
+        var missingDependencies = dependencies.Where(d => d.Id != "TopModel.Generator.Core").ToList();
+        await DownloadMissingDependenciesCascade(moduleFolder, missingDependencies, framework, cancellationToken);
+
+        Logger.LogInformation(
+            LocalizeUtils.Localize(GeneratorMessage.ModuleInstallCompleted, dep.FullName, depVersion)
+        );
+        dep.Version.Hash = GetFolderHash(moduleFolder);
+    }
+
+    private IEnumerable<ModgenDependency> GetDependenciesToUpdate()
+    {
+        return Deps.Where(dep => dep.LatestVersion != null && dep.LatestVersion != dep.Version.Version);
+    }
+
+    private void HandleUpdate()
+    {
+        if (UpdateMode == null)
+        {
+            return;
+        }
+        var modgenRoot = Path.GetFullPath(".modgen", Config.ModelRoot);
+        if (UpdateMode == "all")
+        {
+            TopModelLock.Modules = new Dictionary<string, TopModelLockModule>();
+
+            if (Directory.Exists(modgenRoot))
+            {
+                Directory.Delete(modgenRoot, recursive: true);
+            }
+        }
+        else if (UpdateMode != null)
+        {
+            TopModelLock.Modules.Remove(UpdateMode);
+
+            foreach (
+                var module in Directory
+                    .GetFileSystemEntries(modgenRoot)
+                    .Where(p => p.Split('/')[^1].Contains(UpdateMode))
+            )
+            {
+                Directory.Delete(module, recursive: true);
+            }
+        }
+    }
+
+    private async Task InitModules(CancellationToken cancellationToken)
+    {
+        AnsiConsole.WriteLine();
+
+        HandleUpdate();
+        if (HasError)
+        {
+            return;
+        }
+
+        await BuildCustomModulesAsync(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        LoadCustomModulesAssemblies();
+        if (HasError)
+        {
+            return;
+        }
+
+        await AddRemoteModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        if (Directory.Exists(ModgenRoot))
+        {
+            var usedPrefixes = Deps.Select(d => $"{d.ConfigKey}.").ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in Directory.GetDirectories(ModgenRoot))
+            {
+                if (!usedPrefixes.Any(p => Path.GetFileName(dir).StartsWith(p)))
+                {
+                    Directory.Delete(dir, recursive: true);
+                    Logger.LogInformation($"Supprimé: {dir.ToRelative()}");
+                }
+            }
+        }
+
+        await LoadModules(cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        if (SchemaMode || HasInstalled)
+        {
+            await WriteSchema(cancellationToken);
+        }
+
+        RemoveUnusedCustomModules();
+    }
+
+    private void LoadCustomModulesAssemblies()
+    {
+        foreach (var customModule in CustomModules)
+        {
+            customModule.LoadAssemblies(ConfigFullName, Generators);
+            if (HasError)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task LoadModule(ModgenDependency dep, CancellationToken cancellationToken)
+    {
+        var depVersion = dep.Version.Version;
+        var moduleFolder = Path.Combine(ModgenRoot, $"{dep.ConfigKey}.{depVersion}");
+
+        var depHash = GetFolderHash(moduleFolder);
+
+        if (depHash == null || depHash != dep.Version.Hash)
+        {
+            await DownloadDependencies(dep, moduleFolder, cancellationToken);
+            HasInstalled = true;
+        }
+        await CheckMinVersionAsync(moduleFolder, depVersion, dep, cancellationToken);
+        if (HasError)
+        {
+            return;
+        }
+
+        Generators.AddRange(
+            Directory
+                .GetFiles(moduleFolder, "*.dll")
+                .SelectMany(a =>
+                    Assembly.LoadFrom(a).GetExportedTypes().Where(t => ModuleUtils.GetIGenRegInterface(t) != null)
+                )
+        );
+        resolvedConfigKeys.Add(dep.ConfigKey, depVersion);
+        dep.LatestVersion = (
+            await NugetUtils.GetLatestVersionAsync(dep.FullName, cancellationToken, prerelease: VersionUtils.Prerelease)
+        )?.Version;
+    }
+
+    private async Task PrepareConfiguration()
+    {
+        foreach (var generator in Generators)
+        {
+            var (configType, configName) = ModuleUtils.GetIGenRegInterfaceAndName(generator);
+
+            if (Config.Generators.TryGetValue(configName, out var genConfigMaps))
+            {
+                for (var j = 0; j < genConfigMaps.Count(); j++)
+                {
+                    var genConfigMap = genConfigMaps.ElementAt(j);
+                    var number = j + 1;
+
+                    try
+                    {
+                        var genConfig = (GeneratorConfigBase)
+                            FileChecker.GetGenConfig(configName, configType, genConfigMap);
+                        genConfig.InitVariables(Config.App, number);
+
+                        genConfig.ExcludedTags = ExcludedTags.ToList();
+
+                        genConfig.TranslateReferences ??= Config.I18n.TranslateReferences;
+                        genConfig.TranslateProperties ??= Config.I18n.TranslateProperties;
+
+                        ModelUtils.TrimSlashes(genConfig, c => c.OutputDirectory);
+                        ModelUtils.CombinePath(Config.ConfigRoot, genConfig, c => c.OutputDirectory);
+
+                        genConfig.Name ??= $"{configName}@{number}";
+                        try
+                        {
+                            Config.Configs.Add(genConfig.Name, genConfig);
+                        }
+                        catch (ArgumentException)
+                        {
+                            Logger.LogError(
+                                LocalizeUtils.Localize(GeneratorMessage.ConfigNameAlreadyInUse, genConfig.Name)
+                            );
+                            HasError = true;
+                            return;
+                        }
+
+                        foreach (var referencedTag in genConfig.ReferencedTags)
+                        {
+                            if (Config.Configs.TryGetValue(referencedTag.Value, out var referencedConfig))
+                            {
+                                genConfig.ReferencedTagConfigs.Add(referencedTag.Key, referencedConfig);
+                            }
+                            else
+                            {
+                                Logger.LogWarning(
+                                    LocalizeUtils.Localize(
+                                        GeneratorMessage.ReferencedConfigNotFound,
+                                        referencedTag.Value,
+                                        referencedTag.Key,
+                                        genConfig.Name
+                                    )
+                                );
+                            }
+                        }
+
+                        if (genConfig.ReferencedTagConfigs.Any())
+                        {
+                            genConfig = (GeneratorConfigBase)
+                                proxyGenerator.CreateClassProxyWithTarget(genConfig.GetType(), genConfig, interceptor);
+                        }
+
+                        var instance = Activator.CreateInstance(generator);
+                        instance!.GetType().GetMethod("Register")!.Invoke(instance, [services, genConfig, number]);
+                    }
+                    catch (ModelException me)
+                    {
+                        HasError = true;
+                        AnsiConsole.MarkupLine($"[red]{me.Message.EscapeMarkup()}[/]");
+                        AnsiConsole.WriteLine();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private void RemoveUnusedCustomModules()
+    {
+        var unused = TopModelLock.Custom.Keys.Except(Config.CustomGenerators).ToList();
+        if (unused.Count > 0)
+        {
+            foreach (var key in unused)
+            {
+                TopModelLock.Custom.Remove(key);
+                var hashFile = CustomModule.GetHashFilePath(ModgenRoot, key);
+                if (File.Exists(hashFile))
+                {
+                    File.Delete(hashFile);
+                }
+            }
+
+            TopModelLock.Write();
+        }
+    }
+
+    private async Task RunGeneration(CancellationToken cancellationToken)
+    {
+        var provider = services.BuildServiceProvider();
+        providers.Add(provider);
+
+        var modelStore = provider.GetRequiredService<ModelStore>();
+
+        modelStore.DisableLockfile = ExcludedTags.Any();
+
+        modelStore.OnResolve += he =>
+        {
+            HasError = he;
+        };
+
+        await modelStore.LoadFromConfig(WatchMode, TopModelLock, storeConfig, cancellationToken);
+    }
+}

--- a/TopModel.Generator/VersionUtils.cs
+++ b/TopModel.Generator/VersionUtils.cs
@@ -1,0 +1,16 @@
+using System.Reflection;
+
+namespace TopModel.Generator;
+
+public static class VersionUtils
+{
+    public static readonly int DotnetMajor = Environment.Version.Major;
+    public static readonly int MajorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Major;
+    public static readonly int MinorVersion = Assembly.GetEntryAssembly()!.GetName().Version!.Minor;
+
+    public static readonly string Version = Assembly
+        .GetEntryAssembly()!
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+        .InformationalVersion;
+    public static bool Prerelease => Version.Contains('-');
+}

--- a/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
+++ b/TopModel.ModelGenerator/Database/DatabaseTmdGenerator.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
 namespace TopModel.ModelGenerator.Database;
 
@@ -45,8 +46,8 @@ public abstract class DatabaseTmdGenerator(
     )
     {
         InitConnection();
-        logger.LogInformation($"Connexion à la base de données {config.Source.DbName} réussie !");
-        logger.LogInformation($"Génération en cours, veuillez patienter...");
+        logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.DbConnectionSuccess, config.Source.DbName));
+        logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.GeneratingPleaseWait));
         var columns = await GetColumns();
         var classGroups = columns.GroupBy(c => c.TableName);
 
@@ -541,13 +542,16 @@ public abstract class DatabaseTmdGenerator(
         try
         {
             _connection = GetConnection();
-            logger.LogInformation($"Connexion à la base de données {config.Source.DbName}...");
+            logger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.ConnectingToDb, config.Source.DbName));
             _connection.Open();
         }
         catch (Exception)
         {
             logger.LogInformation(
-                $"Mot de passe{(password != null ? " erroné" : string.Empty)} pour l'utilisateur {config.Source.User}:  "
+                LocalizeUtils.Localize(
+                    password != null ? ModelGeneratorMessage.WrongPasswordPrompt : ModelGeneratorMessage.PasswordPrompt,
+                    config.Source.User ?? string.Empty
+                )
             );
             Passwords.Remove(config.Source.DbName);
             while (true)

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.cs
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.cs
@@ -1,0 +1,12 @@
+namespace TopModel.ModelGenerator;
+
+public enum ModelGeneratorMessage
+{
+    RegisteredGenerators,
+    UpdateCompleted,
+    DbConnectionSuccess,
+    GeneratingPleaseWait,
+    ConnectingToDb,
+    PasswordPrompt,
+    WrongPasswordPrompt,
+}

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.fr.resx
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.fr.resx
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisteredGenerators" xml:space="preserve">
+    <value>Générateurs enregistrés :{0}</value>
+  </data>
+  <data name="UpdateCompleted" xml:space="preserve">
+    <value>Mise à jour terminée avec succès.</value>
+  </data>
+  <data name="DbConnectionSuccess" xml:space="preserve">
+    <value>Connexion à la base de données {0} réussie !</value>
+  </data>
+  <data name="GeneratingPleaseWait" xml:space="preserve">
+    <value>Génération en cours, veuillez patienter...</value>
+  </data>
+  <data name="ConnectingToDb" xml:space="preserve">
+    <value>Connexion à la base de données {0}...</value>
+  </data>
+  <data name="PasswordPrompt" xml:space="preserve">
+    <value>Mot de passe pour l'utilisateur {0} : </value>
+  </data>
+  <data name="WrongPasswordPrompt" xml:space="preserve">
+    <value>Mot de passe erroné pour l'utilisateur {0} : </value>
+  </data>
+</root>

--- a/TopModel.ModelGenerator/ModelGeneratorMessage.resx
+++ b/TopModel.ModelGenerator/ModelGeneratorMessage.resx
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisteredGenerators" xml:space="preserve">
+    <value>Registered generators:{0}</value>
+  </data>
+  <data name="UpdateCompleted" xml:space="preserve">
+    <value>Update completed successfully.</value>
+  </data>
+  <data name="DbConnectionSuccess" xml:space="preserve">
+    <value>Connected to database {0}!</value>
+  </data>
+  <data name="GeneratingPleaseWait" xml:space="preserve">
+    <value>Generating, please wait...</value>
+  </data>
+  <data name="ConnectingToDb" xml:space="preserve">
+    <value>Connecting to database {0}...</value>
+  </data>
+  <data name="PasswordPrompt" xml:space="preserve">
+    <value>Password for user {0}: </value>
+  </data>
+  <data name="WrongPasswordPrompt" xml:space="preserve">
+    <value>Wrong password for user {0}: </value>
+  </data>
+</root>

--- a/TopModel.ModelGenerator/Program.cs
+++ b/TopModel.ModelGenerator/Program.cs
@@ -1,28 +1,25 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Help;
-using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SharpYaml.Serialization;
 using Spectre.Console;
+using TopModel.Core;
 using TopModel.ModelGenerator;
 using TopModel.ModelGenerator.Database;
 using TopModel.ModelGenerator.OpenApi;
 using TopModel.Utils;
+using TopModel.Utils.Cli;
 
-var fileOption = new Option<IEnumerable<FileInfo>>("--file", "-f")
+var command = new RootCommand("Lance le générateur de fichiers tmd.")
 {
-    Description = "Chemin vers un fichier de config.",
+    TopModelCli.FileOption,
+    TopModelCli.WatchOption,
+    TopModelCli.CheckOption,
 };
-var watchOption = new Option<bool>("--watch", "-w") { Description = "Lance le générateur en mode 'watch'" };
-var checkOption = new Option<bool>("--check", "-c")
-{
-    Description = "Vérifie que le modèle généré est conforme aux sources.",
-};
-
-var command = new RootCommand("Lance le générateur de fichiers tmd.") { fileOption, watchOption, checkOption };
 
 var helpOption = command.Options.OfType<HelpOption>().Single();
 var versionOption = command.Options.OfType<VersionOption>().Single();
@@ -34,9 +31,9 @@ if (result.GetResult(helpOption) != null || result.GetResult(versionOption) != n
     return await result.InvokeAsync();
 }
 
-var files = result.GetValue(fileOption) ?? [];
-var watchMode = result.GetValue(watchOption);
-var checkMode = result.GetValue(checkOption);
+var files = result.GetValue(TopModelCli.FileOption) ?? [];
+var watchMode = result.GetValue(TopModelCli.WatchOption);
+var checkMode = result.GetValue(TopModelCli.CheckOption);
 
 var configs = new List<(string FullPath, string DirectoryName)>();
 var serializer = new Serializer(new() { NamingConvention = new CamelCaseNamingConvention() });
@@ -46,85 +43,31 @@ void HandleFile(FileInfo file)
     configs.Add((file.FullName, file.DirectoryName!));
 }
 
-if (files.Any())
+var tmdgenPattern = new Regex(@"tmdgen[^/\\]*\.config$");
+foreach (var file in TopModelCli.ResolveFiles(files, tmdgenPattern))
 {
-    foreach (var file in files)
-    {
-        if (!file.Exists)
-        {
-            AnsiConsole.MarkupLine($"[red]Le fichier '{file.FullName}' est introuvable.[/]");
-        }
-        else
-        {
-            HandleFile(file);
-        }
-    }
-}
-else
-{
-    var dir = Directory.GetCurrentDirectory();
-    var pattern = "tmdgen*.config";
-    foreach (var fileName in Directory.GetFiles(dir, pattern, SearchOption.AllDirectories))
-    {
-        var foundFile = new FileInfo(fileName);
-        if (foundFile != null)
-        {
-            HandleFile(foundFile);
-        }
-    }
-
-    if (!configs.Any())
-    {
-        var found = false;
-        while (!found && dir != null)
-        {
-            dir = Directory.GetParent(dir)?.FullName;
-            if (dir != null)
-            {
-                foreach (var fileName in Directory.GetFiles(dir, pattern))
-                {
-                    HandleFile(new FileInfo(fileName));
-                    found = true;
-                }
-            }
-        }
-    }
+    HandleFile(file);
 }
 
 if (!configs.Any())
 {
-    AnsiConsole.MarkupLine($"[red]Aucun fichier de configuration trouvé.[/]");
+    AnsiConsole.MarkupLine($"[red]{LocalizeUtils.Localize(CliMessage.NoConfigFileFound)}[/]");
     return 1;
 }
 
-var version = Assembly
-    .GetEntryAssembly()!
-    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
-    .InformationalVersion;
-
-var colors = new[] { "teal", "olive", "yellow", "aqua" };
-
-AnsiConsole.MarkupLine($"========= TopModel.ModelGenerator v{version} =========");
-AnsiConsole.WriteLine();
+await TopModelCli.StartPackage("TopModel.ModelGenerator", CancellationToken.None);
 
 if (watchMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]watch[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.WatchModeEnabled));
 }
 
 if (checkMode)
 {
-    AnsiConsole.MarkupLine("Mode [darkcyan]check[/] activé.");
+    AnsiConsole.MarkupLine(LocalizeUtils.Localize(CliMessage.CheckModeEnabled));
 }
 
-AnsiConsole.WriteLine("Fichiers de configuration trouvés :");
-
-for (var i = 0; i < configs.Count; i++)
-{
-    var (fullName, _) = configs[i];
-    var color = colors[i % colors.Length];
-    AnsiConsole.MarkupLine($"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), fullName)}[/]");
-}
+TopModelCli.ListFoundFiles(configs.Select(c => c.FullPath));
 
 var disposables = new List<IDisposable>();
 var loggerProvider = new LoggerProvider();
@@ -137,7 +80,7 @@ async Task StartGeneration(string filePath, string directoryName, int i)
     AnsiConsole.WriteLine();
 
     var configFile = new FileInfo(filePath);
-    using var stream = configFile.OpenRead();
+    await using var stream = configFile.OpenRead();
     var config = serializer.Deserialize<ModelGeneratorConfig>(stream)!;
 
     config.ConfigRoot = directoryName;
@@ -225,16 +168,19 @@ async Task StartGeneration(string filePath, string directoryName, int i)
         }
     }
 
-    using var provider = services.BuildServiceProvider();
+    await using var provider = services.BuildServiceProvider();
 
     var mainLogger = provider.GetRequiredService<ILogger<TmdGenerator>>();
-    var loggingScope = new LoggingScope(i + 1, colors[i]);
+    var loggingScope = new LoggingScope(i + 1, TopModelCli.Colors[i % TopModelCli.Colors.Length]);
     using var scope = mainLogger.BeginScope(loggingScope);
 
     var generators = provider.GetRequiredService<IEnumerable<TmdGenerator>>();
 
     mainLogger.LogInformation(
-        $"Générateurs enregistrés :\n                          {string.Join("\n                          ", generators.Select(g => $"- {g.Name}@{{{g.Number}}}"))}"
+        LocalizeUtils.Localize(
+            ModelGeneratorMessage.RegisteredGenerators,
+            $"\n                          {string.Join("\n                          ", generators.Select(g => $"- {g.Name}@{{{g.Number}}}"))}"
+        )
     );
 
     var tmdLock = new TopModelLock(config, mainLogger);
@@ -247,7 +193,7 @@ async Task StartGeneration(string filePath, string directoryName, int i)
 
     tmdLock.UpdateFiles(generatedFiles);
 
-    mainLogger.LogInformation("Mise à jour terminée avec succès.");
+    mainLogger.LogInformation(LocalizeUtils.Localize(ModelGeneratorMessage.UpdateCompleted));
 }
 
 foreach (var config in configs)
@@ -303,20 +249,12 @@ if (watchMode)
 
 if (checkMode && loggerProvider.Changes > 0)
 {
-    Console.ForegroundColor = ConsoleColor.Red;
     AnsiConsole.WriteLine();
-    if (loggerProvider.Changes == 1)
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.[/]"
-        );
-    }
-    else
-    {
-        AnsiConsole.MarkupLine(
-            $"[red]{loggerProvider.Changes} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.[/]"
-        );
-    }
+    AnsiConsole.MarkupLine(
+        loggerProvider.Changes == 1
+            ? $"[red]{LocalizeUtils.Localize(CliMessage.OneFileModifiedInCheckMode)}[/]"
+            : $"[red]{LocalizeUtils.Localize(CliMessage.MultipleFilesModifiedInCheckMode, loggerProvider.Changes)}[/]"
+    );
 
     return 1;
 }

--- a/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
+++ b/TopModel.ModelGenerator/TopModel.ModelGenerator.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TopModel.Utils.Cli\TopModel.Utils.Cli.csproj" />
     <ProjectReference Include="..\TopModel.Utils\TopModel.Utils.csproj" />
+    <ProjectReference Include="..\TopModel.Core\TopModel.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/TopModel.Utils.Cli/CliMessage.cs
+++ b/TopModel.Utils.Cli/CliMessage.cs
@@ -1,0 +1,17 @@
+namespace TopModel.Utils.Cli;
+
+public enum CliMessage
+{
+    ConfigFileNotFound,
+    ConfigFilesFound,
+    NoConfigFileFound,
+    NewVersionAvailable,
+    DotnetUpdateCommand,
+    WatchModeEnabled,
+    CheckModeEnabled,
+    OneFileModifiedInCheckMode,
+    MultipleFilesModifiedInCheckMode,
+    FileOptionDescription,
+    WatchOptionDescription,
+    CheckOptionDescription,
+}

--- a/TopModel.Utils.Cli/CliMessage.fr.resx
+++ b/TopModel.Utils.Cli/CliMessage.fr.resx
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigFileNotFound" xml:space="preserve">
+    <value>Le fichier de configuration '{0}' est introuvable.</value>
+  </data>
+  <data name="ConfigFilesFound" xml:space="preserve">
+    <value>Fichiers de configuration trouvés :</value>
+  </data>
+  <data name="NoConfigFileFound" xml:space="preserve">
+    <value>Aucun fichier de configuration trouvé.</value>
+  </data>
+  <data name="NewVersionAvailable" xml:space="preserve">
+    <value>Nouvelle version disponible : {0}</value>
+  </data>
+  <data name="DotnetUpdateCommand" xml:space="preserve">
+    <value>Vous pouvez lancer la commande `dotnet tool update -g {0}` pour effectuer la mise à jour.</value>
+  </data>
+  <data name="WatchModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]watch[/] activé.</value>
+  </data>
+  <data name="CheckModeEnabled" xml:space="preserve">
+    <value>Mode [darkcyan]check[/] activé.</value>
+  </data>
+  <data name="OneFileModifiedInCheckMode" xml:space="preserve">
+    <value>1 fichier généré a été modifié ou supprimé. Le code généré n'était pas à jour.</value>
+  </data>
+  <data name="MultipleFilesModifiedInCheckMode" xml:space="preserve">
+    <value>{0} fichiers générés ont été modifiés ou supprimés. Le code généré n'était pas à jour.</value>
+  </data>
+  <data name="FileOptionDescription" xml:space="preserve">
+    <value>Chemin vers un fichier de config.</value>
+  </data>
+  <data name="WatchOptionDescription" xml:space="preserve">
+    <value>Lance le générateur en mode 'watch'.</value>
+  </data>
+  <data name="CheckOptionDescription" xml:space="preserve">
+    <value>Vérifie que la génération est à jour (aucun fichier ne doit être généré).</value>
+  </data>
+</root>

--- a/TopModel.Utils.Cli/CliMessage.resx
+++ b/TopModel.Utils.Cli/CliMessage.resx
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigFileNotFound" xml:space="preserve">
+    <value>Config file '{0}' not found.</value>
+  </data>
+  <data name="ConfigFilesFound" xml:space="preserve">
+    <value>Config files found:</value>
+  </data>
+  <data name="NoConfigFileFound" xml:space="preserve">
+    <value>No config file found.</value>
+  </data>
+  <data name="NewVersionAvailable" xml:space="preserve">
+    <value>New version available: {0}</value>
+  </data>
+  <data name="DotnetUpdateCommand" xml:space="preserve">
+    <value>You can run `dotnet tool update -g {0}` to update.</value>
+  </data>
+  <data name="WatchModeEnabled" xml:space="preserve">
+    <value>[darkcyan]watch[/] mode enabled.</value>
+  </data>
+  <data name="CheckModeEnabled" xml:space="preserve">
+    <value>[darkcyan]check[/] mode enabled.</value>
+  </data>
+  <data name="OneFileModifiedInCheckMode" xml:space="preserve">
+    <value>1 generated file was modified or deleted. Generated code was not up to date.</value>
+  </data>
+  <data name="MultipleFilesModifiedInCheckMode" xml:space="preserve">
+    <value>{0} generated files were modified or deleted. Generated code was not up to date.</value>
+  </data>
+  <data name="FileOptionDescription" xml:space="preserve">
+    <value>Path to a config file.</value>
+  </data>
+  <data name="WatchOptionDescription" xml:space="preserve">
+    <value>Runs the generator in 'watch' mode.</value>
+  </data>
+  <data name="CheckOptionDescription" xml:space="preserve">
+    <value>Checks that the generation is up to date (no file should be generated).</value>
+  </data>
+</root>

--- a/TopModel.Utils.Cli/ConfigUtils.cs
+++ b/TopModel.Utils.Cli/ConfigUtils.cs
@@ -1,0 +1,66 @@
+﻿using System.Text.RegularExpressions;
+
+namespace TopModel.Utils.Cli;
+
+/// <summary>
+/// Localise les fichiers de configuration TopModel dans un répertoire.
+/// Logique partagée entre TopModel.Generator et TopModel.LanguageServer.
+/// </summary>
+public static partial class ConfigUtils
+{
+    /// <summary>
+    /// Cherche les fichiers de config depuis un répertoire racine.
+    /// Stratégie :
+    ///   1. Descend récursivement jusqu'à profondeur 3.
+    ///   2. Si rien trouvé, remonte l'arbre jusqu'au premier niveau qui en contient.
+    /// </summary>
+    public static IEnumerable<FileInfo> FindConfigFiles(string rootPath, Regex pattern)
+    {
+        var found = new List<FileInfo>();
+
+        SearchDescending(pattern, rootPath, found, depth: 0);
+
+        if (found.Count == 0)
+        {
+            var dir = rootPath;
+            while (dir != null)
+            {
+                dir = Directory.GetParent(dir)?.FullName;
+                if (dir == null)
+                    break;
+
+                var matches = Directory
+                    .EnumerateFiles(dir)
+                    .Where(f => pattern.IsMatch(f))
+                    .Select(f => new FileInfo(f))
+                    .ToList();
+
+                if (matches.Count > 0)
+                {
+                    found.AddRange(matches);
+                    break;
+                }
+            }
+        }
+
+        return found;
+    }
+
+    private static void SearchDescending(Regex configPattern, string dirName, List<FileInfo> found, int depth)
+    {
+        if (depth > 3)
+            return;
+
+        foreach (var entryName in Directory.EnumerateFileSystemEntries(dirName))
+        {
+            if (Directory.Exists(entryName))
+            {
+                SearchDescending(configPattern, entryName, found, depth + 1);
+            }
+            else if (configPattern.IsMatch(entryName))
+            {
+                found.Add(new FileInfo(entryName));
+            }
+        }
+    }
+}

--- a/TopModel.Utils.Cli/LocalizeUtils.cs
+++ b/TopModel.Utils.Cli/LocalizeUtils.cs
@@ -1,0 +1,20 @@
+using System.Resources;
+
+namespace TopModel.Utils.Cli;
+
+public static class LocalizeUtils
+{
+    public static string Localize<T>(T messageType, params object[] args)
+        where T : struct, Enum
+    {
+        var format =
+            ResourceManagerCache<T>.Instance.GetString(Enum.GetName(messageType)!) ?? Enum.GetName(messageType)!;
+        return args.Length > 0 ? string.Format(format, args) : format;
+    }
+
+    private static class ResourceManagerCache<T>
+        where T : struct, Enum
+    {
+        public static readonly ResourceManager Instance = new(typeof(T));
+    }
+}

--- a/TopModel.Utils.Cli/LogUtils.cs
+++ b/TopModel.Utils.Cli/LogUtils.cs
@@ -1,0 +1,38 @@
+using Spectre.Console;
+
+namespace TopModel.Utils.Cli;
+
+public static class LogUtils
+{
+    public static readonly string[] Colors = ["teal", "olive", "yellow", "aqua"];
+
+    public static void Log<T>(T key, string color, params object[] args)
+        where T : struct, Enum
+    {
+        AnsiConsole.MarkupLine($"[{color}]{LocalizeUtils.Localize(key, args)}[/]");
+    }
+
+    public static void LogError<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "red", args);
+    }
+
+    public static void LogInformation<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "white", args);
+    }
+
+    public static void LogSuccess<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "green", args);
+    }
+
+    public static void LogWarning<T>(T key, params object[] args)
+        where T : struct, Enum
+    {
+        Log(key, "yellow", args);
+    }
+}

--- a/TopModel.Utils.Cli/NugetUtils.cs
+++ b/TopModel.Utils.Cli/NugetUtils.cs
@@ -4,8 +4,9 @@ using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using TopModel.Utils;
 
-namespace TopModel.Utils;
+namespace TopModel.Utils.Cli;
 
 public static class NugetUtils
 {
@@ -13,7 +14,6 @@ public static class NugetUtils
         NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
         "topmodel-cache.json"
     );
-    private static readonly CancellationToken Ct = CancellationToken.None;
     private static readonly SourceCacheContext NugetCache = new();
     private static readonly Dictionary<string, ModuleLatestVersion> Versions = [];
 
@@ -30,15 +30,15 @@ public static class NugetUtils
         }
     }
 
-    public static async Task ClearAsync()
+    public static async Task ClearAsync(CancellationToken Ct)
     {
         Versions.Clear();
-        await WriteAsync();
+        await WriteAsync(Ct);
     }
 
-    public static async Task<bool> DoesPackageExistsAsync(string id, string version)
+    public static async Task<bool> DoesPackageExistsAsync(string id, string version, CancellationToken Ct)
     {
-        var nugetResource = await GetNugetResourceAsync();
+        var nugetResource = await GetNugetResourceAsync(Ct);
         return await nugetResource.DoesPackageExistAsync(
             id,
             new NuGetVersion(version),
@@ -48,9 +48,9 @@ public static class NugetUtils
         );
     }
 
-    public static async Task<PackageArchiveReader> DownloadPackageAsync(string id, string version)
+    public static async Task<PackageArchiveReader> DownloadPackageAsync(string id, string version, CancellationToken Ct)
     {
-        var nugetResource = await GetNugetResourceAsync();
+        var nugetResource = await GetNugetResourceAsync(Ct);
         var packageStream = new MemoryStream();
         await nugetResource.CopyNupkgToStreamAsync(
             id,
@@ -65,6 +65,7 @@ public static class NugetUtils
 
     public static async Task<TopModelLockModule?> GetLatestVersionAsync(
         string id,
+        CancellationToken Ct,
         bool forceCheck = false,
         bool prerelease = false
     )
@@ -73,7 +74,7 @@ public static class NugetUtils
         {
             if (cachedVersion.CheckDate.AddHours(6) < DateTime.UtcNow)
             {
-                Versions.Remove(id);
+                Versions.Remove(prerelease ? $"{id}-prerelease" : id);
             }
             else
             {
@@ -95,8 +96,16 @@ public static class NugetUtils
 
         try
         {
-            var nugetResource = await GetNugetResourceAsync();
-            var moduleVersions = await nugetResource.GetAllVersionsAsync(id, NugetCache, NullLogger.Instance, Ct);
+            var nugetResource = await GetNugetResourceAsync(Ct);
+            IEnumerable<NuGetVersion> moduleVersions;
+            try
+            {
+                moduleVersions = await nugetResource.GetAllVersionsAsync(id, NugetCache, NullLogger.Instance, Ct);
+            }
+            catch (InvalidPackageIdException)
+            {
+                return null;
+            }
 
             if (!moduleVersions.Any())
             {
@@ -108,21 +117,21 @@ public static class NugetUtils
                 Version = moduleVersions.Last(m => prerelease || !m.IsPrerelease).ToFullString(),
             };
 
-            Versions[id] = new(version.Version, DateTime.UtcNow);
-            await WriteAsync();
+            Versions[prerelease ? $"{id}-prerelease" : id] = new(version.Version, DateTime.UtcNow);
+            await WriteAsync(Ct);
             return version;
         }
         catch (FatalProtocolException)
         {
             // Si on a pas internet par exemple.
             _cantCheckVersion = true;
-            Versions[id] = new(Version: null, DateTime.UtcNow);
-            await WriteAsync();
+            Versions[prerelease ? $"{id}-prerelease" : id] = new(Version: null, DateTime.UtcNow);
+            await WriteAsync(Ct);
             return null;
         }
     }
 
-    private static async Task<FindPackageByIdResource> GetNugetResourceAsync()
+    private static async Task<FindPackageByIdResource> GetNugetResourceAsync(CancellationToken Ct)
     {
         if (_nugetResource == null)
         {
@@ -133,7 +142,7 @@ public static class NugetUtils
         return _nugetResource;
     }
 
-    private static async Task WriteAsync()
+    private static async Task WriteAsync(CancellationToken Ct)
     {
         await File.WriteAllTextAsync(CacheFile, JsonSerializer.Serialize(Versions), Ct);
     }

--- a/TopModel.Utils.Cli/TopModel.Utils.Cli.csproj
+++ b/TopModel.Utils.Cli/TopModel.Utils.Cli.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>4.2.5</Version>
+    <Description>Utilitaires CLI TopModel.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.Cli" />
+    <PackageReference Include="NuGet.Commands" />
+    <ProjectReference Include="..\TopModel.Utils\TopModel.Utils.csproj" />
+  </ItemGroup>
+</Project>

--- a/TopModel.Utils.Cli/TopModelCli.cs
+++ b/TopModel.Utils.Cli/TopModelCli.cs
@@ -1,0 +1,83 @@
+using System.CommandLine;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace TopModel.Utils.Cli;
+
+public static class TopModelCli
+{
+    public static Option<IEnumerable<FileInfo>> FileOption { get; } =
+        new("--file", "-f") { Description = LocalizeUtils.Localize(CliMessage.FileOptionDescription) };
+
+    public static Option<bool> WatchOption { get; } =
+        new("--watch", "-w") { Description = LocalizeUtils.Localize(CliMessage.WatchOptionDescription) };
+
+    public static Option<bool> CheckOption { get; } =
+        new("--check", "-c") { Description = LocalizeUtils.Localize(CliMessage.CheckOptionDescription) };
+
+    public static string[] Colors => LogUtils.Colors;
+
+    public static void ListFoundFiles(IEnumerable<string> filePaths)
+    {
+        LogUtils.LogInformation(CliMessage.ConfigFilesFound);
+        var i = 0;
+        foreach (var path in filePaths)
+        {
+            var color = LogUtils.Colors[i % LogUtils.Colors.Length];
+            AnsiConsole.MarkupLine(
+                $"[{color}]#{i + 1} - {Path.GetRelativePath(Directory.GetCurrentDirectory(), path)}[/]"
+            );
+            i++;
+        }
+    }
+
+    public static IEnumerable<FileInfo> ResolveFiles(IEnumerable<FileInfo> files, Regex pattern)
+    {
+        if (files.Any())
+        {
+            foreach (var file in files)
+            {
+                if (!file.Exists)
+                {
+                    LogUtils.LogError(CliMessage.ConfigFileNotFound, file.FullName);
+                }
+                else
+                {
+                    yield return file;
+                }
+            }
+        }
+        else
+        {
+            foreach (var file in ConfigUtils.FindConfigFiles(Directory.GetCurrentDirectory(), pattern))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    public static async Task StartPackage(string nugetPackageName, CancellationToken cancellationToken)
+    {
+        var version = Assembly
+            .GetEntryAssembly()!
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
+
+        AnsiConsole.MarkupLine($"========= {nugetPackageName} v{version} =========");
+        AnsiConsole.WriteLine();
+
+        var prerelease = version.Contains('-');
+        var latestVersion = await NugetUtils.GetLatestVersionAsync(
+            nugetPackageName,
+            cancellationToken,
+            prerelease: prerelease
+        );
+        if (latestVersion != null && latestVersion.Version != version)
+        {
+            LogUtils.LogWarning(CliMessage.NewVersionAvailable, latestVersion.Version!);
+            LogUtils.LogWarning(CliMessage.DotnetUpdateCommand, nugetPackageName);
+            AnsiConsole.WriteLine();
+        }
+    }
+}

--- a/TopModel.Utils/ErrorType.fr.resx
+++ b/TopModel.Utils/ErrorType.fr.resx
@@ -207,4 +207,5 @@
   <data name="TMD9013" xml:space="preserve">
     <value>Il est impossible de définir une valeur pour l'association '{0}' de la classe '{1}' car elle est multiple ou ne cible pas une classe enum readonly.</value>
   </data>
+
 </root>

--- a/TopModel.Utils/ErrorType.resx
+++ b/TopModel.Utils/ErrorType.resx
@@ -207,4 +207,5 @@
   <data name="TMD9013" xml:space="preserve">
     <value>Cannot define value on association '{0}' of class '{1}' because it is multiple or doesn't target a readonly enum class. </value>
   </data>
+
 </root>

--- a/TopModel.Utils/TopModel.Utils.csproj
+++ b/TopModel.Utils/TopModel.Utils.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Meziantou.Framework.Globbing" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="NuGet.Commands" />
+    <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Spectre.Console.Cli" />
     <PackageReference Include="YamlDotNet" />

--- a/TopModel.slnx
+++ b/TopModel.slnx
@@ -16,5 +16,6 @@
   <Project Path="TopModel.LanguageServer/TopModel.LanguageServer.csproj" />
   <Project Path="TopModel.ModelGenerator/TopModel.ModelGenerator.csproj" />
   <Project Path="TopModel.Utils/TopModel.Utils.csproj" />
+  <Project Path="TopModel.Utils.Cli/TopModel.Utils.Cli.csproj" />
   <Project Path="TopModel.Utils.Mermaid/TopModel.Utils.Mermaid.csproj" />
 </Solution>

--- a/tests/model/topmodel.lock
+++ b/tests/model/topmodel.lock
@@ -6,7 +6,7 @@ version: 4.3.0
 custom:
   ../../TopModel.Generator.Csharp: f1991d14810bb39e9bcaf2bc73931878
   ../../TopModel.Generator.Javascript: 03f0545430c92a60e75e455a4d82813c
-  ../../TopModel.Generator.Jpa: 0079e1a6a189cd0bfaa4d810b78563d1
+  ../../TopModel.Generator.Jpa: ff846b85a4b3ac68b5ce053db0e1c02e
   ../../TopModel.Generator.Sql: bdc0e49e9a9aa3b3abd9c69fbbe5f0d4
   ../../TopModel.Generator.Translation: 37bcf602b3079fdf3556fff547655e8f
   ../../TopModel.Generator.Documentation: 950cd4b8b59bcf41532329bb1556984d


### PR DESCRIPTION
Cette PR vise à refacoriser TopModel.Generator, pour améliorer la maintenabilité et la lisibilité. L'objectif est d'isoler le code réutilisable avec les autres outils cli (TopModel.ModelGenerator et TopModel.LanguageServer), pour bénéficier des fonctionnalités communes : 
- Recherche de configuration
- Vérification des versions
- Logging
- Mode `check`
- ...

Pour le moment :

- Création du module TopModel.Cli
- Mutualisation des options
- Traduction des messages de la cli
- Le mode Watch s'abonne aux changements des fichiers de configurations, et recharge le ModelStore correspondant