### PR TITLE
Correction documentation getting-started section 'Mapper From'

### DIFF
--- a/docs/docs/getting-started/05_dto.mdx
+++ b/docs/docs/getting-started/05_dto.mdx
@@ -303,7 +303,7 @@ class:
 
 Ici, notre résultat de recherche devra renvoyer tous les champs de la classe `Utilisateur` (hormis son Id), ainsi que le label de son `TypeUtilisateur`.
 
-Nous aurions donc besoin d'un `mapper` pour construire ces objets `UtilisateurSearchResultDto`. Idéalement, ce `mapper` doit pouvoir prendre en paramètres une instance de la classe `Utilisateur`, et une instance de la classe `Utilisateur` correspondante.
+Nous aurions donc besoin d'un `mapper` pour construire ces objets `UtilisateurSearchResultDto`. Idéalement, ce `mapper` doit pouvoir prendre en paramètres une instance de la classe `Utilisateur`, et une instance de la classe `TypeUtilisateur` correspondante.
 
 Un tel mapper s'écrit de la façon suivante :
 


### PR DESCRIPTION
Le mapper décrit devrait prendre en paramètre un objet Utilisateur et un objet TypeUtilisateur, non pas un objet Utilisateur et second objet Utilisateur