### PR TITLE
[TS] Propriétés required non optionnelles dans les interfaces + `optionalPrimaryKeys`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,3 +86,10 @@ jobs:
       - name: build sample focus
         run: npm run build
         working-directory: ./tests/output/focus
+
+      - name: deps sample vanilla-js
+        run: npm i -g typescript
+        working-directory: ./tests/output/vanilla-js
+      - name: build sample vanilla-js
+        run: tsc --noEmit
+        working-directory: ./tests/output/vanilla-js

--- a/TopModel.Generator.Javascript/AngularApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/AngularApiClientGenerator.cs
@@ -8,7 +8,7 @@ using TopModel.Utils;
 namespace TopModel.Generator.Javascript;
 
 /// <summary>
-/// Générateur des objets de traduction javascripts.
+/// Générateur de clients d'API Angular.
 /// </summary>
 public class AngularApiClientGenerator(ILogger<AngularApiClientGenerator> logger, IFileWriterProvider writerProvider)
     : EndpointsGeneratorBase<JavascriptConfig>(logger, writerProvider)

--- a/TopModel.Generator.Javascript/EntityMode.cs
+++ b/TopModel.Generator.Javascript/EntityMode.cs
@@ -1,5 +1,8 @@
 ﻿namespace TopModel.Generator.Javascript;
 
+/// <summary>
+/// Mode de génération des entités TypeScript.
+/// </summary>
 public enum EntityMode
 {
     /// <summary>

--- a/TopModel.Generator.Javascript/GeneratorRegistration.cs
+++ b/TopModel.Generator.Javascript/GeneratorRegistration.cs
@@ -5,6 +5,9 @@ using static TopModel.Utils.ModelUtils;
 
 namespace TopModel.Generator.Javascript;
 
+/// <summary>
+/// Enregistre les générateurs JavaScript.
+/// </summary>
 public class GeneratorRegistration : IGeneratorRegistration<JavascriptConfig>
 {
     /// <inheritdoc cref="IGeneratorRegistration{T}.Register" />

--- a/TopModel.Generator.Javascript/JavascriptApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/JavascriptApiClientGenerator.cs
@@ -8,7 +8,7 @@ using TopModel.Utils;
 namespace TopModel.Generator.Javascript;
 
 /// <summary>
-/// Générateur des objets de traduction javascripts.
+/// Générateur de clients d'API JavaScript basés sur fetch.
 /// </summary>
 public class JavascriptApiClientGenerator(
     ILogger<JavascriptApiClientGenerator> logger,

--- a/TopModel.Generator.Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator.Javascript/JavascriptConfig.cs
@@ -108,6 +108,12 @@ public class JavascriptConfig : GeneratorConfigBase
 
     protected override string NullValue => "undefined";
 
+    /// <summary>
+    /// Retourne le nom du fichier généré pour une classe.
+    /// </summary>
+    /// <param name="classe">Classe.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Nom du fichier généré.</returns>
     public virtual string GetClassFileName(Class classe, string tag)
     {
         return Path.Combine(
@@ -118,6 +124,13 @@ public class JavascriptConfig : GeneratorConfigBase
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne le chemin du fichier de ressources pour les commentaires.
+    /// </summary>
+    /// <param name="ns">Namespace.</param>
+    /// <param name="tag">Tag.</param>
+    /// <param name="lang">Langue.</param>
+    /// <returns>Chemin du fichier.</returns>
     public virtual string GetCommentResourcesFilePath(Namespace ns, string tag, string lang)
     {
         return Path.Combine(
@@ -128,6 +141,13 @@ public class JavascriptConfig : GeneratorConfigBase
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne les imports de domaines requis pour une propriété.
+    /// </summary>
+    /// <param name="fileName">Nom du fichier source contenant la propriété.</param>
+    /// <param name="prop">Propriété.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Les imports.</returns>
     public virtual IEnumerable<(string Import, string Path)> GetDomainImportPaths(
         string fileName,
         IProperty prop,
@@ -140,6 +160,13 @@ public class JavascriptConfig : GeneratorConfigBase
             );
     }
 
+    /// <summary>
+    /// Retourne les imports requis par un fichier d'endpoints.
+    /// </summary>
+    /// <param name="fileName">Nom du fichier.</param>
+    /// <param name="endpoints">Endpoints.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Les imports.</returns>
     public virtual IList<(string Import, string Path)> GetEndpointImports(
         string fileName,
         IEnumerable<Endpoint> endpoints,
@@ -150,8 +177,8 @@ public class JavascriptConfig : GeneratorConfigBase
             .SelectMany(GetClassDependencies)
             .Select(dep =>
                 (
-                    Import: dep is { Source: IProperty fp and not IProperty { Composition: not null } }
-                        ? GetEnumType(fp)
+                    Import: dep is { Source: IProperty p and not IProperty { Composition: not null } }
+                        ? GetEnumType(p)
                         : dep.Classe.NamePascal,
                     Path: GetImportPathForClass(
                         dep,
@@ -160,17 +187,23 @@ public class JavascriptConfig : GeneratorConfigBase
                     )!
                 )
             )
-            .Concat(endpoints.SelectMany(d => d.Properties).SelectMany(dep => GetDomainImportPaths(fileName, dep, tag)))
+            .Concat(endpoints.SelectMany(e => e.Properties).SelectMany(dep => GetDomainImportPaths(fileName, dep, tag)))
             .Concat(
                 endpoints
                     .SelectMany(GetParams)
                     .Where(p => p.IsQueryParam(this))
                     .SelectMany(dep => GetValueImportPaths(fileName, dep))
             )
-            .Where(i => i.Path != null)
+            .Where(import => import.Path != null)
             .GroupAndSort();
     }
 
+    /// <summary>
+    /// Retourne le nom du fichier d'endpoints correspondant à un fichier de modèle.
+    /// </summary>
+    /// <param name="file">Fichier de modèle.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Nom du fichier d'endpoints correspondant.</returns>
     public virtual string GetEndpointsFileName(ModelFile file, string tag)
     {
         return Path.Combine(
@@ -182,6 +215,12 @@ public class JavascriptConfig : GeneratorConfigBase
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne le nom du fichier d'enums correspondant à un namespace.
+    /// </summary>
+    /// <param name="ns">Namespace.</param>
+    /// <param name="tag">Tag.</param>
+    /// <returns>Nom du fichier d'enums correspondant.</returns>
     public virtual string GetEnumsFileName(Namespace ns, string tag)
     {
         return Path.Combine(
@@ -192,6 +231,13 @@ public class JavascriptConfig : GeneratorConfigBase
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne le chemin d'import correspondant à la dépendance de classe donnée.
+    /// </summary>
+    /// <param name="dep">Dépendance de classe.</param>
+    /// <param name="targetTag">Tag cible.</param>
+    /// <param name="sourceTag">Tag source.</param>
+    /// <returns>Chemin d'import, ou <see langword="null" /> si aucun import n'est nécessaire.</returns>
     public virtual string? GetImportPathForClass(ClassDependency dep, string targetTag, string sourceTag)
     {
         string target;
@@ -238,12 +284,24 @@ public class JavascriptConfig : GeneratorConfigBase
         return path;
     }
 
+    /// <summary>
+    /// Retourne le chemin du fichier principal de ressources.
+    /// </summary>
+    /// <param name="tag">Tag.</param>
+    /// <param name="lang">Langue.</param>
+    /// <returns>Chemin du fichier.</returns>
     public virtual string GetMainResourceFilePath(string tag, string lang)
     {
         return Path.Combine(OutputDirectory, ResolveVariables(ResourceRootPath!, tag, lang: lang), "index.ts")
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Calcule le chemin relatif d'un chemin depuis un fichier source.
+    /// </summary>
+    /// <param name="path">Chemin à rendre relatif.</param>
+    /// <param name="fileName">Nom du fichier source.</param>
+    /// <returns>Chemin relatif.</returns>
     public virtual string GetRelativePath(string path, string fileName)
     {
         return !path.StartsWith('.')
@@ -255,6 +313,13 @@ public class JavascriptConfig : GeneratorConfigBase
                 .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne le chemin du fichier de ressources.
+    /// </summary>
+    /// <param name="ns">Namespace.</param>
+    /// <param name="tag">Tag.</param>
+    /// <param name="lang">Langue.</param>
+    /// <returns>Chemin du fichier.</returns>
     public virtual string GetResourcesFilePath(Namespace ns, string tag, string lang)
     {
         return Path.Combine(
@@ -265,6 +330,13 @@ public class JavascriptConfig : GeneratorConfigBase
             .Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Retourne les imports requis par une valeur de propriété.
+    /// </summary>
+    /// <param name="fileName">Nom du fichier source.</param>
+    /// <param name="prop">Propriété.</param>
+    /// <param name="value">Valeur.</param>
+    /// <returns>Imports des valeurs.</returns>
     public virtual IEnumerable<(string Import, string Path)> GetValueImportPaths(
         string fileName,
         IProperty prop,
@@ -277,6 +349,11 @@ public class JavascriptConfig : GeneratorConfigBase
             );
     }
 
+    /// <summary>
+    /// Indique si une propriété est une composition typée comme une liste.
+    /// </summary>
+    /// <param name="property">Propriété.</param>
+    /// <returns><see langword="true" /> si la propriété est une composition de liste.</returns>
     public virtual bool IsListComposition(IProperty property)
     {
         return property is { Composition: Class c, Domain: Domain d }

--- a/TopModel.Generator.Javascript/JavascriptConfig.cs
+++ b/TopModel.Generator.Javascript/JavascriptConfig.cs
@@ -54,12 +54,17 @@ public class JavascriptConfig : GeneratorConfigBase
     /// <summary>
     /// Typage des entités générées
     /// </summary>
-    public virtual EntityMode EntityMode { get; set; } = EntityMode.TYPED;
+    public virtual EntityMode EntityMode { get; set; }
 
     /// <summary>
     /// Génère `isRequired`, `label` (et `comment`) sur les compositions dans les entitées typées.
     /// </summary>
     public virtual bool ExtendedCompositions { get; set; }
+
+    /// <summary>
+    /// Génère les (alias de) clés primaires simples comme optionnelles dans les définitions d'entités. Il s'agit d'un paramètre de compatibilité avec l'existant, qui ne devrait plus être utilisé dans les nouveaux projets.
+    /// </summary>
+    public virtual bool OptionalPrimaryKeys { get; set; }
 
     /// <summary>
     /// Chemin (ou alias commençant par '@') vers les imports de types d'entités, relatif au répertoire de génération.

--- a/TopModel.Generator.Javascript/JavascriptResourceGenerator.cs
+++ b/TopModel.Generator.Javascript/JavascriptResourceGenerator.cs
@@ -178,7 +178,7 @@ public class JavascriptResourceGenerator(
             fw.WriteLine(indentLevel, $"{Quote(container.Key.NameCamel)}: {{");
         }
 
-        var i = 1;
+        var pi = 1;
         if (Config.TranslateProperties == true)
         {
             foreach (var property in container.OrderBy(p => p.PropertyNameCamel, StringComparer.Ordinal))
@@ -195,7 +195,7 @@ public class JavascriptResourceGenerator(
                 fw.Write(indentLevel + 1, $"{Quote(property.PropertyNameCamel)}: ");
                 fw.Write($@"""{translation}""");
                 fw.WriteLine(
-                    container.Count() == i++
+                    container.Count() == pi++
                     && !onlyProperties
                     && !(
                         Config.TranslateReferences == true
@@ -214,13 +214,13 @@ public class JavascriptResourceGenerator(
             && classe?.Values.Count > 0
         )
         {
-            i = 1;
+            var rvi = 1;
             fw.WriteLine(indentLevel + 1, @$"{Quote("values")}: {{");
             foreach (var refValue in classe.Values)
             {
                 fw.Write(indentLevel + 2, $@"{Quote(refValue.Name)}: ");
                 fw.Write($@"""{_translationStore.GetTranslation(refValue, lang)}""");
-                fw.WriteLine(classe.Values.Count == i++ ? string.Empty : ",");
+                fw.WriteLine(classe.Values.Count == rvi++ ? string.Empty : ",");
             }
 
             fw.WriteLine(indentLevel + 1, "}");
@@ -245,11 +245,11 @@ public class JavascriptResourceGenerator(
         var modules = classes.GroupBy(c =>
             c.Key.Namespace.Module.Split('.').Skip(level).ElementAtOrDefault(0)?.ToCamelCase()
         );
-        var u = 1;
+        var submoduleIndex = 1;
 
         var mainModuleClasses = modules
-            .Where(c => c.Key == null)
-            .SelectMany(c => c.Select(p => p.Key.NameCamel))
+            .Where(module => module.Key == null)
+            .SelectMany(module => module.Select(container => container.Key.NameCamel))
             .ToHashSet();
         var extraSubModuleProperties = new Dictionary<string, IGrouping<IPropertyContainer, IProperty>>();
 
@@ -262,7 +262,10 @@ public class JavascriptResourceGenerator(
                 {
                     extraSubModuleProperties.Add(
                         key,
-                        modules.Where(m => m.Key == null).SelectMany(p => p.Where(c => c.Key.NameCamel == key)).Single()
+                        modules
+                            .Where(module => module.Key == null)
+                            .SelectMany(module => module.Where(container => container.Key.NameCamel == key))
+                            .Single()
                     );
                 }
             }
@@ -270,17 +273,17 @@ public class JavascriptResourceGenerator(
 
         foreach (var submodule in modules.OrderBy(m => m.Key, StringComparer.Ordinal))
         {
-            var isLast = u++ == modules.Count();
+            var isLast = submoduleIndex++ == modules.Count();
             if (submodule.Key == null)
             {
-                var i = 1;
+                var ci = 1;
                 foreach (
                     var container in submodule
-                        .Where(c => !extraSubModuleProperties.ContainsKey(c.Key.NameCamel))
-                        .OrderBy(c => c.Key.NameCamel)
+                        .Where(container => !extraSubModuleProperties.ContainsKey(container.Key.NameCamel))
+                        .OrderBy(container => container.Key.NameCamel)
                 )
                 {
-                    WriteClasseNode(fw, container, isComment, classes.Count() == i++ && isLast, lang, level);
+                    WriteClasseNode(fw, container, isComment, classes.Count() == ci++ && isLast, lang, level);
                 }
             }
             else

--- a/TopModel.Generator.Javascript/JavascriptUtils.cs
+++ b/TopModel.Generator.Javascript/JavascriptUtils.cs
@@ -3,8 +3,16 @@ using TopModel.Utils;
 
 namespace TopModel.Generator.Javascript;
 
+/// <summary>
+/// Utilitaires pour la génération JavaScript.
+/// </summary>
 public static class JavascriptUtils
 {
+    /// <summary>
+    /// Regroupe et trie les imports par chemin.
+    /// </summary>
+    /// <param name="imports">Imports à regrouper.</param>
+    /// <returns>Imports regroupés et triés.</returns>
     public static IList<(string Import, string Path)> GroupAndSort(
         this IEnumerable<(string Import, string Path)> imports
     )
@@ -16,6 +24,12 @@ public static class JavascriptUtils
             .ToList();
     }
 
+    /// <summary>
+    /// Ecrit la définition d'une référence.
+    /// </summary>
+    /// <param name="fw">Writer.</param>
+    /// <param name="classe">Classe de référence.</param>
+    /// <param name="config">Config.</param>
     public static void WriteReferenceDefinition(this IFileWriter fw, Class classe, JavascriptConfig config)
     {
         fw.Write($"export const {classe.NameCamel} = {{");

--- a/TopModel.Generator.Javascript/LegacyApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/LegacyApiClientGenerator.cs
@@ -8,7 +8,7 @@ using TopModel.Utils;
 namespace TopModel.Generator.Javascript;
 
 /// <summary>
-/// Générateur des objets de traduction javascripts.
+/// Générateur de clients d'API JavaScript legacy.
 /// </summary>
 public class LegacyApiClientGenerator(ILogger<LegacyApiClientGenerator> logger, IFileWriterProvider writerProvider)
     : EndpointsGeneratorBase<JavascriptConfig>(logger, writerProvider)

--- a/TopModel.Generator.Javascript/NuxtApiClientGenerator.cs
+++ b/TopModel.Generator.Javascript/NuxtApiClientGenerator.cs
@@ -8,7 +8,7 @@ using TopModel.Utils;
 namespace TopModel.Generator.Javascript;
 
 /// <summary>
-/// Générateur des objets de traduction javascripts.
+/// Générateur de clients d'API Nuxt.
 /// </summary>
 public class NuxtApiClientGenerator(ILogger<NuxtApiClientGenerator> logger, IFileWriterProvider writerProvider)
     : EndpointsGeneratorBase<JavascriptConfig>(logger, writerProvider)

--- a/TopModel.Generator.Javascript/TargetFramework.cs
+++ b/TopModel.Generator.Javascript/TargetFramework.cs
@@ -1,5 +1,8 @@
 ﻿namespace TopModel.Generator.Javascript;
 
+/// <summary>
+/// Framework cible pour la génération des clients d'API JavaScript.
+/// </summary>
 public enum TargetFramework
 {
     /// <summary>
@@ -13,7 +16,7 @@ public enum TargetFramework
     ANGULAR,
 
     /// <summary>
-    /// Angular that return Promise instead of Observable.
+    /// Angular qui retourne des promesses au lieu d'observables.
     /// </summary>
     ANGULAR_PROMISE,
 

--- a/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
+++ b/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
@@ -77,7 +77,7 @@ public class TypescriptDefinitionGenerator(
                         && !Config.IsListComposition(cp)
                     )
                         ? dep.Classe.NamePascal
-                    : dep is { Source: IProperty fp and not { Composition: not null } } ? Config.GetEnumType(fp)
+                    : dep is { Source: IProperty p and not { Composition: not null } } ? Config.GetEnumType(p)
                     : $"{(Config.EntityMode == EntityMode.TYPED || Config.EntityMode == EntityMode.UNTYPED ? dep.Classe.NamePascal + "Entity, " : string.Empty)}{dep.Classe.NamePascal}{(Config.EntityMode == EntityMode.TYPED ? "EntityType" : Config.EntityMode == EntityMode.FOCUS ? "Entity" : string.Empty)}",
                     Path: Config.GetImportPathForClass(
                         dep,
@@ -470,13 +470,13 @@ public class TypescriptDefinitionGenerator(
         }
 
         foreach (
-            var p in Config
+            var (import, _) in Config
                 .GetProperties(classe)
                 .SelectMany(dep => Config.GetDomainImportPaths(fileName, dep, tag))
                 .Where(p => p.Path == entityTypesPath)
         )
         {
-            yield return p.Import;
+            yield return import;
         }
 
         yield return "EntityToType";

--- a/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
+++ b/TopModel.Generator.Javascript/TypescriptDefinitionGenerator.cs
@@ -106,7 +106,10 @@ public class TypescriptDefinitionGenerator(
             .Where(p => p.Path != null && p.Path != entityTypesPath)
             .GroupAndSort();
 
-        fw.WriteLine();
+        if (commonImports.Any())
+        {
+            fw.WriteLine();
+        }
 
         foreach (var import in dependencyImports)
         {
@@ -150,7 +153,9 @@ public class TypescriptDefinitionGenerator(
 
             foreach (var property in Config.GetProperties(classe))
             {
-                fw.Write($"    {property.NameCamel}{(Config.EntityMode == EntityMode.TYPED ? string.Empty : "?")}: ");
+                fw.Write(
+                    $"    {property.NameCamel}{(Config.EntityMode == EntityMode.TYPED || property.Required ? string.Empty : "?")}: "
+                );
                 var type = Config.GetType(property, forceAssociationPropertyType: true);
 
                 if (Config.EntityMode == EntityMode.TYPED)
@@ -185,11 +190,11 @@ public class TypescriptDefinitionGenerator(
             }
 
             fw.WriteLine("}");
-            fw.WriteLine();
         }
 
         if (Config.EntityMode == EntityMode.TYPED || Config.EntityMode == EntityMode.UNTYPED)
         {
+            fw.WriteLine();
             fw.Write($"export const {classe.NamePascal}Entity");
 
             if (Config.EntityMode == EntityMode.TYPED)
@@ -271,7 +276,7 @@ public class TypescriptDefinitionGenerator(
                 {
                     fw.WriteLine(
                         2,
-                        $"isRequired: {(property.Required && !(property.PrimaryKeyish && property.GeneratedValue != null)).ToString().ToFirstLower()},"
+                        $"isRequired: {(property.Required && (!Config.OptionalPrimaryKeys || !(property.PrimaryKeyish && property.GeneratedValue != null))).ToString().ToFirstLower()},"
                     );
 
                     if (Config.TranslateProperties == true)
@@ -385,7 +390,12 @@ public class TypescriptDefinitionGenerator(
                     fw.Write($".defaultValue({defaultValue})");
                 }
 
-                if (!(property.Required && !(property.PrimaryKeyish && property.GeneratedValue != null)))
+                if (
+                    !(
+                        property.Required
+                        && (!Config.OptionalPrimaryKeys || !(property.PrimaryKeyish && property.GeneratedValue != null))
+                    )
+                )
                 {
                     fw.WriteLine(".optional()");
                 }

--- a/TopModel.Generator.Javascript/TypescriptEnumsGenerator.cs
+++ b/TopModel.Generator.Javascript/TypescriptEnumsGenerator.cs
@@ -39,7 +39,7 @@ public class TypescriptEnumsGenerator(ILogger<TypescriptEnumsGenerator> logger, 
                 (
                     Import: dep.Source switch
                     {
-                        IProperty fp => Config.GetType(fp, forceAssociationPropertyType: true),
+                        IProperty p => Config.GetType(p, forceAssociationPropertyType: true),
                         Class c => c.NamePascal,
                         _ => null!,
                     },

--- a/TopModel.Generator.Javascript/javascript.config.json
+++ b/TopModel.Generator.Javascript/javascript.config.json
@@ -139,6 +139,10 @@
       "type": "boolean",
       "description": "Génère `isRequired`, `label` (et `comment`) sur les compositions dans les entitées typées."
     },
+    "optionalPrimaryKeys": {
+      "type": "boolean",
+      "description": "Génère les (alias de) clés primaires simples comme optionnelles dans les définitions d'entités. Il s'agit d'un paramètre de compatibilité avec l'existant, qui ne devrait plus être utilisé dans les nouveaux projets."
+    },
     "entityTypesPath": {
       "type": "string",
       "description": "Chemin (ou alias commençant par '@') vers les imports de types d'entités, relatif au répertoire de génération."

--- a/docs/docs/generator/js.md
+++ b/docs/docs/generator/js.md
@@ -100,14 +100,91 @@ apiClientFilePath: "api/{module}/{fileName}"
 
 Il est possible de générer les entités selon quatre modes (`entityMode`) :
 
+- `untyped` : génération d'une interface simple pour la classe, et d'une définition d'entité sans dépendances externes (valeur par défaut).
+- `none` : génération de l'interface simple uniquement.
 - `focus` : génération avec les APIs du module `@focus4/entities`.
-- `typed` : génération du DTO et de l'entité, avec typage du DTO via l'entité.
-- `untyped` : génération du DTO et de l'entité, sans typage du DTO via l'entité.
-- `none` : génération du DTO uniquement.
+- `typed` : génération avec les types du module `@focus4/entities`, ou équivalents (choix legacy, priviligier le mode `focus` si possible).
 
-Dans les deux premiers cas, la génération utilise le chemin défini dans la propriété `domainPath`, pour importer les objets de définition de domaine.
+A l'exception du mode `none`, la génération utilise le chemin défini dans la propriété `domainPath`, pour importer les objets de définition de domaine. Par défaut, elle vaut `../domains`.
 
-Par défaut `domainPath` vaut `../domains`
+_Remarque : Si vous avez besoin que vos (alias de) clés primaires soient générés comme optionnel pour compatibilité avec l'existant, vous pouvez utiliser le paramètre `optionalPrimaryKeys: true`._
+
+#### Untyped
+
+Le mode `untyped` permet de générer la description des entités métier en tant que **`const`** non typés.
+
+Exemple :
+
+```ts
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import { DO_CODE, DO_CODE_LIST, DO_ID } from "@domains";
+
+import {
+  UtilisateurDtoEntity,
+  UtilisateurDto,
+} from "../utilisateur/utilisateur-dto";
+import { DroitCode, TypeProfilCode } from "./references";
+import { SecteurDtoEntity, SecteurDto } from "./secteur-dto";
+
+export interface ProfilDto {
+  id: number;
+  typeProfilCode?: TypeProfilCode;
+  droits?: DroitCode[];
+  utilisateurs: UtilisateurDto[];
+  secteurs: SecteurDto[];
+}
+
+export const ProfilDtoEntity = {
+  id: {
+    type: "field",
+    name: "id",
+    domain: DO_ID,
+    isRequired: true,
+    label: "securite.profil.id",
+  },
+  typeProfilCode: {
+    type: "field",
+    name: "typeProfilCode",
+    domain: DO_CODE,
+    isRequired: false,
+    label: "securite.profil.typeProfilCode",
+  },
+  droits: {
+    type: "field",
+    name: "droits",
+    domain: DO_CODE_LIST,
+    isRequired: false,
+    label: "securite.profil.droits",
+  },
+  utilisateurs: {
+    type: "list",
+    entity: UtilisateurDtoEntity,
+  },
+  secteurs: {
+    type: "list",
+    entity: SecteurDtoEntity,
+  },
+} as const;
+```
+
+#### None
+
+Le mode `none` permet de générer uniquement les interfaces TypeScript sans générer les entités. Ce mode est utile lorsque vous n'avez pas besoin des métadonnées des entités.
+
+Exemple :
+
+```ts
+export interface ProfilDto {
+  id: number;
+  typeProfilCode?: TypeProfilCode;
+  droits?: DroitCode[];
+  utilisateurs: UtilisateurDto[];
+  secteurs: SecteurDto[];
+}
+```
 
 #### Focus
 
@@ -146,83 +223,6 @@ Le mode `typed` permet de générer la description des entités métier avec les
 Vous pouvez également activer l'option `extendedCompositions` pour générer toutes les propriétés sur les compositions (`label`, `isRequired`, `comment`), qui ne sont pas générées par défaut.
 
 Les types sont importés par défaut de `@focus4/stores`, mais ce chemin peut être surchargé avec la propriété `entityTypesPath`.
-
-#### None
-
-Le mode `none` permet de générer uniquement les interfaces TypeScript (DTO) sans générer les entités. Ce mode est utile lorsque vous n'avez pas besoin des métadonnées des entités.
-
-Exemple :
-
-```ts
-export interface ProfilDto {
-  id?: number;
-  typeProfilCode?: TypeProfilCode;
-  droits?: DroitCode[];
-  utilisateurs?: UtilisateurDto[];
-  secteurs?: SecteurDto[];
-}
-```
-
-#### Untyped
-
-Le mode `untyped` permet de générer la description des entités métier en tant que **`const`** non typés.
-
-Exemple :
-
-```ts
-////
-//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
-////
-
-import { DO_CODE, DO_CODE_LIST, DO_ID } from "@domains";
-
-import {
-  UtilisateurDtoEntity,
-  UtilisateurDto,
-} from "../utilisateur/utilisateur-dto";
-import { DroitCode, TypeProfilCode } from "./references";
-import { SecteurDtoEntity, SecteurDto } from "./secteur-dto";
-
-export interface ProfilDto {
-  id?: number;
-  typeProfilCode?: TypeProfilCode;
-  droits?: DroitCode[];
-  utilisateurs?: UtilisateurDto[];
-  secteurs?: SecteurDto[];
-}
-
-export const ProfilDtoEntity = {
-  id: {
-    type: "field",
-    name: "id",
-    domain: DO_ID,
-    isRequired: false,
-    label: "securite.profil.id",
-  },
-  typeProfilCode: {
-    type: "field",
-    name: "typeProfilCode",
-    domain: DO_CODE,
-    isRequired: false,
-    label: "securite.profil.typeProfilCode",
-  },
-  droits: {
-    type: "field",
-    name: "droits",
-    domain: DO_CODE_LIST,
-    isRequired: false,
-    label: "securite.profil.droits",
-  },
-  utilisateurs: {
-    type: "list",
-    entity: UtilisateurDtoEntity,
-  },
-  secteurs: {
-    type: "list",
-    entity: SecteurDtoEntity,
-  },
-} as const;
-```
 
 ### Génération des enums
 

--- a/docs/docs/generator/js.md
+++ b/docs/docs/generator/js.md
@@ -1,6 +1,10 @@
 # JS Generator
 
-_Remarque : tous les imports spécifiés pour le générateur JS dans les domaines et la configuration seront relatifs au répertoire de génération (`outputDirectory`) s'ils commencent par un `.` (exemple : `./common` ou `../domains`). Ils seront considérés comme des imports de modules sinon (exemple : `@/domains` ou `luxon`). Les imports dans les implémentations de domaines doivent aussi inclure l'objet importé dans leur chemin (exemple, pour avoir `import {DateTime} from "luxon"`, il faut écrire `luxon/DateTime`)._
+> **Note sur les imports :** Les imports spécifiés dans la configuration du générateur JS suivent cette règle :
+>
+> - S'ils commencent par `.` (ex : `./common` ou `../domains`), ils sont **relatifs** au répertoire de génération
+> - Sinon, ils sont traités comme des **imports de modules** (ex : `@/domains` ou `luxon`)
+> - Les domaines importés doivent inclure l'objet dans le chemin (ex : `luxon/DateTime` pour `import {DateTime} from "luxon"`)
 
 ## Configuration
 
@@ -46,7 +50,7 @@ export function getProfil(
 
 #### Legacy
 
-Le mode `legacy` permet de générer un fichier ts, contenant les méthodes d'appels à l'API exportées sous forme de fonctions. Ce mode nécessite la définition d'une méthode `fetch`. Par défaut, cette méthode est importée de `@focus4/core`, mais il est possible de la surcharger avec le paramètre `fetchPath`.
+Le mode `legacy` permet de générer un fichier TypeScript contenant les méthodes d'appels à l'API exportées sous forme de fonctions. Ce mode nécessite la définition d'une méthode `fetch`. Par défaut, cette méthode est importée de `@focus4/core`, mais il est possible de la surcharger avec le paramètre `fetchPath`.
 
 Exemple :
 
@@ -86,9 +90,9 @@ L'extension `.ts` est ajoutée automatiquement.
 
 **Variables disponibles dans les chemins :**
 
-- `{module}` : Le module de la classe/endpoint (ex: `securite`)
-- `{lang}` : La langue pour les fichiers de ressources (ex: `fr`, `en`)
-- `{fileName}` : Le nom du fichier pour les endpoints (défini dans la configuration des endpoints du modèle)
+- **`{module}`** : Module de la classe/endpoint (ex : `securite`)
+- **`{lang}`** : Langue pour les fichiers de ressources (ex : `fr`, `en`)
+- **`{fileName}`** : Nom du fichier pour les endpoints (défini dans la configuration des endpoints)
 
 Exemple :
 
@@ -98,14 +102,16 @@ apiClientFilePath: "api/{module}/{fileName}"
 
 ### Modes de génération des entités
 
-Il est possible de générer les entités selon quatre modes (`entityMode`) :
+Le paramètre `entityMode` permet de choisir le type de génération pour les entités. Quatre modes sont disponibles :
 
-- `untyped` : génération d'une interface simple pour la classe, et d'une définition d'entité sans dépendances externes (valeur par défaut).
-- `none` : génération de l'interface simple uniquement.
-- `focus` : génération avec les APIs du module `@focus4/entities`.
-- `typed` : génération avec les types du module `@focus4/entities`, ou équivalents (choix legacy, priviligier le mode `focus` si possible).
+| Mode      | Description                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `untyped` | Génère une interface et une définition d'entité sans dépendances externes (**par défaut**)    |
+| `none`    | Génère uniquement l'interface TypeScript, sans objet de définition                            |
+| `focus`   | Utilise les APIs du module `@focus4/entities` pour générer les entités                        |
+| `typed`   | Utilise les types du module `@focus4/entities` sans les APIs (mode legacy - préférer `focus`) |
 
-A l'exception du mode `none`, la génération utilise le chemin défini dans la propriété `domainPath`, pour importer les objets de définition de domaine. Par défaut, elle vaut `../domains`.
+**Configuration des domaines :** À l'exception du mode `none`, la génération utilise la propriété `domainPath` (par défaut : `../domains`) pour importer les définitions de domaine.
 
 _Remarque : Si vous avez besoin que vos (alias de) clés primaires soient générés comme optionnel pour compatibilité avec l'existant, vous pouvez utiliser le paramètre `optionalPrimaryKeys: true`._
 
@@ -190,7 +196,7 @@ export interface ProfilDto {
 
 Le mode `focus` permet de générer la description des entités métier en utilisant les APIs et les types exposés par le module NPM `@focus4/entities`, [documenté ici](https://klee-contrib.github.io/focus4/?path=/docs/mod%C3%A8le-m%C3%A9tier-entit%C3%A9s-et-champs--docs). Ce module n'est **pas lié à Focus** et peut être utilisé par **n'importe quel framework JS**.
 
-Il génère des entitiés sous la forme :
+Il génère des entités sous la forme :
 
 ```ts
 import {e, entity} from "@focus4/entities";
@@ -218,7 +224,7 @@ Vous pouvez surcharger l'import de `@focus4/entities` avec la propriété `entit
 
 #### Typed
 
-Le mode `typed` permet de générer la description des entités métier avec les mêmes types que le mode `Focus`, mais sans les APIs pour les construire. Les objets sont écrits en JS et en TS pur. Il s'agit d'un mode "legacy", car il faut mieux utiliser le mode `Focus` si on veut des objets typés.
+Le mode `typed` permet de générer la description des entités métier avec les mêmes types que le mode `focus`, mais sans les APIs pour les construire. Les objets sont écrits en JavaScript et TypeScript pur. Il s'agit d'un mode **legacy** : les APIs utilisées par le mode `focus` permettent un résultat identique en étant beaucoup moins verbeux.
 
 Vous pouvez également activer l'option `extendedCompositions` pour générer toutes les propriétés sur les compositions (`label`, `isRequired`, `comment`), qui ne sont pas générées par défaut.
 
@@ -226,7 +232,7 @@ Les types sont importés par défaut de `@focus4/stores`, mais ce chemin peut ê
 
 ### Génération des enums
 
-**On ne génère pas de définition d'entité pour les enums**. A la place, elles seront toutes agrégées dans un fichier `enums.ts` (relativement au `modelRootPath`, donc il y aura à priori au moins un fichier par module). Le nom de ce fichier est configurable via le paramètre de configuration `enumsFileName`.
+Les énumérations ne génèrent **pas** de définition d'entité. À la place, elles sont agrégées dans un fichier `enums.ts` par module (relativement au `modelRootPath`). Le nom de ce fichier peut être personnalisé avec le paramètre `enumsFileName`.
 
 Pour chaque classe, on génèrera :
 
@@ -285,14 +291,14 @@ export const statutCommandeList: StatutCommandeObject[] = [
 Si `reference: true` sur une classe, alors un objet décrivant la liste de référence sera généré en plus :
 
 - Pour une classe non enum, ou une classe enum non readonly, il sera de la forme `{type, valueKey, labelKey}`
-- Pour une classe enum reaondly ou `enum: true` il sera de la forme `{list, valueKey, labelKey}`
+- Pour une classe `enum: true` ou enum readonly, il sera de la forme `{list, valueKey, labelKey}`
 
-Ces propriétés sont :
+Ces propriétés incluent :
 
-- `type`, le type Typescript de la classe (généré comme `{} as Classe`)/
-- `list`, la liste des valeurs de la classe.
-- `valueKey`, le nom de la clé de la classe de référence (la clé primaire ou la clé d'unicité qui la remplace)
-- `labelKey`, le nom de la `DefaultProperty` de la classe de référence.
+- **`type`** : Type TypeScript de la classe (généré comme `{} as Classe`)
+- **`list`** : Liste des valeurs de la classe
+- **`valueKey`** : Nom de la propriété de clé (clé primaire ou clé d'unicité équivalente)
+- **`labelKey`** : Nom de la `DefaultProperty` de la classe de référence
 
 Exemple :
 
@@ -334,7 +340,7 @@ export const departement = {
 } as const;
 ```
 
-### Modes de génération des fichiers de ressource
+### Modes de génération des fichiers de ressources
 
 Le paramètre `resourceMode` permet de choisir le format de génération des fichiers de ressources (traductions).
 
@@ -382,7 +388,7 @@ Exemple :
 
 #### generateMainResourceFiles
 
-Génère un fichier `index.ts` qui importe et réexporte tous les fichiers de ressources générés par langue. Cette option est uniquement compatible avec `resourceMode: js`.
+Génère un fichier `index.ts` qui importe et réexporte tous les fichiers de ressources par langue. **Compatible uniquement avec `resourceMode: js`.**
 
 Exemple de fichier `index.ts` généré :
 
@@ -395,11 +401,17 @@ export { securite, common };
 
 #### translateProperties
 
-Si cette option est définie à `true` (par défaut), les libellés des propriétés seront traduits dans les fichiers de ressources. Si elle est définie à `false`, les clés de traduction seront utilisées directement.
+Gère la traduction des libellés des propriétés :
+
+- **`true` (par défaut)** : Les libellés sont générés dans les fichiers de ressources, et la clé de traduction correspondante est utilisée dans la définition d'entité.
+- **`false`** : Les libellés sont utilisés directement.
 
 #### translateReferences
 
-Si cette option est définie à `true` (par défaut), les libellés des listes de références seront traduits. Si elle est définie à `false`, les libellés seront remplacés par les valeurs réelles définies dans le modèle.
+Gère la traduction des listes de références :
+
+- **`true` (par défaut)** : Les libellés des références sont générés dans les fichiers de ressources, et la clé de traduction correspondante est utilisée dans les valeurs (si générées).
+- **`false`** : Les libellés sont utilisés directement.
 
 ### Génération de commentaires
 

--- a/docs/docs/getting-started/model/topmodel.lock
+++ b/docs/docs/getting-started/model/topmodel.lock
@@ -8,8 +8,8 @@ modules:
     version: 4.4.1
     hash: fc919dd6f316a68e5b19980ec5c6e998
   csharp:
-    version: 4.3.2
-    hash: 6562c45d82925b3d33c76448362e0444
+    version: 4.3.3
+    hash: a9002506b82278d9317c059f0f9d2429
   sql:
     version: 4.4.0
     hash: 81eea4982bd9f19a775e50792cb31c2d

--- a/tests/model/topmodel.config
+++ b/tests/model/topmodel.config
@@ -39,6 +39,12 @@ javascript:
     apiClientRootPath: services
     entityMode: focus
 
+  - name: vanilla
+    tags: *front
+    translateProperties: false
+    translateReferences: false
+    outputDirectory: ../output/vanilla-js
+    modelRootPath: model
 sql:
   - name: pg
     tags:

--- a/tests/model/topmodel.config.schema.json
+++ b/tests/model/topmodel.config.schema.json
@@ -592,6 +592,10 @@
             "type": "boolean",
             "description": "Génère `isRequired`, `label` (et `comment`) sur les compositions dans les entitées typées."
           },
+          "optionalPrimaryKeys": {
+            "type": "boolean",
+            "description": "Génère les (alias de) clés primaires simples comme optionnelles dans les définitions d'entités. Il s'agit d'un paramètre de compatibilité avec l'existant, qui ne devrait plus être utilisé dans les nouveaux projets."
+          },
           "entityTypesPath": {
             "type": "string",
             "description": "Chemin (ou alias commençant par '@') vers les imports de types d'entités, relatif au répertoire de génération."

--- a/tests/model/topmodel.lock
+++ b/tests/model/topmodel.lock
@@ -5,7 +5,7 @@
 version: 4.6.1
 custom:
   ../../TopModel.Generator.Csharp: 5dc914d79432cfb6b4c99cdb9c628c55
-  ../../TopModel.Generator.Javascript: 5c0bdac9b628223e1f8552abc71e277a
+  ../../TopModel.Generator.Javascript: a95f4c6793f5558f89ae723f999b6540
   ../../TopModel.Generator.Jpa: d9d87abb6b67ea994cf9e488cacb45af
   ../../TopModel.Generator.Sql: b38875216aa64b473fbd3eccbb96afc2
   ../../TopModel.Generator.Translation: 37bcf602b3079fdf3556fff547655e8f
@@ -651,3 +651,38 @@ generatedFiles:
   - ../output/translation/i18n/de/out/common_de.properties
   - ../output/translation/i18n/de/out/restaurant_de.properties
   - ../output/translation/i18n/en/out/restaurant_en.properties
+  - ../output/vanilla-js/model/restaurant/avis-client-read.ts
+  - ../output/vanilla-js/model/restaurant/avis-client-write.ts
+  - ../output/vanilla-js/model/restaurant/client-avec-commandes.ts
+  - ../output/vanilla-js/model/restaurant/client-item.ts
+  - ../output/vanilla-js/model/restaurant/client-read.ts
+  - ../output/vanilla-js/model/restaurant/client-write.ts
+  - ../output/vanilla-js/model/restaurant/commande-item.ts
+  - ../output/vanilla-js/model/restaurant/commande-read.ts
+  - ../output/vanilla-js/model/restaurant/commande-resume.ts
+  - ../output/vanilla-js/model/restaurant/commande-write.ts
+  - ../output/vanilla-js/model/restaurant/employe-item.ts
+  - ../output/vanilla-js/model/restaurant/employe-read.ts
+  - ../output/vanilla-js/model/restaurant/employe-write.ts
+  - ../output/vanilla-js/model/restaurant/enums.ts
+  - ../output/vanilla-js/model/restaurant/ligne-commande-read.ts
+  - ../output/vanilla-js/model/restaurant/ligne-commande-write.ts
+  - ../output/vanilla-js/model/restaurant/menu-read.ts
+  - ../output/vanilla-js/model/restaurant/menu-write.ts
+  - ../output/vanilla-js/model/restaurant/personne-item.ts
+  - ../output/vanilla-js/model/restaurant/plat-item-readonly.ts
+  - ../output/vanilla-js/model/restaurant/plat-item.ts
+  - ../output/vanilla-js/model/restaurant/plat-read.ts
+  - ../output/vanilla-js/model/restaurant/plat-write.ts
+  - ../output/vanilla-js/model/restaurant/promotion-read.ts
+  - ../output/vanilla-js/model/restaurant/promotion-write.ts
+  - ../output/vanilla-js/model/restaurant/reservation-read.ts
+  - ../output/vanilla-js/model/restaurant/reservation-write.ts
+  - ../output/vanilla-js/model/restaurant/restaurant-avec-statistiques.ts
+  - ../output/vanilla-js/model/restaurant/restaurant-item.ts
+  - ../output/vanilla-js/model/restaurant/restaurant-read.ts
+  - ../output/vanilla-js/model/restaurant/restaurant-write.ts
+  - ../output/vanilla-js/model/restaurant/statistiques-restaurant.ts
+  - ../output/vanilla-js/model/restaurant/table-item.ts
+  - ../output/vanilla-js/model/restaurant/table-read.ts
+  - ../output/vanilla-js/model/restaurant/table-write.ts

--- a/tests/model/topmodel.lock
+++ b/tests/model/topmodel.lock
@@ -5,7 +5,7 @@
 version: 4.6.1
 custom:
   ../../TopModel.Generator.Csharp: 5dc914d79432cfb6b4c99cdb9c628c55
-  ../../TopModel.Generator.Javascript: a95f4c6793f5558f89ae723f999b6540
+  ../../TopModel.Generator.Javascript: ae9f1bab200c46ffe1a69cb0b476784b
   ../../TopModel.Generator.Jpa: d9d87abb6b67ea994cf9e488cacb45af
   ../../TopModel.Generator.Sql: b38875216aa64b473fbd3eccbb96afc2
   ../../TopModel.Generator.Translation: 37bcf602b3079fdf3556fff547655e8f

--- a/tests/output/angular/src/appgenerated/model/restaurant/avis-client-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/avis-client-read.ts
@@ -9,7 +9,7 @@ export type AvisClientRead = EntityToType<AvisClientReadEntityType>;
 export type AvisClientReadEntityType = typeof AvisClientReadEntity;
 
 export const AvisClientReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.avisClient.id")
     ),
     note: e.field(DO_QUANTITE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/client-avec-commandes.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/client-avec-commandes.ts
@@ -11,7 +11,7 @@ export type ClientAvecCommandes = EntityToType<ClientAvecCommandesEntityType>;
 export type ClientAvecCommandesEntityType = typeof ClientAvecCommandesEntity;
 
 export const ClientAvecCommandesEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/client-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/client-read.ts
@@ -11,7 +11,7 @@ export type ClientRead = EntityToType<ClientReadEntityType>;
 export type ClientReadEntityType = typeof ClientReadEntity;
 
 export const ClientReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/commande-item.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/commande-item.ts
@@ -11,7 +11,7 @@ export type CommandeItem = EntityToType<CommandeItemEntityType>;
 export type CommandeItemEntityType = typeof CommandeItemEntity;
 
 export const CommandeItemEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     ),
     dateCommande: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/commande-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/commande-read.ts
@@ -14,7 +14,7 @@ export type CommandeRead = EntityToType<CommandeReadEntityType>;
 export type CommandeReadEntityType = typeof CommandeReadEntity;
 
 export const CommandeReadEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     ),
     dateCommande: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/commande-resume.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/commande-resume.ts
@@ -9,7 +9,7 @@ export type CommandeResume = EntityToType<CommandeResumeEntityType>;
 export type CommandeResumeEntityType = typeof CommandeResumeEntity;
 
 export const CommandeResumeEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     )
 });

--- a/tests/output/angular/src/appgenerated/model/restaurant/employe-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/employe-read.ts
@@ -11,7 +11,7 @@ export type EmployeRead = EntityToType<EmployeReadEntityType>;
 export type EmployeReadEntityType = typeof EmployeReadEntity;
 
 export const EmployeReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/ligne-commande-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/ligne-commande-read.ts
@@ -9,7 +9,7 @@ export type LigneCommandeRead = EntityToType<LigneCommandeReadEntityType>;
 export type LigneCommandeReadEntityType = typeof LigneCommandeReadEntity;
 
 export const LigneCommandeReadEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.ligneCommande.id")
     ),
     quantite: e.field(DO_QUANTITE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/menu-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/menu-read.ts
@@ -12,7 +12,7 @@ export type MenuRead = EntityToType<MenuReadEntityType>;
 export type MenuReadEntityType = typeof MenuReadEntity;
 
 export const MenuReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.menu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/plat-item-readonly.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/plat-item-readonly.ts
@@ -11,7 +11,7 @@ export type PlatItemReadonly = EntityToType<PlatItemReadonlyEntityType>;
 export type PlatItemReadonlyEntityType = typeof PlatItemReadonlyEntity;
 
 export const PlatItemReadonlyEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/plat-item.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/plat-item.ts
@@ -11,7 +11,7 @@ export type PlatItem = EntityToType<PlatItemEntityType>;
 export type PlatItemEntityType = typeof PlatItemEntity;
 
 export const PlatItemEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/plat-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/plat-read.ts
@@ -11,7 +11,7 @@ export type PlatRead = EntityToType<PlatReadEntityType>;
 export type PlatReadEntityType = typeof PlatReadEntity;
 
 export const PlatReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/reservation-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/reservation-read.ts
@@ -9,7 +9,7 @@ export type ReservationRead = EntityToType<ReservationReadEntityType>;
 export type ReservationReadEntityType = typeof ReservationReadEntity;
 
 export const ReservationReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.reservation.id")
     ),
     dateReservation: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/restaurant-avec-statistiques.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/restaurant-avec-statistiques.ts
@@ -11,7 +11,7 @@ export type RestaurantAvecStatistiques = EntityToType<RestaurantAvecStatistiques
 export type RestaurantAvecStatistiquesEntityType = typeof RestaurantAvecStatistiquesEntity;
 
 export const RestaurantAvecStatistiquesEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/restaurant-item.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/restaurant-item.ts
@@ -9,7 +9,7 @@ export type RestaurantItem = EntityToType<RestaurantItemEntityType>;
 export type RestaurantItemEntityType = typeof RestaurantItemEntity;
 
 export const RestaurantItemEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/restaurant-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/restaurant-read.ts
@@ -11,7 +11,7 @@ export type RestaurantRead = EntityToType<RestaurantReadEntityType>;
 export type RestaurantReadEntityType = typeof RestaurantReadEntity;
 
 export const RestaurantReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/table-item.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/table-item.ts
@@ -9,7 +9,7 @@ export type TableItem = EntityToType<TableItemEntityType>;
 export type TableItemEntityType = typeof TableItemEntity;
 
 export const TableItemEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.tableRestaurant.id")
     ),
     numero: e.field(DO_CODE, f => f

--- a/tests/output/angular/src/appgenerated/model/restaurant/table-read.ts
+++ b/tests/output/angular/src/appgenerated/model/restaurant/table-read.ts
@@ -9,7 +9,7 @@ export type TableRead = EntityToType<TableReadEntityType>;
 export type TableReadEntityType = typeof TableReadEntity;
 
 export const TableReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.tableRestaurant.id")
     ),
     numero: e.field(DO_CODE, f => f

--- a/tests/output/focus/src/model/restaurant/avis-client-read.ts
+++ b/tests/output/focus/src/model/restaurant/avis-client-read.ts
@@ -9,7 +9,7 @@ export type AvisClientRead = EntityToType<AvisClientReadEntityType>;
 export type AvisClientReadEntityType = typeof AvisClientReadEntity;
 
 export const AvisClientReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.avisClient.id")
     ),
     note: e.field(DO_QUANTITE, f => f

--- a/tests/output/focus/src/model/restaurant/client-avec-commandes.ts
+++ b/tests/output/focus/src/model/restaurant/client-avec-commandes.ts
@@ -11,7 +11,7 @@ export type ClientAvecCommandes = EntityToType<ClientAvecCommandesEntityType>;
 export type ClientAvecCommandesEntityType = typeof ClientAvecCommandesEntity;
 
 export const ClientAvecCommandesEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/client-read.ts
+++ b/tests/output/focus/src/model/restaurant/client-read.ts
@@ -11,7 +11,7 @@ export type ClientRead = EntityToType<ClientReadEntityType>;
 export type ClientReadEntityType = typeof ClientReadEntity;
 
 export const ClientReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/commande-item.ts
+++ b/tests/output/focus/src/model/restaurant/commande-item.ts
@@ -11,7 +11,7 @@ export type CommandeItem = EntityToType<CommandeItemEntityType>;
 export type CommandeItemEntityType = typeof CommandeItemEntity;
 
 export const CommandeItemEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     ),
     dateCommande: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/focus/src/model/restaurant/commande-read.ts
+++ b/tests/output/focus/src/model/restaurant/commande-read.ts
@@ -14,7 +14,7 @@ export type CommandeRead = EntityToType<CommandeReadEntityType>;
 export type CommandeReadEntityType = typeof CommandeReadEntity;
 
 export const CommandeReadEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     ),
     dateCommande: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/focus/src/model/restaurant/commande-resume.ts
+++ b/tests/output/focus/src/model/restaurant/commande-resume.ts
@@ -9,7 +9,7 @@ export type CommandeResume = EntityToType<CommandeResumeEntityType>;
 export type CommandeResumeEntityType = typeof CommandeResumeEntity;
 
 export const CommandeResumeEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.commande.id")
     )
 });

--- a/tests/output/focus/src/model/restaurant/employe-read.ts
+++ b/tests/output/focus/src/model/restaurant/employe-read.ts
@@ -11,7 +11,7 @@ export type EmployeRead = EntityToType<EmployeReadEntityType>;
 export type EmployeReadEntityType = typeof EmployeReadEntity;
 
 export const EmployeReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.personneBase.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/ligne-commande-read.ts
+++ b/tests/output/focus/src/model/restaurant/ligne-commande-read.ts
@@ -9,7 +9,7 @@ export type LigneCommandeRead = EntityToType<LigneCommandeReadEntityType>;
 export type LigneCommandeReadEntityType = typeof LigneCommandeReadEntity;
 
 export const LigneCommandeReadEntity = entity({
-    id: e.field(DO_ID_2, f => f.optional()
+    id: e.field(DO_ID_2, f => f
         .label("restaurant.ligneCommande.id")
     ),
     quantite: e.field(DO_QUANTITE, f => f

--- a/tests/output/focus/src/model/restaurant/menu-read.ts
+++ b/tests/output/focus/src/model/restaurant/menu-read.ts
@@ -12,7 +12,7 @@ export type MenuRead = EntityToType<MenuReadEntityType>;
 export type MenuReadEntityType = typeof MenuReadEntity;
 
 export const MenuReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.menu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/plat-item-readonly.ts
+++ b/tests/output/focus/src/model/restaurant/plat-item-readonly.ts
@@ -11,7 +11,7 @@ export type PlatItemReadonly = EntityToType<PlatItemReadonlyEntityType>;
 export type PlatItemReadonlyEntityType = typeof PlatItemReadonlyEntity;
 
 export const PlatItemReadonlyEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/plat-item.ts
+++ b/tests/output/focus/src/model/restaurant/plat-item.ts
@@ -11,7 +11,7 @@ export type PlatItem = EntityToType<PlatItemEntityType>;
 export type PlatItemEntityType = typeof PlatItemEntity;
 
 export const PlatItemEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/plat-read.ts
+++ b/tests/output/focus/src/model/restaurant/plat-read.ts
@@ -11,7 +11,7 @@ export type PlatRead = EntityToType<PlatReadEntityType>;
 export type PlatReadEntityType = typeof PlatReadEntity;
 
 export const PlatReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.plat.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/reservation-read.ts
+++ b/tests/output/focus/src/model/restaurant/reservation-read.ts
@@ -9,7 +9,7 @@ export type ReservationRead = EntityToType<ReservationReadEntityType>;
 export type ReservationReadEntityType = typeof ReservationReadEntity;
 
 export const ReservationReadEntity = entity({
-    id: e.field(DO_SEQ_ID, f => f.optional()
+    id: e.field(DO_SEQ_ID, f => f
         .label("restaurant.reservation.id")
     ),
     dateReservation: e.field(DO_DATE_HEURE, f => f

--- a/tests/output/focus/src/model/restaurant/restaurant-avec-statistiques.ts
+++ b/tests/output/focus/src/model/restaurant/restaurant-avec-statistiques.ts
@@ -11,7 +11,7 @@ export type RestaurantAvecStatistiques = EntityToType<RestaurantAvecStatistiques
 export type RestaurantAvecStatistiquesEntityType = typeof RestaurantAvecStatistiquesEntity;
 
 export const RestaurantAvecStatistiquesEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/restaurant-item.ts
+++ b/tests/output/focus/src/model/restaurant/restaurant-item.ts
@@ -9,7 +9,7 @@ export type RestaurantItem = EntityToType<RestaurantItemEntityType>;
 export type RestaurantItemEntityType = typeof RestaurantItemEntity;
 
 export const RestaurantItemEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/restaurant-read.ts
+++ b/tests/output/focus/src/model/restaurant/restaurant-read.ts
@@ -11,7 +11,7 @@ export type RestaurantRead = EntityToType<RestaurantReadEntityType>;
 export type RestaurantReadEntityType = typeof RestaurantReadEntity;
 
 export const RestaurantReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.lieu.id")
     ),
     nom: e.field(DO_LIBELLE, f => f

--- a/tests/output/focus/src/model/restaurant/table-item.ts
+++ b/tests/output/focus/src/model/restaurant/table-item.ts
@@ -9,7 +9,7 @@ export type TableItem = EntityToType<TableItemEntityType>;
 export type TableItemEntityType = typeof TableItemEntity;
 
 export const TableItemEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.tableRestaurant.id")
     ),
     numero: e.field(DO_CODE, f => f

--- a/tests/output/focus/src/model/restaurant/table-read.ts
+++ b/tests/output/focus/src/model/restaurant/table-read.ts
@@ -9,7 +9,7 @@ export type TableRead = EntityToType<TableReadEntityType>;
 export type TableReadEntityType = typeof TableReadEntity;
 
 export const TableReadEntity = entity({
-    id: e.field(DO_ID, f => f.optional()
+    id: e.field(DO_ID, f => f
         .label("restaurant.tableRestaurant.id")
     ),
     numero: e.field(DO_CODE, f => f

--- a/tests/output/vanilla-js/domains.ts
+++ b/tests/output/vanilla-js/domains.ts
@@ -1,0 +1,15 @@
+export const DO_BOOLEEN = {};
+export const DO_CODE = {};
+export const DO_ENTIER = {};
+export const DO_CODE_LISTE = {};
+export const DO_DATE = {};
+export const DO_DATE_HEURE = {};
+export const DO_EMAIL = {};
+export const DO_ID = {};
+export const DO_ID_2 = {};
+export const DO_SEQ_ID = {};
+export const DO_LIBELLE = {};
+export const DO_LISTE = {};
+export const DO_QUANTITE = {};
+export const DO_PRIX = {};
+export const DO_TELEPHONE = {};

--- a/tests/output/vanilla-js/model/restaurant/avis-client-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/avis-client-read.ts
@@ -1,0 +1,85 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_QUANTITE} from "../../domains";
+
+export interface AvisClientRead {
+    id: number;
+    note: number;
+    commentaire?: string;
+    dateAvis: string;
+    approuve: boolean;
+    clientId: number;
+    restaurantId: number;
+    dateCreation: string;
+    nombreVues: number;
+}
+
+export const AvisClientReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    note: {
+        type: "field",
+        name: "note",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Note"
+    },
+    commentaire: {
+        type: "field",
+        name: "commentaire",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Commentaire"
+    },
+    dateAvis: {
+        type: "field",
+        name: "dateAvis",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateAvis"
+    },
+    approuve: {
+        type: "field",
+        name: "approuve",
+        domain: DO_BOOLEEN,
+        defaultValue: false,
+        isRequired: true,
+        label: "Approuve"
+    },
+    clientId: {
+        type: "field",
+        name: "clientId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "ClientId"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    nombreVues: {
+        type: "field",
+        name: "nombreVues",
+        domain: DO_QUANTITE,
+        defaultValue: 0,
+        isRequired: true,
+        label: "NombreVues"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/avis-client-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/avis-client-write.ts
@@ -1,0 +1,52 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_ID, DO_LIBELLE, DO_QUANTITE} from "../../domains";
+
+export interface AvisClientWrite {
+    note: number;
+    commentaire?: string;
+    approuve: boolean;
+    clientId: number;
+    restaurantId: number;
+}
+
+export const AvisClientWriteEntity = {
+    note: {
+        type: "field",
+        name: "note",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Note"
+    },
+    commentaire: {
+        type: "field",
+        name: "commentaire",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Commentaire"
+    },
+    approuve: {
+        type: "field",
+        name: "approuve",
+        domain: DO_BOOLEEN,
+        defaultValue: false,
+        isRequired: true,
+        label: "Approuve"
+    },
+    clientId: {
+        type: "field",
+        name: "clientId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "ClientId"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/client-avec-commandes.ts
+++ b/tests/output/vanilla-js/model/restaurant/client-avec-commandes.ts
@@ -1,0 +1,157 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE} from "../../domains";
+
+import {DepartementCode, StatutCommande} from "./enums";
+
+export interface ClientAvecCommandes {
+    id: number;
+    nom: string;
+    prenom: string;
+    departementCode?: DepartementCode;
+    dateCreation: string;
+    email?: string;
+    avisClients: number[];
+    commandeId: number[];
+    commandeDateCommande: string[];
+    commandeDateLivraison?: string[];
+    commandeMontantTotal: number[];
+    commandeClientId: number[];
+    commandeTableId?: number[];
+    commandeReservationId?: number[];
+    commandeStatutCommande: StatutCommande[];
+    commandeAvisClientId?: number[];
+    commandeLignes: number[][];
+    commandeDateCreation: string[];
+}
+
+export const ClientAvecCommandesEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    departementCode: {
+        type: "field",
+        name: "departementCode",
+        domain: DO_CODE,
+        isRequired: false,
+        label: "DepartementCode"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    email: {
+        type: "field",
+        name: "email",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Courriel"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    },
+    commandeId: {
+        type: "field",
+        name: "commandeId",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CommandeId"
+    },
+    commandeDateCommande: {
+        type: "field",
+        name: "commandeDateCommande",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CommandeDateCommande"
+    },
+    commandeDateLivraison: {
+        type: "field",
+        name: "commandeDateLivraison",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "CommandeDateLivraison"
+    },
+    commandeMontantTotal: {
+        type: "field",
+        name: "commandeMontantTotal",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Montant total"
+    },
+    commandeClientId: {
+        type: "field",
+        name: "commandeClientId",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CommandeClientId"
+    },
+    commandeTableId: {
+        type: "field",
+        name: "commandeTableId",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "CommandeTableId"
+    },
+    commandeReservationId: {
+        type: "field",
+        name: "commandeReservationId",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "CommandeReservationId"
+    },
+    commandeStatutCommande: {
+        type: "field",
+        name: "commandeStatutCommande",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CommandeStatutCommande"
+    },
+    commandeAvisClientId: {
+        type: "field",
+        name: "commandeAvisClientId",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "CommandeAvisClientId"
+    },
+    commandeLignes: {
+        type: "field",
+        name: "commandeLignes",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CommandeLignes"
+    },
+    commandeDateCreation: {
+        type: "field",
+        name: "commandeDateCreation",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/client-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/client-item.ts
@@ -1,0 +1,22 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_LIBELLE} from "../../domains";
+
+import {PersonneItemEntity, PersonneItem} from "./personne-item";
+
+export interface ClientItem extends PersonneItem {
+    nomComplet?: string;
+}
+
+export const ClientItemEntity = {
+    ...PersonneItemEntity,
+    nomComplet: {
+        type: "field",
+        name: "nomComplet",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "NomComplet"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/client-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/client-read.ts
@@ -1,0 +1,69 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE} from "../../domains";
+
+import {DepartementCode} from "./enums";
+
+export interface ClientRead {
+    id: number;
+    nom: string;
+    prenom: string;
+    departementCode?: DepartementCode;
+    dateCreation: string;
+    email?: string;
+    avisClients: number[];
+}
+
+export const ClientReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    departementCode: {
+        type: "field",
+        name: "departementCode",
+        domain: DO_CODE,
+        isRequired: false,
+        label: "DepartementCode"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    email: {
+        type: "field",
+        name: "email",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Courriel"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/client-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/client-write.ts
@@ -1,0 +1,54 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_LIBELLE, DO_LISTE} from "../../domains";
+
+import {DepartementCode} from "./enums";
+
+export interface ClientWrite {
+    nom: string;
+    prenom: string;
+    departementCode?: DepartementCode;
+    email?: string;
+    avisClients: number[];
+}
+
+export const ClientWriteEntity = {
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    departementCode: {
+        type: "field",
+        name: "departementCode",
+        domain: DO_CODE,
+        defaultValue: "75",
+        isRequired: false,
+        label: "DepartementCode"
+    },
+    email: {
+        type: "field",
+        name: "email",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Courriel"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/commande-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/commande-item.ts
@@ -1,0 +1,54 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_ID_2, DO_PRIX} from "../../domains";
+
+import {StatutCommande} from "./enums";
+
+export interface CommandeItem {
+    id: number;
+    dateCommande: string;
+    montantTotal: number;
+    statutCommande: StatutCommande;
+    clientId: number;
+}
+
+export const CommandeItemEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "Id"
+    },
+    dateCommande: {
+        type: "field",
+        name: "dateCommande",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateCommande"
+    },
+    montantTotal: {
+        type: "field",
+        name: "montantTotal",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Montant total"
+    },
+    statutCommande: {
+        type: "field",
+        name: "statutCommande",
+        domain: DO_CODE,
+        defaultValue: "EN_ATT",
+        isRequired: true,
+        label: "StatutCommande"
+    },
+    clientId: {
+        type: "field",
+        name: "clientId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "ClientId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/commande-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/commande-read.ts
@@ -1,0 +1,96 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_ID_2, DO_PRIX} from "../../domains";
+
+import {ClientReadEntity, ClientRead} from "./client-read";
+import {StatutCommande} from "./enums";
+import {LigneCommandeReadEntity, LigneCommandeRead} from "./ligne-commande-read";
+import {ReservationReadEntity, ReservationRead} from "./reservation-read";
+
+export interface CommandeRead {
+    id: number;
+    dateCommande: string;
+    dateLivraison?: string;
+    montantTotal: number;
+    tableId?: number;
+    statutCommande: StatutCommande;
+    avisClientId?: number;
+    dateCreation: string;
+    client: ClientRead;
+    reservation?: ReservationRead;
+    lignes: LigneCommandeRead[];
+}
+
+export const CommandeReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "Id"
+    },
+    dateCommande: {
+        type: "field",
+        name: "dateCommande",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateCommande"
+    },
+    dateLivraison: {
+        type: "field",
+        name: "dateLivraison",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateLivraison"
+    },
+    montantTotal: {
+        type: "field",
+        name: "montantTotal",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Montant total"
+    },
+    tableId: {
+        type: "field",
+        name: "tableId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "TableId"
+    },
+    statutCommande: {
+        type: "field",
+        name: "statutCommande",
+        domain: DO_CODE,
+        defaultValue: "EN_ATT",
+        isRequired: true,
+        label: "StatutCommande"
+    },
+    avisClientId: {
+        type: "field",
+        name: "avisClientId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "AvisClientId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    client: {
+        type: "object",
+        entity: ClientReadEntity
+    },
+    reservation: {
+        type: "object",
+        entity: ReservationReadEntity
+    },
+    lignes: {
+        type: "list",
+        entity: LigneCommandeReadEntity
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/commande-resume.ts
+++ b/tests/output/vanilla-js/model/restaurant/commande-resume.ts
@@ -1,0 +1,19 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_ID_2} from "../../domains";
+
+export interface CommandeResume {
+    id: number;
+}
+
+export const CommandeResumeEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "Id"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/commande-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/commande-write.ts
@@ -1,0 +1,80 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_PRIX} from "../../domains";
+
+import {ClientWriteEntity, ClientWrite} from "./client-write";
+import {StatutCommande} from "./enums";
+import {LigneCommandeWriteEntity, LigneCommandeWrite} from "./ligne-commande-write";
+import {ReservationWriteEntity, ReservationWrite} from "./reservation-write";
+
+export interface CommandeWrite {
+    dateCommande: string;
+    dateLivraison?: string;
+    montantTotal: number;
+    tableId?: number;
+    statutCommande: StatutCommande;
+    avisClientId?: number;
+    client: ClientWrite;
+    reservation?: ReservationWrite;
+    lignes: LigneCommandeWrite[];
+}
+
+export const CommandeWriteEntity = {
+    dateCommande: {
+        type: "field",
+        name: "dateCommande",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateCommande"
+    },
+    dateLivraison: {
+        type: "field",
+        name: "dateLivraison",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateLivraison"
+    },
+    montantTotal: {
+        type: "field",
+        name: "montantTotal",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Montant total"
+    },
+    tableId: {
+        type: "field",
+        name: "tableId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "TableId"
+    },
+    statutCommande: {
+        type: "field",
+        name: "statutCommande",
+        domain: DO_CODE,
+        defaultValue: "EN_ATT",
+        isRequired: true,
+        label: "StatutCommande"
+    },
+    avisClientId: {
+        type: "field",
+        name: "avisClientId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "AvisClientId"
+    },
+    client: {
+        type: "object",
+        entity: ClientWriteEntity
+    },
+    reservation: {
+        type: "object",
+        entity: ReservationWriteEntity
+    },
+    lignes: {
+        type: "list",
+        entity: LigneCommandeWriteEntity
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/employe-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/employe-item.ts
@@ -1,0 +1,34 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_ID} from "../../domains";
+
+import {PersonneItemEntity, PersonneItem} from "./personne-item";
+
+export interface EmployeItem extends PersonneItem {
+    matricule: string;
+    restaurantId: number;
+    autresEmployes: EmployeItem[];
+}
+
+export const EmployeItemEntity = {
+    ...PersonneItemEntity,
+    matricule: {
+        type: "field",
+        name: "matricule",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Matricule"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    autresEmployes: {
+        type: "recursive-list"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/employe-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/employe-read.ts
@@ -1,0 +1,101 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_PRIX, DO_TELEPHONE} from "../../domains";
+
+import {DepartementCode} from "./enums";
+
+export interface EmployeRead {
+    id: number;
+    nom: string;
+    prenom: string;
+    departementCode?: DepartementCode;
+    dateCreation: string;
+    telephone?: string;
+    dateNaissance?: string;
+    matricule: string;
+    dateEmbauche: string;
+    salaire?: number;
+    restaurantId: number;
+}
+
+export const EmployeReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    departementCode: {
+        type: "field",
+        name: "departementCode",
+        domain: DO_CODE,
+        isRequired: false,
+        label: "DepartementCode"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    },
+    dateNaissance: {
+        type: "field",
+        name: "dateNaissance",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateNaissance"
+    },
+    matricule: {
+        type: "field",
+        name: "matricule",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Matricule"
+    },
+    dateEmbauche: {
+        type: "field",
+        name: "dateEmbauche",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateEmbauche"
+    },
+    salaire: {
+        type: "field",
+        name: "salaire",
+        domain: DO_PRIX,
+        isRequired: false,
+        label: "Salaire"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/employe-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/employe-write.ts
@@ -1,0 +1,86 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_PRIX, DO_TELEPHONE} from "../../domains";
+
+import {DepartementCode} from "./enums";
+
+export interface EmployeWrite {
+    nom: string;
+    prenom: string;
+    departementCode?: DepartementCode;
+    telephone?: string;
+    dateNaissance?: string;
+    matricule: string;
+    dateEmbauche: string;
+    salaire?: number;
+    restaurantId: number;
+}
+
+export const EmployeWriteEntity = {
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    departementCode: {
+        type: "field",
+        name: "departementCode",
+        domain: DO_CODE,
+        defaultValue: "75",
+        isRequired: false,
+        label: "DepartementCode"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    },
+    dateNaissance: {
+        type: "field",
+        name: "dateNaissance",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateNaissance"
+    },
+    matricule: {
+        type: "field",
+        name: "matricule",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Matricule"
+    },
+    dateEmbauche: {
+        type: "field",
+        name: "dateEmbauche",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateEmbauche"
+    },
+    salaire: {
+        type: "field",
+        name: "salaire",
+        domain: DO_PRIX,
+        isRequired: false,
+        label: "Salaire"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/enums.ts
+++ b/tests/output/vanilla-js/model/restaurant/enums.ts
@@ -1,0 +1,137 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+export type CategoriePlatCode = "AUTRE" | "BOISSON" | "DESSERT" | "ENTREE" | "PRINCIPAL";
+export type CategoriePlatOrdre = 1 | 2 | 3 | 4 | 5;
+export interface CategoriePlat {
+    code: CategoriePlatCode;
+    libelle: string;
+    ordre: CategoriePlatOrdre;
+    prixMoyen?: number;
+}
+export const categoriePlatList: CategoriePlat[] = [
+    {
+        code: "BOISSON",
+        libelle: "Boisson",
+        ordre: 1,
+        prixMoyen: 2
+    },
+    {
+        code: "ENTREE",
+        libelle: "Entrée",
+        ordre: 2
+    },
+    {
+        code: "PRINCIPAL",
+        libelle: "Plat principal",
+        ordre: 3,
+        prixMoyen: 10
+    },
+    {
+        code: "DESSERT",
+        libelle: "Dessert",
+        ordre: 4
+    },
+    {
+        code: "AUTRE",
+        libelle: "Autre",
+        ordre: 5
+    },
+];
+export const categoriePlat = {list: categoriePlatList, valueKey: "code", labelKey: "libelle"} as const;
+
+export interface CategoriePlatRegion {
+    regionCode: RegionCode;
+    categoriePlat: CategoriePlatCode;
+}
+export const categoriePlatRegionList: CategoriePlatRegion[] = [
+    {
+        regionCode: "IDF",
+        categoriePlat: "ENTREE"
+    },
+    {
+        regionCode: "IDF",
+        categoriePlat: "DESSERT"
+    },
+];
+
+export type DepartementCode = "75" | "92" | "93" | "94";
+export interface Departement {
+    code: DepartementCode;
+    libelle: string;
+    regionCode: RegionCode;
+}
+export const departementList: Departement[] = [
+    {
+        code: "92",
+        libelle: "Hauts de Seine",
+        regionCode: "IDF"
+    },
+    {
+        code: "75",
+        libelle: "Paris",
+        regionCode: "IDF"
+    },
+    {
+        code: "94",
+        libelle: "Seine et Marne",
+        regionCode: "IDF"
+    },
+    {
+        code: "93",
+        libelle: "Seine Saint Denis",
+        regionCode: "IDF"
+    },
+];
+export const departement = {list: departementList, valueKey: "code", labelKey: "libelle"} as const;
+
+export type RegionCode = "IDF";
+export interface Region {
+    code: RegionCode;
+    libelle: string;
+    nomResponsable?: string;
+}
+export const region = {type: {} as Region, valueKey: "code", labelKey: "libelle"} as const;
+
+export type StatutCommande = "ANNULE" | "EN_ATT" | "EN_PREP" | "PRETE" | "SERVIE";
+export interface StatutCommandeObject {
+    code: StatutCommande;
+    libelle: string;
+}
+export const statutCommandeList: StatutCommandeObject[] = [
+    {
+        code: "ANNULE",
+        libelle: "Annulée"
+    },
+    {
+        code: "EN_ATT",
+        libelle: "En attente"
+    },
+    {
+        code: "EN_PREP",
+        libelle: "En préparation"
+    },
+    {
+        code: "PRETE",
+        libelle: "Prête"
+    },
+    {
+        code: "SERVIE",
+        libelle: "Servie"
+    },
+];
+export const statutCommande = {list: statutCommandeList, valueKey: "code", labelKey: "libelle"} as const;
+
+export type TypeTerrasse = "EXT" | "INT";
+export interface TypeTerrasseObject {
+    code: TypeTerrasse;
+}
+export const typeTerrasseList: TypeTerrasseObject[] = [
+    {
+        code: "INT"
+    },
+    {
+        code: "EXT"
+    },
+];

--- a/tests/output/vanilla-js/model/restaurant/ligne-commande-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/ligne-commande-read.ts
@@ -1,0 +1,67 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_DATE_HEURE, DO_ID_2, DO_PRIX, DO_QUANTITE, DO_SEQ_ID} from "../../domains";
+
+export interface LigneCommandeRead {
+    id: number;
+    quantite: number;
+    prixUnitaire: number;
+    prixTotal: number;
+    commandeId: number;
+    platId: number;
+    dateCreation: string;
+}
+
+export const LigneCommandeReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "Id"
+    },
+    quantite: {
+        type: "field",
+        name: "quantite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Quantite"
+    },
+    prixUnitaire: {
+        type: "field",
+        name: "prixUnitaire",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "PrixUnitaire"
+    },
+    prixTotal: {
+        type: "field",
+        name: "prixTotal",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "PrixTotal"
+    },
+    commandeId: {
+        type: "field",
+        name: "commandeId",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "CommandeId"
+    },
+    platId: {
+        type: "field",
+        name: "platId",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "PlatId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/ligne-commande-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/ligne-commande-write.ts
@@ -1,0 +1,51 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_ID_2, DO_PRIX, DO_QUANTITE, DO_SEQ_ID} from "../../domains";
+
+export interface LigneCommandeWrite {
+    quantite: number;
+    prixUnitaire: number;
+    prixTotal: number;
+    commandeId: number;
+    platId: number;
+}
+
+export const LigneCommandeWriteEntity = {
+    quantite: {
+        type: "field",
+        name: "quantite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Quantite"
+    },
+    prixUnitaire: {
+        type: "field",
+        name: "prixUnitaire",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "PrixUnitaire"
+    },
+    prixTotal: {
+        type: "field",
+        name: "prixTotal",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "PrixTotal"
+    },
+    commandeId: {
+        type: "field",
+        name: "commandeId",
+        domain: DO_ID_2,
+        isRequired: true,
+        label: "CommandeId"
+    },
+    platId: {
+        type: "field",
+        name: "platId",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "PlatId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/menu-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/menu-read.ts
@@ -1,0 +1,100 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE, DO_PRIX, DO_SEQ_ID} from "../../domains";
+
+import {CategoriePlat} from "./enums";
+import {PlatItemEntity, PlatItem} from "./plat-item";
+
+export interface MenuRead {
+    id: number;
+    nom: string;
+    description?: string;
+    prix: number;
+    disponible: boolean;
+    dateDebut?: string;
+    dateFin?: string;
+    restaurantId: number;
+    dateCreation: string;
+    categoriesPlat: CategoriePlat[];
+    plats: PlatItem[];
+}
+
+export const MenuReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    description: {
+        type: "field",
+        name: "description",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Description"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    dateDebut: {
+        type: "field",
+        name: "dateDebut",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateDebut"
+    },
+    dateFin: {
+        type: "field",
+        name: "dateFin",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateFin"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    categoriesPlat: {
+        type: "field",
+        name: "categoriesPlat",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CategoriesPlat"
+    },
+    plats: {
+        type: "list",
+        entity: PlatItemEntity
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/menu-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/menu-write.ts
@@ -1,0 +1,78 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE, DO_PRIX} from "../../domains";
+
+import {CategoriePlatCode} from "./enums";
+
+export interface MenuWrite {
+    nom: string;
+    description?: string;
+    prix: number;
+    disponible: boolean;
+    dateDebut?: string;
+    dateFin?: string;
+    restaurantId: number;
+    categoriesPlat: CategoriePlatCode[];
+}
+
+export const MenuWriteEntity = {
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    description: {
+        type: "field",
+        name: "description",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Description"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    dateDebut: {
+        type: "field",
+        name: "dateDebut",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateDebut"
+    },
+    dateFin: {
+        type: "field",
+        name: "dateFin",
+        domain: DO_DATE_HEURE,
+        isRequired: false,
+        label: "DateFin"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    categoriesPlat: {
+        type: "field",
+        name: "categoriesPlat",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "CategoriesPlat"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/personne-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/personne-item.ts
@@ -1,0 +1,35 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_ID, DO_LIBELLE} from "../../domains";
+
+export interface PersonneItem {
+    id?: number;
+    nom?: string;
+    prenom?: string;
+}
+
+export const PersonneItemEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: false,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Nom"
+    },
+    prenom: {
+        type: "field",
+        name: "prenom",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Prenom"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/plat-item-readonly.ts
+++ b/tests/output/vanilla-js/model/restaurant/plat-item-readonly.ts
@@ -1,0 +1,54 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_LIBELLE, DO_PRIX, DO_SEQ_ID} from "../../domains";
+
+import {CategoriePlatCode} from "./enums";
+
+export interface PlatItemReadonly {
+    id: number;
+    nom: string;
+    categoriePlatCode: CategoriePlatCode;
+    prix: number;
+    disponible: boolean;
+}
+
+export const PlatItemReadonlyEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    categoriePlatCode: {
+        type: "field",
+        name: "categoriePlatCode",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "CategoriePlatCode"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/plat-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/plat-item.ts
@@ -1,0 +1,54 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_LIBELLE, DO_PRIX, DO_SEQ_ID} from "../../domains";
+
+import {CategoriePlatCode} from "./enums";
+
+export interface PlatItem {
+    id: number;
+    nom: string;
+    prix: number;
+    disponible: boolean;
+    categoriePlatCode: CategoriePlatCode;
+}
+
+export const PlatItemEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    categoriePlatCode: {
+        type: "field",
+        name: "categoriePlatCode",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "CategoriePlatCode"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/plat-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/plat-read.ts
@@ -1,0 +1,78 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_PRIX, DO_SEQ_ID} from "../../domains";
+
+import {CategoriePlatCode} from "./enums";
+
+export interface PlatRead {
+    id: number;
+    nom: string;
+    description?: string;
+    prix: number;
+    disponible: boolean;
+    categoriePlatCode: CategoriePlatCode;
+    restaurantId: number;
+    dateCreation: string;
+}
+
+export const PlatReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    description: {
+        type: "field",
+        name: "description",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Description"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    categoriePlatCode: {
+        type: "field",
+        name: "categoriePlatCode",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "CategoriePlatCode"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/plat-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/plat-write.ts
@@ -1,0 +1,70 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_PRIX} from "../../domains";
+
+import {CategoriePlatCode} from "./enums";
+
+export interface PlatWrite {
+    nom: string;
+    description?: string;
+    prix: number;
+    disponible: boolean;
+    categoriePlatCode: CategoriePlatCode;
+    restaurantId: number;
+    dateCreation: string;
+}
+
+export const PlatWriteEntity = {
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    description: {
+        type: "field",
+        name: "description",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Description"
+    },
+    prix: {
+        type: "field",
+        name: "prix",
+        domain: DO_PRIX,
+        isRequired: true,
+        label: "Prix"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    categoriePlatCode: {
+        type: "field",
+        name: "categoriePlatCode",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "CategoriePlatCode"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/promotion-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/promotion-read.ts
@@ -1,0 +1,76 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_QUANTITE, DO_SEQ_ID} from "../../domains";
+
+export interface PromotionRead {
+    platId: number;
+    libelle: string;
+    pourcentageReduction: number;
+    dateDebut: string;
+    dateFin: string;
+    active: boolean;
+    restaurantId?: number;
+    dateCreation: string;
+}
+
+export const PromotionReadEntity = {
+    platId: {
+        type: "field",
+        name: "platId",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "PlatId"
+    },
+    libelle: {
+        type: "field",
+        name: "libelle",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Libelle"
+    },
+    pourcentageReduction: {
+        type: "field",
+        name: "pourcentageReduction",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "PourcentageReduction"
+    },
+    dateDebut: {
+        type: "field",
+        name: "dateDebut",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateDebut"
+    },
+    dateFin: {
+        type: "field",
+        name: "dateFin",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateFin"
+    },
+    active: {
+        type: "field",
+        name: "active",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Active"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/promotion-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/promotion-write.ts
@@ -1,0 +1,60 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_QUANTITE} from "../../domains";
+
+export interface PromotionWrite {
+    libelle: string;
+    pourcentageReduction: number;
+    dateDebut: string;
+    dateFin: string;
+    active: boolean;
+    restaurantId?: number;
+}
+
+export const PromotionWriteEntity = {
+    libelle: {
+        type: "field",
+        name: "libelle",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Libelle"
+    },
+    pourcentageReduction: {
+        type: "field",
+        name: "pourcentageReduction",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "PourcentageReduction"
+    },
+    dateDebut: {
+        type: "field",
+        name: "dateDebut",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateDebut"
+    },
+    dateFin: {
+        type: "field",
+        name: "dateFin",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateFin"
+    },
+    active: {
+        type: "field",
+        name: "active",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Active"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/reservation-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/reservation-read.ts
@@ -1,0 +1,124 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_QUANTITE, DO_SEQ_ID} from "../../domains";
+
+export interface ReservationRead {
+    id: number;
+    dateReservation: string;
+    nombrePersonnes: number;
+    commentaire?: string;
+    confirmee: boolean;
+    clientId: number;
+    tableId?: number;
+    restaurantId: number;
+    dateCreation: string;
+    clientNom: string;
+    clientPrenom: string;
+    clientEmail?: string;
+    tableNumero: string;
+    tableCapacite: number;
+}
+
+export const ReservationReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_SEQ_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    dateReservation: {
+        type: "field",
+        name: "dateReservation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateReservation"
+    },
+    nombrePersonnes: {
+        type: "field",
+        name: "nombrePersonnes",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "NombrePersonnes"
+    },
+    commentaire: {
+        type: "field",
+        name: "commentaire",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Commentaire"
+    },
+    confirmee: {
+        type: "field",
+        name: "confirmee",
+        domain: DO_BOOLEEN,
+        defaultValue: false,
+        isRequired: true,
+        label: "Confirmee"
+    },
+    clientId: {
+        type: "field",
+        name: "clientId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "ClientId"
+    },
+    tableId: {
+        type: "field",
+        name: "tableId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "TableId"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    clientNom: {
+        type: "field",
+        name: "clientNom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    clientPrenom: {
+        type: "field",
+        name: "clientPrenom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Prénom"
+    },
+    clientEmail: {
+        type: "field",
+        name: "clientEmail",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Courriel"
+    },
+    tableNumero: {
+        type: "field",
+        name: "tableNumero",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "TableNumero"
+    },
+    tableCapacite: {
+        type: "field",
+        name: "tableCapacite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "TableCapacite"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/reservation-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/reservation-write.ts
@@ -1,0 +1,68 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_QUANTITE} from "../../domains";
+
+export interface ReservationWrite {
+    dateReservation: string;
+    nombrePersonnes: number;
+    commentaire?: string;
+    confirmee: boolean;
+    clientId: number;
+    tableId?: number;
+    restaurantId: number;
+}
+
+export const ReservationWriteEntity = {
+    dateReservation: {
+        type: "field",
+        name: "dateReservation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "DateReservation"
+    },
+    nombrePersonnes: {
+        type: "field",
+        name: "nombrePersonnes",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "NombrePersonnes"
+    },
+    commentaire: {
+        type: "field",
+        name: "commentaire",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Commentaire"
+    },
+    confirmee: {
+        type: "field",
+        name: "confirmee",
+        domain: DO_BOOLEEN,
+        defaultValue: false,
+        isRequired: true,
+        label: "Confirmee"
+    },
+    clientId: {
+        type: "field",
+        name: "clientId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "ClientId"
+    },
+    tableId: {
+        type: "field",
+        name: "tableId",
+        domain: DO_ID,
+        isRequired: false,
+        label: "TableId"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/restaurant-avec-statistiques.ts
+++ b/tests/output/vanilla-js/model/restaurant/restaurant-avec-statistiques.ts
@@ -1,0 +1,116 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE, DO_QUANTITE, DO_TELEPHONE} from "../../domains";
+
+import {TableReadEntity, TableRead} from "./table-read";
+
+export interface RestaurantAvecStatistiques {
+    id: number;
+    nom: string;
+    adresse?: string;
+    telephone?: string;
+    menus: number[];
+    plats: number[];
+    promotions?: number[];
+    avisClients: number[];
+    tableIds: number[];
+    dateCreation: string;
+    tables: TableRead[];
+    nombrePlats: number;
+    nombreTables: number;
+}
+
+export const RestaurantAvecStatistiquesEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    adresse: {
+        type: "field",
+        name: "adresse",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Adresse"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    },
+    menus: {
+        type: "field",
+        name: "menus",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Menus"
+    },
+    plats: {
+        type: "field",
+        name: "plats",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Plats"
+    },
+    promotions: {
+        type: "field",
+        name: "promotions",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "Promotions"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    },
+    tableIds: {
+        type: "field",
+        name: "tableIds",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "TableIds"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    tables: {
+        type: "list",
+        entity: TableReadEntity
+    },
+    nombrePlats: {
+        type: "field",
+        name: "nombrePlats",
+        domain: DO_QUANTITE,
+        defaultValue: 0,
+        isRequired: true,
+        label: "NombrePlats"
+    },
+    nombreTables: {
+        type: "field",
+        name: "nombreTables",
+        domain: DO_QUANTITE,
+        defaultValue: 0,
+        isRequired: true,
+        label: "NombreTables"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/restaurant-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/restaurant-item.ts
@@ -1,0 +1,43 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_ID, DO_LIBELLE, DO_TELEPHONE} from "../../domains";
+
+export interface RestaurantItem {
+    id: number;
+    nom: string;
+    adresse?: string;
+    telephone?: string;
+}
+
+export const RestaurantItemEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    adresse: {
+        type: "field",
+        name: "adresse",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Adresse"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/restaurant-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/restaurant-read.ts
@@ -1,0 +1,90 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_DATE_HEURE, DO_ID, DO_LIBELLE, DO_LISTE, DO_TELEPHONE} from "../../domains";
+
+import {TableItemEntity, TableItem} from "./table-item";
+
+export interface RestaurantRead {
+    id: number;
+    nom: string;
+    adresse?: string;
+    telephone?: string;
+    menus: number[];
+    plats: number[];
+    promotions?: number[];
+    avisClients: number[];
+    dateCreation: string;
+    tables: TableItem[];
+}
+
+export const RestaurantReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    adresse: {
+        type: "field",
+        name: "adresse",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Adresse"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    },
+    menus: {
+        type: "field",
+        name: "menus",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Menus"
+    },
+    plats: {
+        type: "field",
+        name: "plats",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Plats"
+    },
+    promotions: {
+        type: "field",
+        name: "promotions",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "Promotions"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    },
+    tables: {
+        type: "list",
+        entity: TableItemEntity
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/restaurant-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/restaurant-write.ts
@@ -1,0 +1,74 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_LIBELLE, DO_LISTE, DO_TELEPHONE} from "../../domains";
+
+import {TableItemEntity, TableItem} from "./table-item";
+
+export interface RestaurantWrite {
+    nom: string;
+    adresse?: string;
+    telephone?: string;
+    menus: number[];
+    plats: number[];
+    promotions?: number[];
+    avisClients: number[];
+    tables: TableItem[];
+}
+
+export const RestaurantWriteEntity = {
+    nom: {
+        type: "field",
+        name: "nom",
+        domain: DO_LIBELLE,
+        isRequired: true,
+        label: "Nom"
+    },
+    adresse: {
+        type: "field",
+        name: "adresse",
+        domain: DO_LIBELLE,
+        isRequired: false,
+        label: "Adresse"
+    },
+    telephone: {
+        type: "field",
+        name: "telephone",
+        domain: DO_TELEPHONE,
+        isRequired: false,
+        label: "Telephone"
+    },
+    menus: {
+        type: "field",
+        name: "menus",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Menus"
+    },
+    plats: {
+        type: "field",
+        name: "plats",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "Plats"
+    },
+    promotions: {
+        type: "field",
+        name: "promotions",
+        domain: DO_LISTE,
+        isRequired: false,
+        label: "Promotions"
+    },
+    avisClients: {
+        type: "field",
+        name: "avisClients",
+        domain: DO_LISTE,
+        isRequired: true,
+        label: "AvisClients"
+    },
+    tables: {
+        type: "list",
+        entity: TableItemEntity
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/statistiques-restaurant.ts
+++ b/tests/output/vanilla-js/model/restaurant/statistiques-restaurant.ts
@@ -1,0 +1,54 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_ID, DO_PRIX, DO_QUANTITE} from "../../domains";
+
+export interface StatistiquesRestaurant {
+    restaurantId: number;
+    nombreCommandes: number;
+    chiffreAffaires: number;
+    nombreClients: number;
+    noteMoyenne?: number;
+}
+
+export const StatistiquesRestaurantEntity = {
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    nombreCommandes: {
+        type: "field",
+        name: "nombreCommandes",
+        domain: DO_QUANTITE,
+        defaultValue: 0,
+        isRequired: true,
+        label: "NombreCommandes"
+    },
+    chiffreAffaires: {
+        type: "field",
+        name: "chiffreAffaires",
+        domain: DO_PRIX,
+        defaultValue: 0,
+        isRequired: true,
+        label: "ChiffreAffaires"
+    },
+    nombreClients: {
+        type: "field",
+        name: "nombreClients",
+        domain: DO_QUANTITE,
+        defaultValue: 0,
+        isRequired: true,
+        label: "NombreClients"
+    },
+    noteMoyenne: {
+        type: "field",
+        name: "noteMoyenne",
+        domain: DO_PRIX,
+        isRequired: false,
+        label: "NoteMoyenne"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/table-item.ts
+++ b/tests/output/vanilla-js/model/restaurant/table-item.ts
@@ -1,0 +1,52 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_ID, DO_QUANTITE} from "../../domains";
+
+export interface TableItem {
+    id: number;
+    numero: string;
+    capacite: number;
+    disponible: boolean;
+    restaurantId: number;
+}
+
+export const TableItemEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    numero: {
+        type: "field",
+        name: "numero",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Numero"
+    },
+    capacite: {
+        type: "field",
+        name: "capacite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Capacite"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/table-read.ts
+++ b/tests/output/vanilla-js/model/restaurant/table-read.ts
@@ -1,0 +1,60 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_DATE_HEURE, DO_ID, DO_QUANTITE} from "../../domains";
+
+export interface TableRead {
+    id: number;
+    numero: string;
+    capacite: number;
+    disponible: boolean;
+    restaurantId: number;
+    dateCreation: string;
+}
+
+export const TableReadEntity = {
+    id: {
+        type: "field",
+        name: "id",
+        domain: DO_ID,
+        isRequired: true,
+        label: "Id"
+    },
+    numero: {
+        type: "field",
+        name: "numero",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Numero"
+    },
+    capacite: {
+        type: "field",
+        name: "capacite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Capacite"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    },
+    dateCreation: {
+        type: "field",
+        name: "dateCreation",
+        domain: DO_DATE_HEURE,
+        isRequired: true,
+        label: "Date de création"
+    }
+} as const;

--- a/tests/output/vanilla-js/model/restaurant/table-write.ts
+++ b/tests/output/vanilla-js/model/restaurant/table-write.ts
@@ -1,0 +1,44 @@
+////
+//// ATTENTION CE FICHIER EST GENERE AUTOMATIQUEMENT !
+////
+
+import {DO_BOOLEEN, DO_CODE, DO_ID, DO_QUANTITE} from "../../domains";
+
+export interface TableWrite {
+    numero: string;
+    capacite: number;
+    disponible: boolean;
+    restaurantId: number;
+}
+
+export const TableWriteEntity = {
+    numero: {
+        type: "field",
+        name: "numero",
+        domain: DO_CODE,
+        isRequired: true,
+        label: "Numero"
+    },
+    capacite: {
+        type: "field",
+        name: "capacite",
+        domain: DO_QUANTITE,
+        isRequired: true,
+        label: "Capacite"
+    },
+    disponible: {
+        type: "field",
+        name: "disponible",
+        domain: DO_BOOLEEN,
+        defaultValue: true,
+        isRequired: true,
+        label: "Disponible"
+    },
+    restaurantId: {
+        type: "field",
+        name: "restaurantId",
+        domain: DO_ID,
+        isRequired: true,
+        label: "RestaurantId"
+    }
+} as const;

--- a/tests/output/vanilla-js/tsconfig.json
+++ b/tests/output/vanilla-js/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    "strict": true
+  }
+}


### PR DESCRIPTION
En mode `none` et `untyped`, les interfaces générées ont maintenant les propriétés obligatoires non optionnelles, pour s'aligner avec ce que fait `@focus4/entities` et plus généralement parce que ça permet de garder l'information dans le type. Vous pouvez toujours retrouver le type complètement optionnel avec le helper `Partial` natif de Typescript si besoin.

De plus, les (alias de) clés primaires simples ne sont par défaut **plus générés comme optionnels**. Le comportement précédent peut se retrouver via la nouvelle option `optionalPrimaryKeys: true`. Ce choix de garder les clés primaires optionnelles est antérieur à TopModel (!!) pour faciliter l'utiliser de formulaires avec le même DTO en lecture et en écriture... des choses qu'on déconseille fortement depuis des années maintenant. Cette évolution n'intervient que maintenant car maintenant que le caractère obligatoire intervient dans le type de l'interface, cela pose plus de problème que cela ne résout...

Enfin, `entityMode` prend désormais `untyped` comme valeur par défaut, au lieu de `typed` qui est un mode legacy désormais. Cette PR ajoute aussi un cas de test pour le mode `untyped`.